### PR TITLE
lazy static

### DIFF
--- a/src/core/cigar.rs
+++ b/src/core/cigar.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+
 use crate::core::matter::{tables as matter, Matter};
 use crate::error::{err, Error, Result};
 
@@ -8,13 +10,15 @@ pub struct Cigar {
 }
 
 fn validate_code(code: &str) -> Result<()> {
-    if !vec![
-        matter::Codex::Ed25519_Sig.code(),
-        matter::Codex::ECDSA_256k1_Sig.code(),
-        // matter::Codex::Ed448_Sig.code(),
-    ]
-    .contains(&code)
-    {
+    lazy_static! {
+        static ref CODES: Vec<&'static str> = vec![
+            matter::Codex::Ed25519_Sig.code(),
+            matter::Codex::ECDSA_256k1_Sig.code(),
+            // matter::Codex::Ed448_Sig.code(),
+        ];
+    }
+
+    if !CODES.contains(&code) {
         return err!(Error::UnexpectedCode(code.to_string()));
     }
 

--- a/src/core/diger.rs
+++ b/src/core/diger.rs
@@ -1,4 +1,5 @@
 use blake2::Digest;
+use lazy_static::lazy_static;
 
 use crate::core::matter::{tables as matter, Matter};
 use crate::error::{err, Error, Result};
@@ -83,19 +84,21 @@ fn derive_digest(ev: matter::Codex, ser: &[u8]) -> Result<Vec<u8>> {
 }
 
 fn validate_code(code: &str) -> Result<()> {
-    if !vec![
-        matter::Codex::Blake3_256.code(),
-        matter::Codex::Blake3_512.code(),
-        matter::Codex::Blake2b_256.code(),
-        matter::Codex::Blake2b_512.code(),
-        matter::Codex::Blake2s_256.code(),
-        matter::Codex::SHA3_256.code(),
-        matter::Codex::SHA3_512.code(),
-        matter::Codex::SHA2_256.code(),
-        matter::Codex::SHA2_512.code(),
-    ]
-    .contains(&code)
-    {
+    lazy_static! {
+        static ref CODES: Vec<&'static str> = vec![
+            matter::Codex::Blake3_256.code(),
+            matter::Codex::Blake3_512.code(),
+            matter::Codex::Blake2b_256.code(),
+            matter::Codex::Blake2b_512.code(),
+            matter::Codex::Blake2s_256.code(),
+            matter::Codex::SHA3_256.code(),
+            matter::Codex::SHA3_512.code(),
+            matter::Codex::SHA2_256.code(),
+            matter::Codex::SHA2_512.code(),
+        ];
+    }
+
+    if !CODES.contains(&code) {
         return err!(Error::UnexpectedCode(code.to_string()));
     }
 

--- a/src/core/verfer.rs
+++ b/src/core/verfer.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+
 use crate::core::matter::{tables as matter, Matter};
 use crate::error::{err, Error, Result};
 
@@ -18,16 +20,18 @@ pub trait Verfer {
 }
 
 fn validate_code(code: &str) -> Result<()> {
-    if !vec![
-        matter::Codex::Ed25519N.code(),
-        matter::Codex::Ed25519.code(),
-        matter::Codex::ECDSA_256k1N.code(),
-        matter::Codex::ECDSA_256k1.code(),
-        // matter::Codex::Ed448N.code(),
-        // matter::Codex::Ed448.code(),
-    ]
-    .contains(&code)
-    {
+    lazy_static! {
+        static ref CODES: Vec<&'static str> = vec![
+            matter::Codex::Ed25519N.code(),
+            matter::Codex::Ed25519.code(),
+            matter::Codex::ECDSA_256k1N.code(),
+            matter::Codex::ECDSA_256k1.code(),
+            // matter::Codex::Ed448N.code(),
+            // matter::Codex::Ed448.code(),
+        ];
+    }
+
+    if !CODES.contains(&code) {
         return err!(Error::UnexpectedCode(code.to_string()));
     }
 


### PR DESCRIPTION
## Rationale

We don't want to be instantiating a `Vec` every time we call 'validate()'. This PR uses [lazy static](https://crates.io/crates/lazy_static) to avoid that nonsense.

##  Changes

- Surrounded `vec![]` calls with `lazy_static` blocks

## Testing

`make clean fix python preflight python-shell`