### PR TITLE
counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
+/*.profraw
 .idea

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+use_small_heuristics = "Max"

--- a/src/core/cigar.rs
+++ b/src/core/cigar.rs
@@ -24,35 +24,23 @@ fn validate_code(code: &str) -> Result<()> {
 impl Cigar {
     pub fn new_with_code_and_raw(verfer: &Matter, code: &str, raw: &[u8]) -> Result<Cigar> {
         validate_code(code)?;
-        Ok(Cigar {
-            matter: Matter::new_with_code_and_raw(code, raw, 0)?,
-            verfer: verfer.clone(),
-        })
+        Ok(Cigar { matter: Matter::new_with_code_and_raw(code, raw, 0)?, verfer: verfer.clone() })
     }
 
     pub fn new_with_qb64(verfer: &Matter, qb64: &str) -> Result<Cigar> {
-        let cigar = Cigar {
-            matter: Matter::new_with_qb64(qb64)?,
-            verfer: verfer.clone(),
-        };
+        let cigar = Cigar { matter: Matter::new_with_qb64(qb64)?, verfer: verfer.clone() };
         validate_code(&cigar.matter.code)?;
         Ok(cigar)
     }
 
     pub fn new_with_qb64b(verfer: &Matter, qb64b: &[u8]) -> Result<Cigar> {
-        let cigar = Cigar {
-            matter: Matter::new_with_qb64b(qb64b)?,
-            verfer: verfer.clone(),
-        };
+        let cigar = Cigar { matter: Matter::new_with_qb64b(qb64b)?, verfer: verfer.clone() };
         validate_code(&cigar.matter.code)?;
         Ok(cigar)
     }
 
     pub fn new_with_qb2(verfer: &Matter, qb2: &[u8]) -> Result<Cigar> {
-        let cigar = Cigar {
-            matter: Matter::new_with_qb2(qb2)?,
-            verfer: verfer.clone(),
-        };
+        let cigar = Cigar { matter: Matter::new_with_qb2(qb2)?, verfer: verfer.clone() };
         validate_code(&cigar.matter.code)?;
         Ok(cigar)
     }
@@ -198,5 +186,14 @@ mod test_cigar {
         assert_eq!(cigar.qb64().unwrap(), cigar.matter.qb64().unwrap());
         assert_eq!(cigar.qb64b().unwrap(), cigar.matter.qb64b().unwrap());
         assert_eq!(cigar.qb2().unwrap(), cigar.matter.qb2().unwrap());
+    }
+
+    #[test]
+    fn test_unhappy_paths() {
+        let vcode = matter::Codex::Ed25519.code();
+        let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
+        let verfer = <Matter as Verfer>::new_with_code_and_raw(vcode, vraw).unwrap();
+
+        assert!(Cigar::new_with_code_and_raw(&verfer, "CESR", &[]).is_err());
     }
 }

--- a/src/core/counter/mod.rs
+++ b/src/core/counter/mod.rs
@@ -1,0 +1,481 @@
+pub(crate) mod tables;
+
+use crate::core::util;
+use crate::error::{Error, Result};
+
+#[derive(Debug, Clone)]
+pub struct Counter {
+    pub(crate) code: String,
+    pub(crate) count: u32,
+}
+
+impl Counter {
+    pub fn new_with_code_and_count_b64(code: &str, count_b64: &str) -> Result<Counter> {
+        let count = if count_b64.is_empty() { 1_u32 } else { util::b64_to_u32(count_b64)? };
+
+        Counter::new_with_code_and_count(code, count)
+    }
+
+    pub fn new_with_code_and_count(code: &str, count: u32) -> Result<Counter> {
+        if code.is_empty() {
+            return Err(Box::new(Error::EmptyMaterial("empty code".to_string())));
+        }
+
+        let szg = tables::sizage(code)?;
+        let cs = szg.hs + szg.ss;
+        if szg.fs != cs || cs % 4 != 0 {
+            // unreachable
+            // code validated and unless sizages are broken this cannot be reached
+            return Err(Box::new(Error::InvalidCodeSize(format!(
+                "whole code size not a multiple of 4: cs = {cs}, fs = {}",
+                szg.fs
+            ))));
+        }
+
+        const SIXTY_FOUR: u32 = 64;
+        if count > SIXTY_FOUR.pow(szg.ss) - 1 {
+            return Err(Box::new(Error::InvalidVarIndex(format!(
+                "invalid count for code: count = {count}, code = '{code}'"
+            ))));
+        }
+
+        Ok(Counter { code: code.to_string(), count })
+    }
+
+    pub fn new_with_qb64(qb64: &str) -> Result<Counter> {
+        let mut counter: Counter = Default::default();
+        counter.exfil(qb64)?;
+        Ok(counter)
+    }
+
+    pub fn new_with_qb64b(qb64b: &[u8]) -> Result<Counter> {
+        let qb64 = String::from_utf8(qb64b.to_vec())?;
+
+        let mut counter: Counter = Default::default();
+        counter.exfil(&qb64)?;
+        Ok(counter)
+    }
+
+    pub fn new_with_qb2(qb2: &[u8]) -> Result<Counter> {
+        let mut counter: Counter = Default::default();
+        counter.bexfil(qb2)?;
+        Ok(counter)
+    }
+
+    pub fn code(&self) -> String {
+        self.code.clone()
+    }
+
+    pub fn count(&self) -> u32 {
+        self.count
+    }
+
+    pub fn count_as_b64(&self, length: usize) -> Result<String> {
+        let length = if length == 0 { tables::sizage(&self.code)?.ss as usize } else { length };
+        util::u32_to_b64(self.count, length)
+    }
+
+    fn sem_ver_parts_to_b64(parts: &[u8]) -> Result<String> {
+        for p in parts.iter().copied() {
+            if p > 63 {
+                return Err(Box::new(Error::Parsing(format!(
+                    "semantic version out of bounds: parts = {parts:?}"
+                ))));
+            }
+        }
+
+        Ok(parts
+            .iter()
+            .map(|p| {
+                match util::u32_to_b64(*p as u32, 1) {
+                    Ok(s) => s,
+                    Err(_) => unreachable!(), // this is programmer error, since *p < 64
+                }
+            })
+            .collect::<Vec<String>>()
+            .join(""))
+    }
+
+    pub fn sem_ver_str_to_b64(version: &str) -> Result<String> {
+        let strings = version.split('.').collect::<Vec<_>>();
+        let mut parts = Vec::new();
+
+        if strings.len() > 3 {
+            return Err(Box::new(Error::Conversion(format!(
+                "invalid semantic version: version = '{version}'"
+            ))));
+        }
+
+        for s in strings {
+            let n = match s.parse::<i8>() {
+                Ok(n) => {
+                    if n < 0 {
+                        return Err(Box::new(Error::Conversion(format!(
+                            "invalid semantic version: version = '{version}'"
+                        ))));
+                    } else {
+                        n as u8
+                    }
+                }
+                Err(_) => {
+                    if s.is_empty() {
+                        0
+                    } else {
+                        return Err(Box::new(Error::Conversion(format!(
+                            "invalid semantic version: version = '{version}'"
+                        ))));
+                    }
+                }
+            };
+            parts.push(n);
+        }
+
+        parts.resize(3, 0);
+
+        Counter::sem_ver_parts_to_b64(&parts)
+    }
+
+    pub fn sem_ver_to_b64(major: u8, minor: u8, patch: u8) -> Result<String> {
+        let parts = &vec![major, minor, patch];
+        Counter::sem_ver_parts_to_b64(parts)
+    }
+
+    pub fn qb64(&self) -> Result<String> {
+        self.infil()
+    }
+
+    pub fn qb64b(&self) -> Result<Vec<u8>> {
+        Ok(self.qb64()?.as_bytes().to_vec())
+    }
+
+    pub fn qb2(&self) -> Result<Vec<u8>> {
+        self.binfil()
+    }
+
+    fn infil(&self) -> Result<String> {
+        let code = &self.code;
+        let count = self.count;
+
+        let szg = tables::sizage(code)?;
+        let cs = szg.hs + szg.ss;
+
+        if szg.fs != cs || cs % 4 != 0 {
+            // unreachable
+            // unless sizages are broken this cannot happen
+            return Err(Box::new(Error::InvalidCodeSize(format!(
+                "whole code size not complete or not a multiple of 4: cs = {cs}, fs = {}",
+                szg.fs
+            ))));
+        }
+
+        const SIXTY_FOUR: u32 = 64;
+        if count > SIXTY_FOUR.pow(szg.ss) - 1 {
+            return Err(Box::new(Error::InvalidVarIndex(format!(
+                "invalid count for code: count = {count}, code = '{code}'"
+            ))));
+        }
+
+        let both = format!("{code}{}", util::u32_to_b64(count, szg.ss as usize)?);
+        if both.len() != cs as usize {
+            // unreachable
+            // unless sizages are broken, we constructed both to be of length cs
+            return Err(Box::new(Error::InvalidCodeSize(format!(
+                "mismatched code size: size = {}, code = '{both}'",
+                both.len()
+            ))));
+        }
+
+        Ok(both)
+    }
+
+    fn binfil(&self) -> Result<Vec<u8>> {
+        let both = self.infil()?;
+        util::code_b64_to_b2(&both)
+    }
+
+    fn exfil(&mut self, qb64: &str) -> Result<()> {
+        if qb64.is_empty() {
+            return Err(Box::new(Error::EmptyMaterial("empty qb64".to_string())));
+        }
+
+        // we validated there will be a char here, above.
+        let first = &qb64[..2];
+
+        let hs = tables::hardage(first)? as usize;
+        if qb64.len() < hs {
+            return Err(Box::new(Error::Shortage(format!(
+                "insufficient material for hard part of code: qb64 size = {}, hs = {hs}",
+                qb64.len()
+            ))));
+        }
+
+        // bounds already checked
+        let hard = &qb64[..hs];
+        let szg = tables::sizage(hard)?;
+        let cs = szg.hs + szg.ss;
+
+        if qb64.len() < cs as usize {
+            return Err(Box::new(Error::Shortage(format!(
+                "insufficient material for code: qb64 size = {}, cs = {cs}",
+                qb64.len()
+            ))));
+        }
+
+        let count_b64 = &qb64[szg.hs as usize..cs as usize];
+        let count = util::b64_to_u64(count_b64)? as u32;
+
+        self.code = hard.to_string();
+        self.count = count;
+
+        Ok(())
+    }
+
+    fn bexfil(&mut self, qb2: &[u8]) -> Result<()> {
+        if qb2.is_empty() {
+            return Err(Box::new(Error::EmptyMaterial("empty qualified base2".to_string())));
+        }
+
+        let first = util::nab_sextets(qb2, 2)?;
+        if first[0] > 0x3e {
+            if first[0] == 0x3f {
+                return Err(Box::new(Error::UnexpectedOpCode(
+                    "unexpected start during extraction".to_string(),
+                )));
+            } else {
+                // unreachable
+                // programmer error - nab_sextets ensures values fall below 0x40. the only possible
+                // value is 0x3f, and we handle it
+                return Err(Box::new(Error::UnexpectedCode(format!(
+                    "unexpected code start: sextets = {first:?}"
+                ))));
+            }
+        }
+
+        let hs = tables::bardage(&first)?;
+        let bhs = ((hs + 1) * 3) / 4;
+        if qb2.len() < bhs as usize {
+            return Err(Box::new(Error::Shortage(format!(
+                "need more bytes: qb2 size = {}, bhs = {bhs}",
+                qb2.len()
+            ))));
+        }
+
+        let hard = util::code_b2_to_b64(qb2, hs as usize)?;
+        let szg = tables::sizage(&hard)?;
+        let cs = szg.hs + szg.ss;
+        let bcs = ((cs + 1) * 3) / 4;
+        if qb2.len() < bcs as usize {
+            return Err(Box::new(Error::Shortage(format!(
+                "need more bytes: qb2 size = {}, bcs = {bcs}",
+                qb2.len()
+            ))));
+        }
+
+        let both = util::code_b2_to_b64(qb2, cs as usize)?;
+        let mut count = 0;
+        for c in both[hs as usize..cs as usize].chars() {
+            count <<= 6;
+            count += util::b64_char_to_index(c)? as u32;
+        }
+
+        self.code = hard;
+        self.count = count;
+
+        Ok(())
+    }
+}
+
+impl Default for Counter {
+    fn default() -> Self {
+        Counter { code: "".to_string(), count: 0 }
+    }
+}
+
+#[cfg(test)]
+mod counter_tests {
+    use super::{tables as counter, Counter};
+    use base64::{engine::general_purpose as b64_engine, Engine};
+
+    #[test]
+    fn test_python_interop() {
+        let qsc = "-AAB";
+        let qscb = qsc.as_bytes();
+        let qscb2 = &b64_engine::URL_SAFE.decode(qsc).unwrap();
+
+        let counter1 =
+            Counter::new_with_code_and_count(counter::Codex::ControllerIdxSigs.code(), 1).unwrap();
+        let counter2 =
+            Counter::new_with_code_and_count_b64(counter::Codex::ControllerIdxSigs.code(), "B")
+                .unwrap();
+        let counter3 = Counter::new_with_qb64(qsc).unwrap();
+        let counter4 = Counter::new_with_qb64b(qscb).unwrap();
+        let counter5 = Counter::new_with_qb2(qscb2).unwrap();
+
+        assert_eq!(counter1.code(), counter2.code());
+        assert_eq!(counter1.count(), counter2.count());
+        assert_eq!(counter1.code(), counter3.code());
+        assert_eq!(counter1.count(), counter3.count());
+        assert_eq!(counter1.code(), counter4.code());
+        assert_eq!(counter1.count(), counter4.count());
+        assert_eq!(counter1.code(), counter5.code());
+        assert_eq!(counter1.count(), counter5.count());
+
+        let longqsc64 = &format!("{qsc}ABCD");
+        let counter = Counter::new_with_qb64(longqsc64).unwrap();
+        assert_eq!(
+            counter.qb64().unwrap().len() as u32,
+            counter::sizage(&counter.code()).unwrap().fs
+        );
+
+        let shortqsc64 = &qsc[..qsc.len() - 1];
+        assert!(Counter::new_with_qb64(shortqsc64).is_err());
+
+        let mut longqscb2 = qscb2.clone();
+        longqscb2.resize(longqscb2.len() + 5, 1);
+        let counter = Counter::new_with_qb2(&longqscb2).unwrap();
+        assert_eq!(counter.qb2().unwrap(), *qscb2);
+        assert_eq!(
+            counter.qb64().unwrap().len() as u32,
+            counter::sizage(&counter.code()).unwrap().fs
+        );
+
+        let shortqscb2 = &qscb2[..2];
+        assert!(Counter::new_with_qb2(shortqscb2).is_err());
+
+        let qsc = "-AAF";
+        let qscb = qsc.as_bytes();
+        let qscb2 = &b64_engine::URL_SAFE.decode(qsc).unwrap();
+
+        let counter1 =
+            Counter::new_with_code_and_count(counter::Codex::ControllerIdxSigs.code(), 5).unwrap();
+        let counter2 =
+            Counter::new_with_code_and_count_b64(counter::Codex::ControllerIdxSigs.code(), "F")
+                .unwrap();
+        let counter3 = Counter::new_with_qb64(qsc).unwrap();
+        let counter4 = Counter::new_with_qb64b(qscb).unwrap();
+        let counter5 = Counter::new_with_qb2(qscb2).unwrap();
+
+        assert_eq!(counter1.code(), counter2.code());
+        assert_eq!(counter1.count(), counter2.count());
+        assert_eq!(counter1.code(), counter3.code());
+        assert_eq!(counter1.count(), counter3.count());
+        assert_eq!(counter1.code(), counter4.code());
+        assert_eq!(counter1.count(), counter4.count());
+        assert_eq!(counter1.code(), counter5.code());
+        assert_eq!(counter1.count(), counter5.count());
+
+        let qsc = "-0VAAAQA";
+        let qscb = qsc.as_bytes();
+        let qscb2 = &b64_engine::URL_SAFE.decode(qsc).unwrap();
+
+        let counter1 = Counter::new_with_code_and_count(
+            counter::Codex::BigAttachedMaterialQuadlets.code(),
+            1024,
+        )
+        .unwrap();
+        let counter2 = Counter::new_with_code_and_count_b64(
+            counter::Codex::BigAttachedMaterialQuadlets.code(),
+            "QA",
+        )
+        .unwrap();
+        let counter3 = Counter::new_with_qb64(qsc).unwrap();
+        let counter4 = Counter::new_with_qb64b(qscb).unwrap();
+        let counter5 = Counter::new_with_qb2(qscb2).unwrap();
+
+        assert_eq!(counter1.code(), counter2.code());
+        assert_eq!(counter1.count(), counter2.count());
+        assert_eq!(counter1.code(), counter3.code());
+        assert_eq!(counter1.count(), counter3.count());
+        assert_eq!(counter1.code(), counter4.code());
+        assert_eq!(counter1.count(), counter4.count());
+        assert_eq!(counter1.code(), counter5.code());
+        assert_eq!(counter1.count(), counter5.count());
+
+        let counter1 = Counter::new_with_qb64(qsc).unwrap();
+        let counter2 = Counter::new_with_qb2(&counter1.qb2().unwrap()).unwrap();
+        assert_eq!(counter1.code(), counter2.code());
+        assert_eq!(counter1.count(), counter2.count());
+        assert_eq!(counter1.qb2().unwrap(), counter2.qb2().unwrap());
+        assert_eq!(counter1.qb64().unwrap(), counter2.qb64().unwrap());
+
+        let verint: u32 = 0;
+        let version = "AAA";
+        let qsc = &format!("{}{version}", counter::Codex::KERIProtocolStack.code());
+        let qscb = qsc.as_bytes();
+        let qscb2 = &b64_engine::URL_SAFE.decode(qsc).unwrap();
+
+        let counter1 =
+            Counter::new_with_code_and_count(counter::Codex::KERIProtocolStack.code(), 0).unwrap();
+        let counter2 =
+            Counter::new_with_code_and_count_b64(counter::Codex::KERIProtocolStack.code(), "AAA")
+                .unwrap();
+        let counter3 = Counter::new_with_qb64(qsc).unwrap();
+        let counter4 = Counter::new_with_qb64b(qscb).unwrap();
+        let counter5 = Counter::new_with_qb2(qscb2).unwrap();
+
+        assert_eq!(counter1.code(), counter::Codex::KERIProtocolStack.code());
+        assert_eq!(counter1.count(), verint);
+        assert_eq!(counter1.code(), counter2.code());
+        assert_eq!(counter1.count(), counter2.count());
+        assert_eq!(counter1.code(), counter3.code());
+        assert_eq!(counter1.count(), counter3.count());
+        assert_eq!(counter1.code(), counter4.code());
+        assert_eq!(counter1.count(), counter4.count());
+        assert_eq!(counter1.code(), counter5.code());
+        assert_eq!(counter1.count(), counter5.count());
+
+        assert_eq!(counter1.count_as_b64(3).unwrap(), version);
+        assert_eq!(counter1.count_as_b64(0).unwrap(), version);
+
+        assert_eq!(Counter::sem_ver_str_to_b64("1.2.3").unwrap(), "BCD");
+        assert_eq!(Counter::sem_ver_to_b64(1, 0, 0).unwrap(), "BAA");
+        assert_eq!(Counter::sem_ver_to_b64(0, 1, 0).unwrap(), "ABA");
+        assert_eq!(Counter::sem_ver_to_b64(0, 0, 1).unwrap(), "AAB");
+        assert_eq!(Counter::sem_ver_to_b64(3, 4, 5).unwrap(), "DEF");
+
+        assert_eq!(Counter::sem_ver_str_to_b64("1.1").unwrap(), "BBA");
+        assert_eq!(Counter::sem_ver_str_to_b64("1.").unwrap(), "BAA");
+        assert_eq!(Counter::sem_ver_str_to_b64("1").unwrap(), "BAA");
+        assert_eq!(Counter::sem_ver_str_to_b64("1.2.").unwrap(), "BCA");
+        assert_eq!(Counter::sem_ver_str_to_b64("..").unwrap(), "AAA");
+        assert_eq!(Counter::sem_ver_str_to_b64("1..3").unwrap(), "BAD");
+
+        assert!(Counter::sem_ver_str_to_b64("64.0.1").is_err());
+        assert!(Counter::sem_ver_str_to_b64("-1.0.1").is_err());
+        assert!(Counter::sem_ver_str_to_b64("0.0.64").is_err());
+        assert!(Counter::sem_ver_to_b64(64, 0, 0).is_err());
+    }
+
+    #[test]
+    fn test_unhappy_paths() {
+        assert!(Counter::new_with_code_and_count("", 1).is_err());
+        assert!(Counter::new_with_code_and_count(
+            counter::Codex::ControllerIdxSigs.code(),
+            64 * 64
+        )
+        .is_err());
+        assert!(Counter::sem_ver_str_to_b64("1.2.3.4").is_err());
+        assert!(Counter::sem_ver_str_to_b64("bad.semantic.version").is_err());
+        assert!((Counter {
+            code: counter::Codex::ControllerIdxSigs.code().to_string(),
+            count: 64 * 64
+        })
+        .qb64()
+        .is_err());
+        assert!(Counter::new_with_qb64("").is_err());
+        assert!(Counter::new_with_qb64("--").is_err());
+        assert!(Counter::new_with_qb64("__").is_err());
+        assert!(Counter::new_with_qb64(counter::Codex::ControllerIdxSigs.code()).is_err());
+        assert!(Counter::new_with_qb64b(&[]).is_err());
+        assert!(Counter::new_with_qb2(&[]).is_err());
+        assert!(Counter::new_with_qb2(&[0xf8, 0]).is_err());
+        assert!(Counter::new_with_qb2(&[0xfc, 0]).is_err());
+        assert!(Counter::new_with_qb2(&[0xfb, 0xe0]).is_err());
+    }
+
+    #[test]
+    fn test_qb64b() {
+        let c = Counter { code: counter::Codex::ControllerIdxSigs.code().to_string(), count: 1 };
+        assert!(Counter::new_with_qb64b(&c.qb64b().unwrap()).is_ok());
+    }
+}

--- a/src/core/counter/tables.rs
+++ b/src/core/counter/tables.rs
@@ -1,0 +1,267 @@
+use crate::core::sizage::Sizage;
+use crate::error::{Error, Result};
+
+pub(crate) fn sizage(s: &str) -> Result<Sizage> {
+    Ok(match s {
+        "-A" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-B" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-C" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-D" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-E" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-F" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-G" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-H" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-I" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-J" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-K" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-L" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-V" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
+        "-0V" => Sizage { hs: 3, ss: 5, fs: 8, ls: 0 },
+        "--AAA" => Sizage { hs: 5, ss: 3, fs: 8, ls: 0 },
+        _ => return Err(Box::new(Error::UnknownSizage(s.to_string()))),
+    })
+}
+
+pub(crate) fn hardage(s: &str) -> Result<u32> {
+    match s {
+        "-A" | "-B" | "-C" | "-D" | "-E" | "-F" | "-G" | "-H" | "-I" | "-J" | "-K" | "-L"
+        | "-V" => Ok(2),
+        "-0" => Ok(3),
+        "--" => Ok(5),
+        _ => Err(Box::new(Error::UnknownHardage(s.to_string()))),
+    }
+}
+
+pub(crate) fn bardage(b: &[u8]) -> Result<u32> {
+    match b {
+        [62, 0]
+        | [62, 1]
+        | [62, 2]
+        | [62, 3]
+        | [62, 4]
+        | [62, 5]
+        | [62, 6]
+        | [62, 7]
+        | [62, 8]
+        | [62, 9]
+        | [62, 10]
+        | [62, 11]
+        | [62, 21] => Ok(2),
+        [62, 52] => Ok(3),
+        [62, 62] => Ok(5),
+        _ => Err(Box::new(Error::UnknownBardage(format!("{b:?}")))),
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum Codex {
+    ControllerIdxSigs,
+    WitnessIdxSigs,
+    NonTransReceiptCouples,
+    TransReceiptQuadruples,
+    FirstSeenReplayCouples,
+    TransIdxSigGroups,
+    SealSourceCouples,
+    TransLastIdxSigGroups,
+    SealSourceTriples,
+    SadPathSig,
+    SadPathSigGroup,
+    PathedMaterialQuadlets,
+    AttachedMaterialQuadlets,
+    BigAttachedMaterialQuadlets,
+    KERIProtocolStack,
+}
+
+impl Codex {
+    pub(crate) fn code(&self) -> &'static str {
+        match self {
+            Codex::ControllerIdxSigs => "-A", // Qualified Base64 Indexed Signature.
+            Codex::WitnessIdxSigs => "-B",    // Qualified Base64 Indexed Signature.
+            Codex::NonTransReceiptCouples => "-C", // Composed Base64 Couple, pre+cig.
+            Codex::TransReceiptQuadruples => "-D", // Composed Base64 Quadruple, pre+snu+dig+sig.
+            Codex::FirstSeenReplayCouples => "-E", // Composed Base64 Couple, fnu+dts.
+            Codex::TransIdxSigGroups => "-F", // Composed Base64 Group, pre+snu+dig+ControllerIdxSigs group.
+            Codex::SealSourceCouples => "-G", // Composed Base64 couple, snu+dig of given delegators or issuers event
+            Codex::TransLastIdxSigGroups => "-H", // Composed Base64 Group, pre+ControllerIdxSigs group.
+            Codex::SealSourceTriples => "-I", // Composed Base64 triple, pre+snu+dig of anchoring source event
+            Codex::SadPathSig => "-J", // Composed Base64 Group path+TransIdxSigGroup of SAID of content
+            Codex::SadPathSigGroup => "-K", // Composed Base64 Group, root(path)+SaidPathCouples
+            Codex::PathedMaterialQuadlets => "-L", // Composed Grouped Pathed Material Quadlet (4 char each)
+            Codex::AttachedMaterialQuadlets => "-V", // Composed Grouped Attached Material Quadlet (4 char each)
+            Codex::BigAttachedMaterialQuadlets => "-0V", // Composed Grouped Attached Material Quadlet (4 char each)
+            Codex::KERIProtocolStack => "--AAA",         // KERI ACDC Protocol Stack CESR Version
+        }
+    }
+
+    pub(crate) fn from_code(code: &str) -> Result<Self> {
+        Ok(match code {
+            "-A" => Codex::ControllerIdxSigs,
+            "-B" => Codex::WitnessIdxSigs,
+            "-C" => Codex::NonTransReceiptCouples,
+            "-D" => Codex::TransReceiptQuadruples,
+            "-E" => Codex::FirstSeenReplayCouples,
+            "-F" => Codex::TransIdxSigGroups,
+            "-G" => Codex::SealSourceCouples,
+            "-H" => Codex::TransLastIdxSigGroups,
+            "-I" => Codex::SealSourceTriples,
+            "-J" => Codex::SadPathSig,
+            "-K" => Codex::SadPathSigGroup,
+            "-L" => Codex::PathedMaterialQuadlets,
+            "-V" => Codex::AttachedMaterialQuadlets,
+            "-0V" => Codex::BigAttachedMaterialQuadlets,
+            "--AAA" => Codex::KERIProtocolStack,
+            _ => return Err(Box::new(Error::UnexpectedCode(code.to_string()))),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tables_tests {
+    use super::{bardage, hardage, sizage, Codex, Sizage};
+
+    #[test]
+    fn test_hardage() {
+        assert_eq!(hardage("-A").unwrap(), 2);
+        assert_eq!(hardage("-G").unwrap(), 2);
+        assert_eq!(hardage("-V").unwrap(), 2);
+        assert_eq!(hardage("-0").unwrap(), 3);
+        assert_eq!(hardage("--").unwrap(), 5);
+    }
+
+    #[test]
+    fn test_sizage() {
+        let mut s: Sizage;
+
+        s = sizage("-A").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-B").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-C").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-D").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-E").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-F").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-G").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-H").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-I").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-J").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-K").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-L").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-V").unwrap();
+        assert_eq!(s.hs, 2);
+        assert_eq!(s.ss, 2);
+        assert_eq!(s.fs, 4);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("-0V").unwrap();
+        assert_eq!(s.hs, 3);
+        assert_eq!(s.ss, 5);
+        assert_eq!(s.fs, 8);
+        assert_eq!(s.ls, 0);
+
+        s = sizage("--AAA").unwrap();
+        assert_eq!(s.hs, 5);
+        assert_eq!(s.ss, 3);
+        assert_eq!(s.fs, 8);
+        assert_eq!(s.ls, 0);
+    }
+
+    #[test]
+    fn test_codex() {
+        assert_eq!(Codex::ControllerIdxSigs.code(), "-A");
+        assert_eq!(Codex::WitnessIdxSigs.code(), "-B");
+        assert_eq!(Codex::NonTransReceiptCouples.code(), "-C");
+        assert_eq!(Codex::TransReceiptQuadruples.code(), "-D");
+        assert_eq!(Codex::FirstSeenReplayCouples.code(), "-E");
+        assert_eq!(Codex::TransIdxSigGroups.code(), "-F");
+        assert_eq!(Codex::SealSourceCouples.code(), "-G");
+        assert_eq!(Codex::TransLastIdxSigGroups.code(), "-H");
+        assert_eq!(Codex::SealSourceTriples.code(), "-I");
+        assert_eq!(Codex::SadPathSig.code(), "-J");
+        assert_eq!(Codex::SadPathSigGroup.code(), "-K");
+        assert_eq!(Codex::PathedMaterialQuadlets.code(), "-L");
+        assert_eq!(Codex::AttachedMaterialQuadlets.code(), "-V");
+        assert_eq!(Codex::BigAttachedMaterialQuadlets.code(), "-0V");
+        assert_eq!(Codex::KERIProtocolStack.code(), "--AAA");
+
+        assert_eq!(Codex::from_code("-A").unwrap(), Codex::ControllerIdxSigs);
+        assert_eq!(Codex::from_code("-B").unwrap(), Codex::WitnessIdxSigs);
+        assert_eq!(Codex::from_code("-C").unwrap(), Codex::NonTransReceiptCouples);
+        assert_eq!(Codex::from_code("-D").unwrap(), Codex::TransReceiptQuadruples);
+        assert_eq!(Codex::from_code("-E").unwrap(), Codex::FirstSeenReplayCouples);
+        assert_eq!(Codex::from_code("-F").unwrap(), Codex::TransIdxSigGroups);
+        assert_eq!(Codex::from_code("-G").unwrap(), Codex::SealSourceCouples);
+        assert_eq!(Codex::from_code("-H").unwrap(), Codex::TransLastIdxSigGroups);
+        assert_eq!(Codex::from_code("-I").unwrap(), Codex::SealSourceTriples);
+        assert_eq!(Codex::from_code("-J").unwrap(), Codex::SadPathSig);
+        assert_eq!(Codex::from_code("-K").unwrap(), Codex::SadPathSigGroup);
+        assert_eq!(Codex::from_code("-L").unwrap(), Codex::PathedMaterialQuadlets);
+        assert_eq!(Codex::from_code("-V").unwrap(), Codex::AttachedMaterialQuadlets);
+        assert_eq!(Codex::from_code("-0V").unwrap(), Codex::BigAttachedMaterialQuadlets);
+        assert_eq!(Codex::from_code("--AAA").unwrap(), Codex::KERIProtocolStack);
+    }
+
+    #[test]
+    fn test_unhappy_paths() {
+        assert!(sizage("CESR").is_err());
+        assert!(bardage(&[63, 0]).is_err());
+        assert!(Codex::from_code("CESR").is_err());
+    }
+}

--- a/src/core/diger.rs
+++ b/src/core/diger.rs
@@ -73,7 +73,7 @@ fn derive_digest(ev: matter::Codex, ser: &[u8]) -> Result<Vec<u8>> {
         }
         _ => {
             return Err(Box::new(Error::UnexpectedCode(format!(
-                "unexpected digest code: code = [{}]",
+                "unexpected digest code: code = '{}'",
                 ev.code()
             ))))
         }
@@ -177,7 +177,7 @@ impl Diger for Matter {
 
 #[cfg(test)]
 mod test_diger {
-    use super::{matter, Diger, Matter};
+    use super::{derive_digest, matter, Diger, Matter};
     use hex_literal::hex;
 
     #[test]
@@ -195,11 +195,7 @@ mod test_diger {
         let code = matter::Codex::Blake3_256.code();
 
         let m = <Matter as Diger>::new_with_code_and_ser(code, &ser).unwrap();
-        println!(
-            "blake3_256: {} [{}]",
-            hex::encode(m.raw()),
-            m.qb64().unwrap()
-        );
+        println!("blake3_256: {} [{}]", hex::encode(m.raw()), m.qb64().unwrap());
         assert_eq!(
             m.raw(),
             // https://github.com/BLAKE3-team/BLAKE3/blob/master/test_vectors/test_vectors.json
@@ -210,11 +206,7 @@ mod test_diger {
         let code = matter::Codex::Blake3_512.code();
 
         let m = <Matter as Diger>::new_with_code_and_ser(code, &ser).unwrap();
-        println!(
-            "blake3_512: {} [{}]",
-            hex::encode(m.raw()),
-            m.qb64().unwrap()
-        );
+        println!("blake3_512: {} [{}]", hex::encode(m.raw()), m.qb64().unwrap());
         assert_eq!(
             m.raw(),
             // https://github.com/BLAKE3-team/BLAKE3/blob/master/test_vectors/test_vectors.json
@@ -226,11 +218,7 @@ mod test_diger {
         let code = matter::Codex::Blake2b_256.code();
 
         let m = <Matter as Diger>::new_with_code_and_ser(code, ser).unwrap();
-        println!(
-            "blake2b_256: {} [{}]",
-            hex::encode(m.raw()),
-            m.qb64().unwrap()
-        );
+        println!("blake2b_256: {} [{}]", hex::encode(m.raw()), m.qb64().unwrap());
         assert_eq!(
             m.raw(),
             // https://github.com/jasoncolburne/jason-math/blob/main/spec/jason/math/cryptography/digest/blake_spec.rb
@@ -241,11 +229,7 @@ mod test_diger {
         let code = matter::Codex::Blake2b_512.code();
 
         let m = <Matter as Diger>::new_with_code_and_ser(code, ser).unwrap();
-        println!(
-            "blake2b_512: {} [{}]",
-            hex::encode(m.raw()),
-            m.qb64().unwrap()
-        );
+        println!("blake2b_512: {} [{}]", hex::encode(m.raw()), m.qb64().unwrap());
         assert_eq!(
             m.raw(),
             // https://github.com/jasoncolburne/jason-math/blob/main/spec/jason/math/cryptography/digest/blake_spec.rb
@@ -257,11 +241,7 @@ mod test_diger {
         let code = matter::Codex::Blake2s_256.code();
 
         let m = <Matter as Diger>::new_with_code_and_ser(code, &ser).unwrap();
-        println!(
-            "blake2s_256: {} [{}]",
-            hex::encode(m.raw()),
-            m.qb64().unwrap()
-        );
+        println!("blake2s_256: {} [{}]", hex::encode(m.raw()), m.qb64().unwrap());
         assert_eq!(
             m.raw(),
             // generated locally
@@ -427,7 +407,7 @@ mod test_diger {
     }
 
     #[test]
-    fn test_python_parity() {
+    fn test_python_interop() {
         // compare() will exercise the most code
         let ser = b"abcdefghijklmnopqrstuvwxyz0123456789";
 
@@ -461,5 +441,10 @@ mod test_diger {
 
         assert!(!diger0.compare_diger(ser, &diger).unwrap()); // codes match
         assert!(!diger0.compare_dig(ser, &diger.qb64b().unwrap()).unwrap()); // codes match
+    }
+
+    #[test]
+    fn test_unhappy_paths() {
+        assert!(derive_digest(matter::Codex::Big, &[]).is_err());
     }
 }

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -1,69 +1,56 @@
+use crate::core::sizage::Sizage;
 use crate::error::{Error, Result};
 
-#[derive(Debug, PartialEq)]
-pub struct Sizage {
-    pub hs: u32,
-    pub ss: u32,
-    pub ls: u32,
-    pub fs: u32,
-}
-
-impl Sizage {
-    pub fn new(hs: u32, ss: u32, fs: u32, ls: u32) -> Sizage {
-        Self { hs, ss, ls, fs }
-    }
-}
-
 pub(crate) fn sizage(s: &str) -> Result<Sizage> {
-    match s {
-        "A" => Ok(Sizage::new(1, 0, 44, 0)),
-        "B" => Ok(Sizage::new(1, 0, 44, 0)),
-        "C" => Ok(Sizage::new(1, 0, 44, 0)),
-        "D" => Ok(Sizage::new(1, 0, 44, 0)),
-        "E" => Ok(Sizage::new(1, 0, 44, 0)),
-        "F" => Ok(Sizage::new(1, 0, 44, 0)),
-        "G" => Ok(Sizage::new(1, 0, 44, 0)),
-        "H" => Ok(Sizage::new(1, 0, 44, 0)),
-        "I" => Ok(Sizage::new(1, 0, 44, 0)),
-        "J" => Ok(Sizage::new(1, 0, 44, 0)),
-        "K" => Ok(Sizage::new(1, 0, 76, 0)),
-        "L" => Ok(Sizage::new(1, 0, 76, 0)),
-        "M" => Ok(Sizage::new(1, 0, 4, 0)),
-        "N" => Ok(Sizage::new(1, 0, 12, 0)),
-        "O" => Ok(Sizage::new(1, 0, 44, 0)),
-        "P" => Ok(Sizage::new(1, 0, 124, 0)),
-        "0A" => Ok(Sizage::new(2, 0, 24, 0)),
-        "0B" => Ok(Sizage::new(2, 0, 88, 0)),
-        "0C" => Ok(Sizage::new(2, 0, 88, 0)),
-        "0D" => Ok(Sizage::new(2, 0, 88, 0)),
-        "0E" => Ok(Sizage::new(2, 0, 88, 0)),
-        "0F" => Ok(Sizage::new(2, 0, 88, 0)),
-        "0G" => Ok(Sizage::new(2, 0, 88, 0)),
-        "0H" => Ok(Sizage::new(2, 0, 8, 0)),
-        "1AAA" => Ok(Sizage::new(4, 0, 48, 0)),
-        "1AAB" => Ok(Sizage::new(4, 0, 48, 0)),
-        "1AAC" => Ok(Sizage::new(4, 0, 80, 0)),
-        "1AAD" => Ok(Sizage::new(4, 0, 80, 0)),
-        "1AAE" => Ok(Sizage::new(4, 0, 56, 0)),
-        "1AAF" => Ok(Sizage::new(4, 0, 8, 0)),
-        "1AAG" => Ok(Sizage::new(4, 0, 36, 0)),
-        "1AAH" => Ok(Sizage::new(4, 0, 100, 0)),
-        "2AAA" => Ok(Sizage::new(4, 0, 8, 1)),
-        "3AAA" => Ok(Sizage::new(4, 0, 8, 2)),
-        "4A" => Ok(Sizage::new(2, 2, 0, 0)),
-        "5A" => Ok(Sizage::new(2, 2, 0, 1)),
-        "6A" => Ok(Sizage::new(2, 2, 0, 2)),
-        "7AAA" => Ok(Sizage::new(4, 4, 0, 0)),
-        "8AAA" => Ok(Sizage::new(4, 4, 0, 1)),
-        "9AAA" => Ok(Sizage::new(4, 4, 0, 2)),
-        "4B" => Ok(Sizage::new(2, 2, 0, 0)),
-        "5B" => Ok(Sizage::new(2, 2, 0, 1)),
-        "6B" => Ok(Sizage::new(2, 2, 0, 2)),
-        "7AAB" => Ok(Sizage::new(4, 4, 0, 0)),
-        "8AAB" => Ok(Sizage::new(4, 4, 0, 1)),
-        "9AAB" => Ok(Sizage::new(4, 4, 0, 2)),
-        _ => Err(Box::new(Error::UnknownSizage(s.to_string()))),
-    }
+    Ok(match s {
+        "A" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "B" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "C" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "D" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "E" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "F" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "G" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "H" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "I" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "J" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "K" => Sizage { hs: 1, ss: 0, fs: 76, ls: 0 },
+        "L" => Sizage { hs: 1, ss: 0, fs: 76, ls: 0 },
+        "M" => Sizage { hs: 1, ss: 0, fs: 4, ls: 0 },
+        "N" => Sizage { hs: 1, ss: 0, fs: 12, ls: 0 },
+        "O" => Sizage { hs: 1, ss: 0, fs: 44, ls: 0 },
+        "P" => Sizage { hs: 1, ss: 0, fs: 124, ls: 0 },
+        "0A" => Sizage { hs: 2, ss: 0, fs: 24, ls: 0 },
+        "0B" => Sizage { hs: 2, ss: 0, fs: 88, ls: 0 },
+        "0C" => Sizage { hs: 2, ss: 0, fs: 88, ls: 0 },
+        "0D" => Sizage { hs: 2, ss: 0, fs: 88, ls: 0 },
+        "0E" => Sizage { hs: 2, ss: 0, fs: 88, ls: 0 },
+        "0F" => Sizage { hs: 2, ss: 0, fs: 88, ls: 0 },
+        "0G" => Sizage { hs: 2, ss: 0, fs: 88, ls: 0 },
+        "0H" => Sizage { hs: 2, ss: 0, fs: 8, ls: 0 },
+        "1AAA" => Sizage { hs: 4, ss: 0, fs: 48, ls: 0 },
+        "1AAB" => Sizage { hs: 4, ss: 0, fs: 48, ls: 0 },
+        "1AAC" => Sizage { hs: 4, ss: 0, fs: 80, ls: 0 },
+        "1AAD" => Sizage { hs: 4, ss: 0, fs: 80, ls: 0 },
+        "1AAE" => Sizage { hs: 4, ss: 0, fs: 56, ls: 0 },
+        "1AAF" => Sizage { hs: 4, ss: 0, fs: 8, ls: 0 },
+        "1AAG" => Sizage { hs: 4, ss: 0, fs: 36, ls: 0 },
+        "1AAH" => Sizage { hs: 4, ss: 0, fs: 100, ls: 0 },
+        "2AAA" => Sizage { hs: 4, ss: 0, fs: 8, ls: 1 },
+        "3AAA" => Sizage { hs: 4, ss: 0, fs: 8, ls: 2 },
+        "4A" => Sizage { hs: 2, ss: 2, fs: 0, ls: 0 },
+        "5A" => Sizage { hs: 2, ss: 2, fs: 0, ls: 1 },
+        "6A" => Sizage { hs: 2, ss: 2, fs: 0, ls: 2 },
+        "7AAA" => Sizage { hs: 4, ss: 4, fs: 0, ls: 0 },
+        "8AAA" => Sizage { hs: 4, ss: 4, fs: 0, ls: 1 },
+        "9AAA" => Sizage { hs: 4, ss: 4, fs: 0, ls: 2 },
+        "4B" => Sizage { hs: 2, ss: 2, fs: 0, ls: 0 },
+        "5B" => Sizage { hs: 2, ss: 2, fs: 0, ls: 1 },
+        "6B" => Sizage { hs: 2, ss: 2, fs: 0, ls: 2 },
+        "7AAB" => Sizage { hs: 4, ss: 4, fs: 0, ls: 0 },
+        "8AAB" => Sizage { hs: 4, ss: 4, fs: 0, ls: 1 },
+        "9AAB" => Sizage { hs: 4, ss: 4, fs: 0, ls: 2 },
+        _ => return Err(Box::new(Error::UnknownSizage(s.to_string()))),
+    })
 }
 
 pub(crate) fn hardage(c: char) -> Result<i32> {
@@ -71,9 +58,7 @@ pub(crate) fn hardage(c: char) -> Result<i32> {
         'A'..='Z' | 'a'..='z' => Ok(1),
         '0' | '4' | '5' | '6' => Ok(2),
         '1' | '2' | '3' | '7' | '8' | '9' => Ok(4),
-        '-' => Err(Box::new(Error::UnexpectedCode(
-            "count code start".to_string(),
-        ))),
+        '-' => Err(Box::new(Error::UnexpectedCode("count code start".to_string()))),
         '_' => Err(Box::new(Error::UnexpectedCode("op code start".to_string()))),
         _ => Err(Box::new(Error::UnknownHardage(c.to_string()))),
     }
@@ -578,5 +563,60 @@ mod tables_tests {
         assert_eq!(Codex::Bytes_Big_L0.code(), "7AAB");
         assert_eq!(Codex::Bytes_Big_L1.code(), "8AAB");
         assert_eq!(Codex::Bytes_Big_L2.code(), "9AAB");
+
+        assert_eq!(Codex::from_code("A").unwrap(), Codex::Ed25519_Seed);
+        assert_eq!(Codex::from_code("B").unwrap(), Codex::Ed25519N);
+        assert_eq!(Codex::from_code("C").unwrap(), Codex::X25519);
+        assert_eq!(Codex::from_code("D").unwrap(), Codex::Ed25519);
+        assert_eq!(Codex::from_code("E").unwrap(), Codex::Blake3_256);
+        assert_eq!(Codex::from_code("F").unwrap(), Codex::Blake2b_256);
+        assert_eq!(Codex::from_code("G").unwrap(), Codex::Blake2s_256);
+        assert_eq!(Codex::from_code("H").unwrap(), Codex::SHA3_256);
+        assert_eq!(Codex::from_code("I").unwrap(), Codex::SHA2_256);
+        assert_eq!(Codex::from_code("J").unwrap(), Codex::ECDSA_256k1_Seed);
+        assert_eq!(Codex::from_code("K").unwrap(), Codex::Ed448_Seed);
+        assert_eq!(Codex::from_code("L").unwrap(), Codex::X448);
+        assert_eq!(Codex::from_code("M").unwrap(), Codex::Short);
+        assert_eq!(Codex::from_code("N").unwrap(), Codex::Big);
+        assert_eq!(Codex::from_code("O").unwrap(), Codex::X25519_Private);
+        assert_eq!(Codex::from_code("P").unwrap(), Codex::X25519_Cipher_Seed);
+        assert_eq!(Codex::from_code("0A").unwrap(), Codex::Salt_128);
+        assert_eq!(Codex::from_code("0B").unwrap(), Codex::Ed25519_Sig);
+        assert_eq!(Codex::from_code("0C").unwrap(), Codex::ECDSA_256k1_Sig);
+        assert_eq!(Codex::from_code("0D").unwrap(), Codex::Blake3_512);
+        assert_eq!(Codex::from_code("0E").unwrap(), Codex::Blake2b_512);
+        assert_eq!(Codex::from_code("0F").unwrap(), Codex::SHA3_512);
+        assert_eq!(Codex::from_code("0G").unwrap(), Codex::SHA2_512);
+        assert_eq!(Codex::from_code("0H").unwrap(), Codex::Long);
+        assert_eq!(Codex::from_code("1AAA").unwrap(), Codex::ECDSA_256k1N);
+        assert_eq!(Codex::from_code("1AAB").unwrap(), Codex::ECDSA_256k1);
+        assert_eq!(Codex::from_code("1AAC").unwrap(), Codex::Ed448N);
+        assert_eq!(Codex::from_code("1AAD").unwrap(), Codex::Ed448);
+        assert_eq!(Codex::from_code("1AAE").unwrap(), Codex::Ed448_Sig);
+        assert_eq!(Codex::from_code("1AAF").unwrap(), Codex::Tern);
+        assert_eq!(Codex::from_code("1AAG").unwrap(), Codex::DateTime);
+        assert_eq!(Codex::from_code("1AAH").unwrap(), Codex::X25519_Cipher_Salt);
+        assert_eq!(Codex::from_code("2AAA").unwrap(), Codex::TBD1);
+        assert_eq!(Codex::from_code("3AAA").unwrap(), Codex::TBD2);
+        assert_eq!(Codex::from_code("4A").unwrap(), Codex::StrB64_L0);
+        assert_eq!(Codex::from_code("5A").unwrap(), Codex::StrB64_L1);
+        assert_eq!(Codex::from_code("6A").unwrap(), Codex::StrB64_L2);
+        assert_eq!(Codex::from_code("7AAA").unwrap(), Codex::StrB64_Big_L0);
+        assert_eq!(Codex::from_code("8AAA").unwrap(), Codex::StrB64_Big_L1);
+        assert_eq!(Codex::from_code("9AAA").unwrap(), Codex::StrB64_Big_L2);
+        assert_eq!(Codex::from_code("4B").unwrap(), Codex::Bytes_L0);
+        assert_eq!(Codex::from_code("5B").unwrap(), Codex::Bytes_L1);
+        assert_eq!(Codex::from_code("6B").unwrap(), Codex::Bytes_L2);
+        assert_eq!(Codex::from_code("7AAB").unwrap(), Codex::Bytes_Big_L0);
+        assert_eq!(Codex::from_code("8AAB").unwrap(), Codex::Bytes_Big_L1);
+        assert_eq!(Codex::from_code("9AAB").unwrap(), Codex::Bytes_Big_L2);
+    }
+
+    #[test]
+    fn test_unhappy_paths() {
+        assert!(hardage('-').is_err());
+        assert!(hardage('_').is_err());
+        assert!(hardage('#').is_err());
+        assert!(Codex::from_code("CESR").is_err());
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,7 @@
 mod cigar;
+mod counter;
 mod diger;
 mod matter;
+mod sizage;
 mod util;
 mod verfer;

--- a/src/core/sizage.rs
+++ b/src/core/sizage.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, PartialEq)]
+pub struct Sizage {
+    pub hs: u32,
+    pub ss: u32,
+    pub ls: u32,
+    pub fs: u32,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,8 +19,14 @@ pub enum Error {
     InvalidVarSize(String),
     #[error("invalid variable raw size: {0}")]
     InvalidVarRawSize(String),
+    #[error("invalid variable index: {0}")]
+    InvalidVarIndex(String),
     #[error("invalid code size: {0}")]
     InvalidCodeSize(String),
+    #[error("invalid base64 character: {0}")]
+    InvalidBase64Character(char),
+    #[error("invalid base64 index: {0}")]
+    InvalidBase64Index(u8),
     #[error("shortage: {0}")]
     Shortage(String),
     #[error("empty qb64")]
@@ -29,6 +35,8 @@ pub enum Error {
     UnknownSizage(String),
     #[error("unknown hardage: {0}")]
     UnknownHardage(String),
+    #[error("unknown bardage: {0}")]
+    UnknownBardage(String),
     #[error("variable size codes not supported")]
     UnsupportedSize(),
     #[error("need {0} more characters")]
@@ -43,6 +51,8 @@ pub enum Error {
     NonZeroedLeadBytes(),
     #[error("non-zeroed pad bits")]
     NonZeroedPadBits(),
+    #[error("parsing error: {0}")]
+    Parsing(String),
     #[error("error parsing qb64: {0}")]
     ParseQb64(String),
     #[error("error parsing qb2: {0}")]


### PR DESCRIPTION
## Rationale
This was next in the list of things that could be implemented. It had very few dependencies.

## Changes
- adds `Counter`, `counter::Codex` and associated machinery
- adds `nab_sextets()` to `core::util`
- improves test coverage

## Testing
Extensive testing on `Counter`, as most tests were ported. There were many.

## Notes
Sorry about the length, I got a bit carried away and don't want to ask for review over weekends.