### PR TITLE
error macro

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,5 @@ coverage:
         paths: ["src"]
     patch:
       default:
-        target: 90
+        target: 75
         paths: ["src"]

--- a/src/core/cigar.rs
+++ b/src/core/cigar.rs
@@ -1,5 +1,5 @@
 use crate::core::matter::{tables as matter, Matter};
-use crate::error::{Error, Result};
+use crate::error::{err, Error, Result};
 
 #[derive(Debug, Clone)]
 pub struct Cigar {
@@ -15,7 +15,7 @@ fn validate_code(code: &str) -> Result<()> {
     ]
     .contains(&code)
     {
-        return Err(Box::new(Error::UnexpectedCode(code.to_string())));
+        return err!(Error::UnexpectedCode(code.to_string()));
     }
 
     Ok(())

--- a/src/core/counter/tables.rs
+++ b/src/core/counter/tables.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::error::{err, Error, Result};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Sizage {
@@ -25,7 +25,7 @@ pub(crate) fn sizage(s: &str) -> Result<Sizage> {
         "-V" => Sizage { hs: 2, ss: 2, fs: 4, ls: 0 },
         "-0V" => Sizage { hs: 3, ss: 5, fs: 8, ls: 0 },
         "--AAA" => Sizage { hs: 5, ss: 3, fs: 8, ls: 0 },
-        _ => return Err(Box::new(Error::UnknownSizage(s.to_string()))),
+        _ => return err!(Error::UnknownSizage(s.to_string())),
     })
 }
 
@@ -35,7 +35,7 @@ pub(crate) fn hardage(s: &str) -> Result<u32> {
         | "-V" => Ok(2),
         "-0" => Ok(3),
         "--" => Ok(5),
-        _ => Err(Box::new(Error::UnknownHardage(s.to_string()))),
+        _ => err!(Error::UnknownHardage(s.to_string())),
     }
 }
 
@@ -56,7 +56,7 @@ pub(crate) fn bardage(b: &[u8]) -> Result<u32> {
         | [62, 21] => Ok(2),
         [62, 52] => Ok(3),
         [62, 62] => Ok(5),
-        _ => Err(Box::new(Error::UnknownBardage(format!("{b:?}")))),
+        _ => err!(Error::UnknownBardage(format!("{b:?}"))),
     }
 }
 
@@ -117,7 +117,7 @@ impl Codex {
             "-V" => Codex::AttachedMaterialQuadlets,
             "-0V" => Codex::BigAttachedMaterialQuadlets,
             "--AAA" => Codex::KERIProtocolStack,
-            _ => return Err(Box::new(Error::UnexpectedCode(code.to_string()))),
+            _ => return err!(Error::UnexpectedCode(code.to_string())),
         })
     }
 }

--- a/src/core/diger.rs
+++ b/src/core/diger.rs
@@ -1,7 +1,7 @@
 use blake2::Digest;
 
 use crate::core::matter::{tables as matter, Matter};
-use crate::error::{Error, Result};
+use crate::error::{err, Error, Result};
 
 type Blake2b256 = blake2::Blake2b<blake2::digest::consts::U32>;
 
@@ -72,10 +72,10 @@ fn derive_digest(ev: matter::Codex, ser: &[u8]) -> Result<Vec<u8>> {
             hasher.finalize().to_vec()
         }
         _ => {
-            return Err(Box::new(Error::UnexpectedCode(format!(
+            return err!(Error::UnexpectedCode(format!(
                 "unexpected digest code: code = '{}'",
                 ev.code()
-            ))))
+            )))
         }
     };
 
@@ -96,7 +96,7 @@ fn validate_code(code: &str) -> Result<()> {
     ]
     .contains(&code)
     {
-        return Err(Box::new(Error::UnexpectedCode(code.to_string())));
+        return err!(Error::UnexpectedCode(code.to_string()));
     }
 
     Ok(())

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::error::{err, Error, Result};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Sizage {
@@ -56,7 +56,7 @@ pub(crate) fn sizage(s: &str) -> Result<Sizage> {
         "7AAB" => Sizage { hs: 4, ss: 4, fs: 0, ls: 0 },
         "8AAB" => Sizage { hs: 4, ss: 4, fs: 0, ls: 1 },
         "9AAB" => Sizage { hs: 4, ss: 4, fs: 0, ls: 2 },
-        _ => return Err(Box::new(Error::UnknownSizage(s.to_string()))),
+        _ => return err!(Error::UnknownSizage(s.to_string())),
     })
 }
 
@@ -65,9 +65,9 @@ pub(crate) fn hardage(c: char) -> Result<i32> {
         'A'..='Z' | 'a'..='z' => Ok(1),
         '0' | '4' | '5' | '6' => Ok(2),
         '1' | '2' | '3' | '7' | '8' | '9' => Ok(4),
-        '-' => Err(Box::new(Error::UnexpectedCode("count code start".to_string()))),
-        '_' => Err(Box::new(Error::UnexpectedCode("op code start".to_string()))),
-        _ => Err(Box::new(Error::UnknownHardage(c.to_string()))),
+        '-' => err!(Error::UnexpectedCode("count code start".to_string())),
+        '_' => err!(Error::UnexpectedCode("op code start".to_string())),
+        _ => err!(Error::UnknownHardage(c.to_string())),
     }
 }
 
@@ -222,7 +222,7 @@ impl Codex {
             "7AAB" => Codex::Bytes_Big_L0,
             "8AAB" => Codex::Bytes_Big_L1,
             "9AAB" => Codex::Bytes_Big_L2,
-            _ => return Err(Box::new(Error::UnexpectedCode(code.to_string()))),
+            _ => return err!(Error::UnexpectedCode(code.to_string())),
         })
     }
 }

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::error::{err, Error, Result};
 
 pub fn b64_char_to_index(c: char) -> Result<u8> {
     Ok(match c {
@@ -67,7 +67,7 @@ pub fn b64_char_to_index(c: char) -> Result<u8> {
         '-' => 62,
         '_' => 63,
         _ => {
-            return Err(Box::new(Error::InvalidBase64Character(c)));
+            return err!(Error::InvalidBase64Character(c));
         }
     })
 }
@@ -139,7 +139,7 @@ pub fn b64_index_to_char(i: u8) -> Result<char> {
         62 => '-',
         63 => '_',
         _ => {
-            return Err(Box::new(Error::InvalidBase64Index(i)));
+            return err!(Error::InvalidBase64Index(i));
         }
     })
 }
@@ -200,7 +200,7 @@ pub fn code_b2_to_b64(b2: &[u8], length: usize) -> Result<String> {
     let n = ((length + 1) * 3) / 4;
 
     if n > b2.len() {
-        return Err(Box::new(Error::Matter("not enough bytes".to_string())));
+        return err!(Error::Matter("not enough bytes".to_string()));
     }
 
     if length <= 4 {
@@ -218,7 +218,7 @@ pub fn code_b2_to_b64(b2: &[u8], length: usize) -> Result<String> {
         let tbs = 2 * (length % 4) + (8 - n) * 8;
         Ok(u64_to_b64(i >> tbs, length)?)
     } else {
-        Err(Box::new(Error::Matter("unexpected length".to_string())))
+        err!(Error::Matter("unexpected length".to_string()))
     }
 }
 
@@ -233,7 +233,7 @@ pub fn nab_sextets(binary: &[u8], count: usize) -> Result<Vec<u8>> {
     let n = ((count + 1) * 3) / 4;
 
     if n > binary.len() {
-        return Err(Box::new(Error::TooSmall(n - binary.len())));
+        return err!(Error::TooSmall(n - binary.len()));
     }
 
     let mut padded = binary.to_vec();

--- a/src/core/verfer.rs
+++ b/src/core/verfer.rs
@@ -1,5 +1,5 @@
 use crate::core::matter::{tables as matter, Matter};
-use crate::error::{Error, Result};
+use crate::error::{err, Error, Result};
 
 pub trait Verfer {
     fn new_with_code_and_raw(code: &str, raw: &[u8]) -> Result<Matter>
@@ -28,7 +28,7 @@ fn validate_code(code: &str) -> Result<()> {
     ]
     .contains(&code)
     {
-        return Err(Box::new(Error::UnexpectedCode(code.to_string())));
+        return err!(Error::UnexpectedCode(code.to_string()));
     }
 
     Ok(())
@@ -53,7 +53,7 @@ fn verify_ecdsa_256k1_signature(verfer: &Matter, sig: &[u8], ser: &[u8]) -> Resu
     let signature = match Signature::try_from(sig) {
         Ok(s) => s,
         Err(e) => {
-            return Err(Box::new(e));
+            return err!(e);
         }
     };
 
@@ -101,10 +101,10 @@ impl Verfer for Matter {
             matter::Codex::ECDSA_256k1 => verify_ecdsa_256k1_signature(self, sig, ser),
             // matter::Codex::Ed448N => verify_ed448_signature(verfer, sig, ser)?,
             // matter::Codex::Ed448 => verify_ed448_signature(verfer, sig, ser)?,
-            _ => Err(Box::new(Error::UnexpectedCode(format!(
+            _ => err!(Error::UnexpectedCode(format!(
                 "unexpected signature code: code = '{}'",
                 ev.code()
-            )))),
+            ))),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,3 +60,25 @@ pub enum Error {
     #[error("conversion error: {0}")]
     Conversion(String),
 }
+
+macro_rules! err {
+    ($e:expr) => {
+        Err(Box::new($e))
+    };
+}
+
+pub(crate) use err;
+
+#[cfg(test)]
+mod test {
+    use super::{Error, Result};
+
+    fn explode() -> Result<()> {
+        return err!(Error::Prepad());
+    }
+
+    #[test]
+    fn err() {
+        assert!(explode().is_err());
+    }
+}


### PR DESCRIPTION
## Rationale

This cleans up the boxing of errors, which I've always hated. Instead of this:

```rust
return Err(Box::new(Error::SomeError()));
```

we now have

```rust
return err!(Error::SomeError());
```

## Changes

As described above.

Also had to reduce patch coverage target since many errors are unreachable, thus changes like this that affect all errors impact patch coverage. More importantly, though, project coverage is barely changing (no tangible difference) and that target is still 95%.

## Testing

Explicit unit tests exercise the macro. 