### PR TITLE
codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 95
+        paths: ["src"]
+    patch:
+      default:
+        target: 90
+        paths: ["src"]


### PR DESCRIPTION
## Changes
- require 95% coverage
- only check `src` (useful if we add `build.rs`)

## Screenshots
<img width="837" alt="Screenshot 2023-01-31 at 9 08 39 AM" src="https://user-images.githubusercontent.com/685385/215768676-f10d371c-4f53-4a65-8990-2c2511c33acc.png">