### PR TITLE
better dependency versioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ keywords = ["cesr", "keri", "acdc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.21.0"
-blake2 = "0.10.6"
-blake3 = "1.3.3"
-ed25519-dalek = "1.0.1"
-k256 = "0.12.0"
-lazy_static = "1.4.0"
-sha2 = "0.10.6"
-sha3 = "0.10.6"
-thiserror = "1.0.38"
+base64 = "~0.21"
+blake2 = "~0.10"
+blake3 = "~1"
+ed25519-dalek = "~1"
+k256 = "~0.12"
+lazy_static = "~1"
+sha2 = "~0.10"
+sha3 = "~0.10"
+thiserror = "~1"
 
 [dev-dependencies]
-hex-literal = "0.3.4"
-hex = "0.3.1"
-rand = "0.7.0"
-rand_core = "0.6.4"
+hex-literal = "*"
+hex = "*"
+rand = "0.7.0" # this needs pinning for one of the seeding pieces of a signing suite
+rand_core = "*"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TAIL_LINES = $(shell echo $$(( $(TOTAL_LINES) - $(DELIMITING_LINE) )))
 
 python:
 	@head -n $(DELIMITING_LINE) Cargo.toml > cargo/$@/Cargo.toml
-	@echo "pyo3 = { version = \"0.18.0\", features = [\"abi3\", \"extension-module\"] }" >> cargo/$@/Cargo.toml
+	@echo "pyo3 = { version = \"~0.18\", features = [\"abi3\", \"extension-module\"] }" >> cargo/$@/Cargo.toml
 	@tail -n $(TAIL_LINES) Cargo.toml >> cargo/$@/Cargo.toml
 	@echo >> cargo/$@/Cargo.toml
 	@cat cargo/$@/Cargo.toml.tail >> cargo/$@/Cargo.toml


### PR DESCRIPTION
## Rationale

As a library we don't really want pinned dependencies, but we do want to avoid breakage. [Semantic versioning](https://semver.org) allows us to pin the `major` version and be confident that `minor` and `patch` changes won't break functionality.

Caveat: versions with `major` = `0` may disobey these rules, thus I have pinned them to the first non-zero value in the sequence `[major, minor, patch]`.

## Changes

- Uses `~` to lock dependency `major` (or `minor` if `major` = `0`) versions.
- Unpins dev dependencies entirely.

## Testing

`make clean fix preflight python python-shell`