### PR TITLE
fix constants

### DIFF
--- a/src/core/counter/mod.rs
+++ b/src/core/counter/mod.rs
@@ -32,8 +32,7 @@ impl Counter {
             )));
         }
 
-        const SIXTY_FOUR: u32 = 64;
-        if count > SIXTY_FOUR.pow(szg.ss) - 1 {
+        if count > 64_u32.pow(szg.ss) - 1 {
             return err!(Error::InvalidVarIndex(format!(
                 "invalid count for code: count = {count}, code = '{code}'"
             )));
@@ -168,8 +167,7 @@ impl Counter {
             )));
         }
 
-        const SIXTY_FOUR: u32 = 64;
-        if count > SIXTY_FOUR.pow(szg.ss) - 1 {
+        if count > 64_u32.pow(szg.ss) - 1 {
             return err!(Error::InvalidVarIndex(format!(
                 "invalid count for code: count = {count}, code = '{code}'"
             )));

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -1,5 +1,10 @@
 use crate::error::{err, Error, Result};
 
+pub(crate) const SMALL_VRZ_DEX: [char; 3] = ['4', '5', '6'];
+pub(crate) const LARGE_VRZ_DEX: [char; 3] = ['7', '8', '9'];
+pub(crate) const SMALL_VRZ_BYTES: u32 = 3;
+pub(crate) const LARGE_VRZ_BYTES: u32 = 6;
+
 #[derive(Debug, PartialEq)]
 pub(crate) struct Sizage {
     pub hs: u32,


### PR DESCRIPTION
## Rationale
Constants were gross, like this:

```rust
const SIXTY_FOUR: u32 = 64;
if count > SIXTY_FOUR.pow(szg.ss) - 1 {
// ...
```

This PR changes integral constants to the standard approach, `1_u32` for `1` as a `u32` for example. In the case of the example above, we'd end up with `if count > 64_u32.pow(szg.ss) - 1`.

## Changes

Fixes constants as above, and moves remaining constants into `tables.rs` as that seemed a more appropriate place for module specific constants.

## Testing

Standard test suite covers these changes.