### PR TITLE
refactor sizage

### DIFF
--- a/src/core/counter/tables.rs
+++ b/src/core/counter/tables.rs
@@ -1,5 +1,12 @@
-use crate::core::sizage::Sizage;
 use crate::error::{Error, Result};
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct Sizage {
+    pub hs: u32,
+    pub ss: u32,
+    pub ls: u32,
+    pub fs: u32,
+}
 
 pub(crate) fn sizage(s: &str) -> Result<Sizage> {
     Ok(match s {

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -1,5 +1,12 @@
-use crate::core::sizage::Sizage;
 use crate::error::{Error, Result};
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct Sizage {
+    pub hs: u32,
+    pub ss: u32,
+    pub ls: u32,
+    pub fs: u32,
+}
 
 pub(crate) fn sizage(s: &str) -> Result<Sizage> {
     Ok(match s {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,5 @@ mod cigar;
 mod counter;
 mod diger;
 mod matter;
-mod sizage;
 mod util;
 mod verfer;

--- a/src/core/sizage.rs
+++ b/src/core/sizage.rs
@@ -1,7 +1,0 @@
-#[derive(Debug, PartialEq)]
-pub struct Sizage {
-    pub hs: u32,
-    pub ss: u32,
-    pub ls: u32,
-    pub fs: u32,
-}


### PR DESCRIPTION
## Rationale
Sizage is not uniform and is actually table specific. In the upcoming `Indexer` PR (#49) we will have a structural conflict.

## Changes
Creates `Codex` specific `Sizages`.

## Testing
This was only a change in location, no logic changed. Current tests assert that nothing we know could break has broken.