### PR TITLE
cleanup, to_string(), etc

### DIFF
--- a/src/core/diger.rs
+++ b/src/core/diger.rs
@@ -160,7 +160,7 @@ mod test_diger {
         let ser = vec![0, 1, 2];
         let code = Codex::Blake3_512.code();
 
-        let m = <Matter as super::Diger>::new_with_code_and_ser(code, &ser).unwrap();
+        let m = <Matter as Diger>::new_with_code_and_ser(code, &ser).unwrap();
         println!(
             "blake3_512: {} [{}]",
             hex::encode(m.raw()),
@@ -176,7 +176,7 @@ mod test_diger {
         let ser = b"abc";
         let code = Codex::Blake2b_256.code();
 
-        let m = <Matter as super::Diger>::new_with_code_and_ser(code, ser).unwrap();
+        let m = <Matter as Diger>::new_with_code_and_ser(code, ser).unwrap();
         println!(
             "blake2b_256: {} [{}]",
             hex::encode(m.raw()),
@@ -191,7 +191,7 @@ mod test_diger {
         let ser = b"The quick brown fox jumps over the lazy dog";
         let code = Codex::Blake2b_512.code();
 
-        let m = <Matter as super::Diger>::new_with_code_and_ser(code, ser).unwrap();
+        let m = <Matter as Diger>::new_with_code_and_ser(code, ser).unwrap();
         println!(
             "blake2b_512: {} [{}]",
             hex::encode(m.raw()),
@@ -207,7 +207,7 @@ mod test_diger {
         let ser = vec![0, 1, 2];
         let code = Codex::Blake2s_256.code();
 
-        let m = <Matter as super::Diger>::new_with_code_and_ser(code, &ser).unwrap();
+        let m = <Matter as Diger>::new_with_code_and_ser(code, &ser).unwrap();
         println!(
             "blake2s_256: {} [{}]",
             hex::encode(m.raw()),
@@ -222,7 +222,7 @@ mod test_diger {
         let ser = b"abc";
         let code = Codex::SHA3_256.code();
 
-        let m = <Matter as super::Diger>::new_with_code_and_ser(code, ser).unwrap();
+        let m = <Matter as Diger>::new_with_code_and_ser(code, ser).unwrap();
         println!("sha3_256: {} [{}]", hex::encode(m.raw()), m.qb64().unwrap());
         assert_eq!(
             m.raw(),
@@ -233,7 +233,7 @@ mod test_diger {
         let ser = b"abc";
         let code = Codex::SHA3_512.code();
 
-        let m = <Matter as super::Diger>::new_with_code_and_ser(code, ser).unwrap();
+        let m = <Matter as Diger>::new_with_code_and_ser(code, ser).unwrap();
         println!("sha3_512: {} [{}]", hex::encode(m.raw()), m.qb64().unwrap());
         assert_eq!(
             m.raw(),
@@ -245,7 +245,7 @@ mod test_diger {
         let ser = b"abc";
         let code = Codex::SHA2_256.code();
 
-        let m = <Matter as super::Diger>::new_with_code_and_ser(code, ser).unwrap();
+        let m = <Matter as Diger>::new_with_code_and_ser(code, ser).unwrap();
         println!("sha2_256: {} [{}]", hex::encode(m.raw()), m.qb64().unwrap());
         assert_eq!(
             m.raw(),
@@ -256,7 +256,7 @@ mod test_diger {
         let ser = b"abc";
         let code = Codex::SHA2_512.code();
 
-        let m = <Matter as super::Diger>::new_with_code_and_ser(code, ser).unwrap();
+        let m = <Matter as Diger>::new_with_code_and_ser(code, ser).unwrap();
         println!("sha2_512: {} [{}]", hex::encode(m.raw()), m.qb64().unwrap());
         assert_eq!(
             m.raw(),
@@ -271,8 +271,7 @@ mod test_diger {
         let raw = hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"
                                  "5b49b82f805a538c68915c1ae8035c900fd1d4b13902920fd05e1450822f36de");
 
-        let m = <Matter as super::Diger>::new_with_code_and_raw(Codex::Blake3_512.code(), &raw)
-            .unwrap();
+        let m = <Matter as Diger>::new_with_code_and_raw(Codex::Blake3_512.code(), &raw).unwrap();
         assert!(m.verify(&vec![0, 1, 2]).unwrap());
     }
 

--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -15,7 +15,7 @@ pub struct Matter {
 impl Matter {
     pub fn new_with_code_and_raw(code: &str, raw: &[u8], raw_size: usize) -> Result<Matter> {
         if code.is_empty() {
-            return Err(Box::new(Error::EmptyMaterial("empty code".to_owned())));
+            return Err(Box::new(Error::EmptyMaterial("empty code".to_string())));
         }
 
         let mut size: u32 = 0;
@@ -128,7 +128,7 @@ impl Matter {
     }
 
     pub fn qb64b(&self) -> Result<Vec<u8>> {
-        Ok(Vec::from(self.qb64()?.as_bytes()))
+        Ok(self.qb64()?.as_bytes().to_vec())
     }
 
     pub fn qb2(&self) -> Result<Vec<u8>> {
@@ -282,7 +282,7 @@ impl Matter {
 
     fn exfil(&mut self, qb64: &str) -> Result<()> {
         if qb64.is_empty() {
-            return Err(Box::new(Error::EmptyMaterial("empty qb64".to_owned())));
+            return Err(Box::new(Error::EmptyMaterial("empty qb64".to_string())));
         }
 
         // we validated there will be a char here, above.
@@ -388,7 +388,7 @@ impl Matter {
     fn bexfil(&mut self, qb2: &[u8]) -> Result<()> {
         if qb2.is_empty() {
             return Err(Box::new(Error::EmptyMaterial(
-                "empty qualified base2".to_owned(),
+                "empty qualified base2".to_string(),
             )));
         }
 
@@ -396,11 +396,11 @@ impl Matter {
         if first_byte > 0x3d {
             if first_byte == 0x3e {
                 return Err(Box::new(Error::UnexpectedCountCode(
-                    "unexpected start during extraction".to_owned(),
+                    "unexpected start during extraction".to_string(),
                 )));
             } else if first_byte == 0x3f {
                 return Err(Box::new(Error::UnexpectedOpCode(
-                    "unexpected start during extraction".to_owned(),
+                    "unexpected start during extraction".to_string(),
                 )));
             } else {
                 return Err(Box::new(Error::UnexpectedCode(format!(

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -62,7 +62,7 @@ pub(crate) fn sizage(s: &str) -> error::Result<Sizage> {
         "7AAB" => Ok(Sizage::new(4, 4, 0, 0)),
         "8AAB" => Ok(Sizage::new(4, 4, 0, 1)),
         "9AAB" => Ok(Sizage::new(4, 4, 0, 2)),
-        _ => Err(Box::new(error::Error::UnknownSizage(s.to_owned()))),
+        _ => Err(Box::new(error::Error::UnknownSizage(s.to_string()))),
     }
 }
 
@@ -72,10 +72,10 @@ pub(crate) fn hardage(c: char) -> error::Result<i32> {
         '0' | '4' | '5' | '6' => Ok(2),
         '1' | '2' | '3' | '7' | '8' | '9' => Ok(4),
         '-' => Err(Box::new(error::Error::UnexpectedCode(
-            "count code start".to_owned(),
+            "count code start".to_string(),
         ))),
         '_' => Err(Box::new(error::Error::UnexpectedCode(
-            "op code start".to_owned(),
+            "op code start".to_string(),
         ))),
         _ => Err(Box::new(error::Error::UnknownHardage(c.to_string()))),
     }
@@ -232,7 +232,7 @@ impl Codex {
             "7AAB" => Codex::Bytes_Big_L0,
             "8AAB" => Codex::Bytes_Big_L1,
             "9AAB" => Codex::Bytes_Big_L2,
-            _ => return Err(Box::new(error::Error::UnexpectedCode(code.to_owned()))),
+            _ => return Err(Box::new(error::Error::UnexpectedCode(code.to_string()))),
         })
     }
 }

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -197,7 +197,7 @@ pub fn code_b2_to_b64(b2: &Vec<u8>, length: usize) -> error::Result<String> {
 
     if n > b2.len() {
         return Err(Box::new(error::Error::Matter(
-            "not enough bytes".to_owned(),
+            "not enough bytes".to_string(),
         )));
     }
 
@@ -217,7 +217,7 @@ pub fn code_b2_to_b64(b2: &Vec<u8>, length: usize) -> error::Result<String> {
         Ok(u64_to_b64(i >> tbs, length))
     } else {
         return Err(Box::new(error::Error::Matter(
-            "unexpected length".to_owned(),
+            "unexpected length".to_string(),
         )));
     }
 }


### PR DESCRIPTION
- aligns on `to_string()`
- aligns on `to_vec()`
- removes `super::` in `Diger` tests