### PR TITLE
`rstest` across repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ hex-literal = "*"
 hex = "*"
 rand = "0.7.0" # this needs pinning for one of the seeding pieces of a signing suite
 rand_core = "*"
+rstest = "*"

--- a/src/core/cigar.rs
+++ b/src/core/cigar.rs
@@ -84,8 +84,8 @@ impl Cigar {
 
 #[cfg(test)]
 mod test_cigar {
-    use super::{Cigar, Matter};
-    use crate::core::matter::tables as matter;
+    use crate::core::cigar::Cigar;
+    use crate::core::matter::{tables as matter, Matter};
     use crate::core::verfer::Verfer;
 
     #[test]

--- a/src/core/counter/tables.rs
+++ b/src/core/counter/tables.rs
@@ -124,145 +124,68 @@ impl Codex {
 
 #[cfg(test)]
 mod tables_tests {
-    use super::{bardage, hardage, sizage, Codex, Sizage};
+    use crate::core::counter::tables::{bardage, hardage, sizage, Codex};
+    use rstest::rstest;
 
-    #[test]
-    fn test_hardage() {
-        assert_eq!(hardage("-A").unwrap(), 2);
-        assert_eq!(hardage("-G").unwrap(), 2);
-        assert_eq!(hardage("-V").unwrap(), 2);
-        assert_eq!(hardage("-0").unwrap(), 3);
-        assert_eq!(hardage("--").unwrap(), 5);
+    #[rstest]
+    #[case("-A", 2)]
+    #[case("-G", 2)]
+    #[case("-V", 2)]
+    #[case("-0", 3)]
+    #[case("--", 5)]
+    fn test_hardage(#[case] code: &str, #[case] hdg: u32) {
+        assert_eq!(hardage(code).unwrap(), hdg);
     }
 
-    #[test]
-    fn test_sizage() {
-        let mut s: Sizage;
-
-        s = sizage("-A").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-B").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-C").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-D").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-E").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-F").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-G").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-H").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-I").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-J").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-K").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-L").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-V").unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("-0V").unwrap();
-        assert_eq!(s.hs, 3);
-        assert_eq!(s.ss, 5);
-        assert_eq!(s.fs, 8);
-        assert_eq!(s.ls, 0);
-
-        s = sizage("--AAA").unwrap();
-        assert_eq!(s.hs, 5);
-        assert_eq!(s.ss, 3);
-        assert_eq!(s.fs, 8);
-        assert_eq!(s.ls, 0);
+    #[rstest]
+    #[case("-A", 2, 2, 4, 0)]
+    #[case("-B", 2, 2, 4, 0)]
+    #[case("-C", 2, 2, 4, 0)]
+    #[case("-D", 2, 2, 4, 0)]
+    #[case("-E", 2, 2, 4, 0)]
+    #[case("-F", 2, 2, 4, 0)]
+    #[case("-G", 2, 2, 4, 0)]
+    #[case("-H", 2, 2, 4, 0)]
+    #[case("-I", 2, 2, 4, 0)]
+    #[case("-J", 2, 2, 4, 0)]
+    #[case("-K", 2, 2, 4, 0)]
+    #[case("-L", 2, 2, 4, 0)]
+    #[case("-V", 2, 2, 4, 0)]
+    #[case("-0V", 3, 5, 8, 0)]
+    #[case("--AAA", 5, 3, 8, 0)]
+    fn test_sizage(
+        #[case] code: &str,
+        #[case] hs: u32,
+        #[case] ss: u32,
+        #[case] fs: u32,
+        #[case] ls: u32,
+    ) {
+        let s = sizage(code).unwrap();
+        assert_eq!(s.hs, hs);
+        assert_eq!(s.ss, ss);
+        assert_eq!(s.fs, fs);
+        assert_eq!(s.ls, ls);
     }
 
-    #[test]
-    fn test_codex() {
-        assert_eq!(Codex::ControllerIdxSigs.code(), "-A");
-        assert_eq!(Codex::WitnessIdxSigs.code(), "-B");
-        assert_eq!(Codex::NonTransReceiptCouples.code(), "-C");
-        assert_eq!(Codex::TransReceiptQuadruples.code(), "-D");
-        assert_eq!(Codex::FirstSeenReplayCouples.code(), "-E");
-        assert_eq!(Codex::TransIdxSigGroups.code(), "-F");
-        assert_eq!(Codex::SealSourceCouples.code(), "-G");
-        assert_eq!(Codex::TransLastIdxSigGroups.code(), "-H");
-        assert_eq!(Codex::SealSourceTriples.code(), "-I");
-        assert_eq!(Codex::SadPathSig.code(), "-J");
-        assert_eq!(Codex::SadPathSigGroup.code(), "-K");
-        assert_eq!(Codex::PathedMaterialQuadlets.code(), "-L");
-        assert_eq!(Codex::AttachedMaterialQuadlets.code(), "-V");
-        assert_eq!(Codex::BigAttachedMaterialQuadlets.code(), "-0V");
-        assert_eq!(Codex::KERIProtocolStack.code(), "--AAA");
-
-        assert_eq!(Codex::from_code("-A").unwrap(), Codex::ControllerIdxSigs);
-        assert_eq!(Codex::from_code("-B").unwrap(), Codex::WitnessIdxSigs);
-        assert_eq!(Codex::from_code("-C").unwrap(), Codex::NonTransReceiptCouples);
-        assert_eq!(Codex::from_code("-D").unwrap(), Codex::TransReceiptQuadruples);
-        assert_eq!(Codex::from_code("-E").unwrap(), Codex::FirstSeenReplayCouples);
-        assert_eq!(Codex::from_code("-F").unwrap(), Codex::TransIdxSigGroups);
-        assert_eq!(Codex::from_code("-G").unwrap(), Codex::SealSourceCouples);
-        assert_eq!(Codex::from_code("-H").unwrap(), Codex::TransLastIdxSigGroups);
-        assert_eq!(Codex::from_code("-I").unwrap(), Codex::SealSourceTriples);
-        assert_eq!(Codex::from_code("-J").unwrap(), Codex::SadPathSig);
-        assert_eq!(Codex::from_code("-K").unwrap(), Codex::SadPathSigGroup);
-        assert_eq!(Codex::from_code("-L").unwrap(), Codex::PathedMaterialQuadlets);
-        assert_eq!(Codex::from_code("-V").unwrap(), Codex::AttachedMaterialQuadlets);
-        assert_eq!(Codex::from_code("-0V").unwrap(), Codex::BigAttachedMaterialQuadlets);
-        assert_eq!(Codex::from_code("--AAA").unwrap(), Codex::KERIProtocolStack);
+    #[rstest]
+    #[case(Codex::ControllerIdxSigs, "-A")]
+    #[case(Codex::WitnessIdxSigs, "-B")]
+    #[case(Codex::NonTransReceiptCouples, "-C")]
+    #[case(Codex::TransReceiptQuadruples, "-D")]
+    #[case(Codex::FirstSeenReplayCouples, "-E")]
+    #[case(Codex::TransIdxSigGroups, "-F")]
+    #[case(Codex::SealSourceCouples, "-G")]
+    #[case(Codex::TransLastIdxSigGroups, "-H")]
+    #[case(Codex::SealSourceTriples, "-I")]
+    #[case(Codex::SadPathSig, "-J")]
+    #[case(Codex::SadPathSigGroup, "-K")]
+    #[case(Codex::PathedMaterialQuadlets, "-L")]
+    #[case(Codex::AttachedMaterialQuadlets, "-V")]
+    #[case(Codex::BigAttachedMaterialQuadlets, "-0V")]
+    #[case(Codex::KERIProtocolStack, "--AAA")]
+    fn test_codex(#[case] variant: Codex, #[case] code: &str) {
+        assert_eq!(variant.code(), code);
+        assert_eq!(Codex::from_code(code).unwrap(), variant);
     }
 
     #[test]

--- a/src/core/indexer/mod.rs
+++ b/src/core/indexer/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     error::{err, Error, Result},
 };
 
-use super::util;
+use crate::core::util;
 
 /// Indexer is fully qualified cryptographic material primitive base class for
 /// indexed primitives. Indexed codes are a mix of indexed and variable length

--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -493,122 +493,45 @@ impl Default for Matter {
 #[cfg(test)]
 mod matter_tests {
     use crate::core::matter::{tables as matter, Matter};
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_L0.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_L1.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_L2.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_L0.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_L1.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_L2.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_Big_L0.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_Big_L1.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_Big_L2.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_Big_L0.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_Big_L1.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_Big_L2.code())]
+    fn test_matter_new(#[case] raw: &Vec<u8>, #[case] code: &str) {
+        let m = Matter::new_with_code_and_raw(code, raw).unwrap();
+        let m2 = Matter::new_with_qb64(&m.qb64().unwrap()).unwrap();
+        assert_eq!(m.code, m2.code);
+        assert_eq!(m.raw, m2.raw);
+        assert_eq!(m.size, m2.size);
+        let m2 = Matter::new_with_qb2(&m.qb2().unwrap()).unwrap();
+        assert_eq!(m.code, m2.code);
+        assert_eq!(m.raw, m2.raw);
+        assert_eq!(m.size, m2.size);
+    }
 
     #[test]
-    fn test_matter_new() {
-        let qb64 = "BGlOiUdp5sMmfotHfCWQKEzWR91C72AH0lT84c0um-Qj";
-
-        // basic
-        let mut m = Matter::new_with_qb64(qb64).unwrap();
-        assert_eq!(m.code, matter::Codex::Ed25519N.code());
-
-        // qb64
-        let mut m2 = Matter::new_with_code_and_raw(&m.code, &m.raw).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-        assert_eq!(qb64, m2.qb64().unwrap());
-
-        // qb64b
-        m2 = Matter::new_with_qb64b(&m.qb64b().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-        assert_eq!(qb64, m2.qb64().unwrap());
-
-        // qb2
-        m2 = Matter::new_with_qb2(&m.qb2().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-        assert_eq!(qb64, m2.qb64().unwrap());
-
-        // small variable b64(), ls = 0
-        let raw: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
-        m = Matter::new_with_code_and_raw(matter::Codex::StrB64_L0.code(), &raw).unwrap();
-        m2 = Matter::new_with_qb64(&m.qb64().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-        m2 = Matter::new_with_qb2(&m.qb2().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-
-        // small variable b64(), ls = 1
-        let raw: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7];
-        m = Matter::new_with_code_and_raw(matter::Codex::StrB64_L1.code(), &raw).unwrap();
-        m2 = Matter::new_with_qb64(&m.qb64().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-        m2 = Matter::new_with_qb2(&m.qb2().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-
-        // small variable b64(), ls = 2
-        let raw: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6];
-        m = Matter::new_with_code_and_raw(matter::Codex::StrB64_L2.code(), &raw).unwrap();
-        m2 = Matter::new_with_qb64(&m.qb64().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-        m2 = Matter::new_with_qb2(&m.qb2().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-
-        // small variable bytes is essentially the same as the above
-
-        // large variable b64 is essentially the same as below
-
-        // large variable bytes, ls = 0
-        let raw: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
-        m = Matter::new_with_code_and_raw(matter::Codex::Bytes_Big_L0.code(), &raw).unwrap();
-        m2 = Matter::new_with_qb64(&m.qb64().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-        m2 = Matter::new_with_qb2(&m.qb2().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-
-        // large variable bytes, ls = 1
-        let raw: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6, 7];
-        m = Matter::new_with_code_and_raw(matter::Codex::Bytes_Big_L1.code(), &raw).unwrap();
-        m2 = Matter::new_with_qb64(&m.qb64().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-        m2 = Matter::new_with_qb2(&m.qb2().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-
-        // large variable bytes, ls = 0
-        let raw: Vec<u8> = vec![0, 1, 2, 3, 4, 5, 6];
-        m = Matter::new_with_code_and_raw(matter::Codex::Bytes_Big_L2.code(), &raw).unwrap();
-        m2 = Matter::new_with_qb64(&m.qb64().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-        m2 = Matter::new_with_qb2(&m.qb2().unwrap()).unwrap();
-        assert_eq!(m.code, m2.code);
-        assert_eq!(m.raw, m2.raw);
-        assert_eq!(m.size, m2.size);
-
+    fn test_defaults_and_overrides() {
         // default
-        m = Default::default();
+        let m = Matter::default();
         assert_eq!(m.code, matter::Codex::Blake3_256.code());
 
         // partial override
-        m = Matter { size: 3, ..Default::default() };
+        let m = Matter { size: 3, ..Default::default() };
         assert_eq!(m.size, 3);
 
         // full override
-        m = Matter {
+        let m = Matter {
             raw: b"a".to_vec(),
             code: matter::Codex::X25519_Cipher_Seed.code().to_string(),
             size: 1,
@@ -617,8 +540,41 @@ mod matter_tests {
         assert_eq!(m.raw, b"a".to_vec());
         assert_eq!(m.code, matter::Codex::X25519_Cipher_Seed.code());
         assert_eq!(m.size, 1);
+    }
 
-        m = Matter::new_with_code_and_raw(matter::Codex::Bytes_L2.code(), &[0; 4095 * 3 + 1])
+    #[test]
+    fn test_exfil_infil_bexfil_binfil() {
+        let qb64 = "BGlOiUdp5sMmfotHfCWQKEzWR91C72AH0lT84c0um-Qj";
+
+        // basic
+        let m = Matter::new_with_qb64(qb64).unwrap();
+        assert_eq!(m.code, matter::Codex::Ed25519N.code());
+
+        // qb64
+        let m2 = Matter::new_with_code_and_raw(&m.code, &m.raw).unwrap();
+        assert_eq!(m.code, m2.code);
+        assert_eq!(m.raw, m2.raw);
+        assert_eq!(m.size, m2.size);
+        assert_eq!(qb64, m2.qb64().unwrap());
+
+        // qb64b
+        let m2 = Matter::new_with_qb64b(&m.qb64b().unwrap()).unwrap();
+        assert_eq!(m.code, m2.code);
+        assert_eq!(m.raw, m2.raw);
+        assert_eq!(m.size, m2.size);
+        assert_eq!(qb64, m2.qb64().unwrap());
+
+        // qb2
+        let m2 = Matter::new_with_qb2(&m.qb2().unwrap()).unwrap();
+        assert_eq!(m.code, m2.code);
+        assert_eq!(m.raw, m2.raw);
+        assert_eq!(m.size, m2.size);
+        assert_eq!(qb64, m2.qb64().unwrap());
+    }
+
+    #[test]
+    fn test_big_boundary() {
+        let m = Matter::new_with_code_and_raw(matter::Codex::Bytes_L2.code(), &[0; 4095 * 3 + 1])
             .unwrap();
         assert_eq!(m.raw().len(), 4095 * 3 + 1);
         assert_eq!(m.code(), matter::Codex::Bytes_Big_L2.code());

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -65,7 +65,7 @@ pub(crate) fn sizage(s: &str) -> Result<Sizage> {
     })
 }
 
-pub(crate) fn hardage(c: char) -> Result<i32> {
+pub(crate) fn hardage(c: char) -> Result<u32> {
     match c {
         'A'..='Z' | 'a'..='z' => Ok(1),
         '0' | '4' | '5' | '6' => Ok(2),
@@ -234,394 +234,131 @@ impl Codex {
 
 #[cfg(test)]
 mod tables_tests {
-    use super::{hardage, sizage, Codex, Sizage};
+    use crate::core::matter::tables::{hardage, sizage, Codex};
+    use rstest::rstest;
 
-    #[test]
-    fn test_sizage() {
-        let mut s: Sizage;
-
-        s = sizage(Codex::Ed25519_Seed.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Ed25519N.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::X25519.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Ed25519.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Blake3_256.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Blake2b_256.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Blake2s_256.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::SHA3_256.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::SHA2_256.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::ECDSA_256k1_Seed.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Ed448_Seed.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 76);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::X448.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 76);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Short.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 4);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Big.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 12);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::X25519_Private.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 44);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::X25519_Cipher_Seed.code()).unwrap();
-        assert_eq!(s.hs, 1);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 124);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Salt_128.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 24);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Ed25519_Sig.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 88);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::ECDSA_256k1_Sig.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 88);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Blake3_512.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 88);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Blake2b_512.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 88);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::SHA3_512.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 88);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::SHA2_512.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 88);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Long.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 8);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::ECDSA_256k1N.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 48);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::ECDSA_256k1.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 48);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Ed448N.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 80);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Ed448.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 80);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Ed448_Sig.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 56);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Tern.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 8);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::DateTime.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 36);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::X25519_Cipher_Salt.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 100);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::TBD1.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 8);
-        assert_eq!(s.ls, 1);
-
-        s = sizage(Codex::TBD2.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 0);
-        assert_eq!(s.fs, 8);
-        assert_eq!(s.ls, 2);
-
-        s = sizage(Codex::StrB64_L0.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::StrB64_L1.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 1);
-
-        s = sizage(Codex::StrB64_L2.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 2);
-
-        s = sizage(Codex::StrB64_Big_L0.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 4);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::StrB64_Big_L1.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 4);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 1);
-
-        s = sizage(Codex::StrB64_Big_L2.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 4);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 2);
-
-        s = sizage(Codex::Bytes_L0.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Bytes_L1.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 1);
-
-        s = sizage(Codex::Bytes_L2.code()).unwrap();
-        assert_eq!(s.hs, 2);
-        assert_eq!(s.ss, 2);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 2);
-
-        s = sizage(Codex::Bytes_Big_L0.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 4);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 0);
-
-        s = sizage(Codex::Bytes_Big_L1.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 4);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 1);
-
-        s = sizage(Codex::Bytes_Big_L2.code()).unwrap();
-        assert_eq!(s.hs, 4);
-        assert_eq!(s.ss, 4);
-        assert_eq!(s.fs, 0);
-        assert_eq!(s.ls, 2);
+    #[rstest]
+    #[case("A", 1, 0, 44, 0)]
+    #[case("B", 1, 0, 44, 0)]
+    #[case("C", 1, 0, 44, 0)]
+    #[case("D", 1, 0, 44, 0)]
+    #[case("E", 1, 0, 44, 0)]
+    #[case("F", 1, 0, 44, 0)]
+    #[case("G", 1, 0, 44, 0)]
+    #[case("H", 1, 0, 44, 0)]
+    #[case("I", 1, 0, 44, 0)]
+    #[case("J", 1, 0, 44, 0)]
+    #[case("K", 1, 0, 76, 0)]
+    #[case("L", 1, 0, 76, 0)]
+    #[case("M", 1, 0, 4, 0)]
+    #[case("N", 1, 0, 12, 0)]
+    #[case("O", 1, 0, 44, 0)]
+    #[case("P", 1, 0, 124, 0)]
+    #[case("0A", 2, 0, 24, 0)]
+    #[case("0B", 2, 0, 88, 0)]
+    #[case("0C", 2, 0, 88, 0)]
+    #[case("0D", 2, 0, 88, 0)]
+    #[case("0E", 2, 0, 88, 0)]
+    #[case("0F", 2, 0, 88, 0)]
+    #[case("0G", 2, 0, 88, 0)]
+    #[case("0H", 2, 0, 8, 0)]
+    #[case("1AAA", 4, 0, 48, 0)]
+    #[case("1AAB", 4, 0, 48, 0)]
+    #[case("1AAC", 4, 0, 80, 0)]
+    #[case("1AAD", 4, 0, 80, 0)]
+    #[case("1AAE", 4, 0, 56, 0)]
+    #[case("1AAF", 4, 0, 8, 0)]
+    #[case("1AAG", 4, 0, 36, 0)]
+    #[case("1AAH", 4, 0, 100, 0)]
+    #[case("2AAA", 4, 0, 8, 1)]
+    #[case("3AAA", 4, 0, 8, 2)]
+    #[case("4A", 2, 2, 0, 0)]
+    #[case("5A", 2, 2, 0, 1)]
+    #[case("6A", 2, 2, 0, 2)]
+    #[case("7AAA", 4, 4, 0, 0)]
+    #[case("8AAA", 4, 4, 0, 1)]
+    #[case("9AAA", 4, 4, 0, 2)]
+    #[case("4B", 2, 2, 0, 0)]
+    #[case("5B", 2, 2, 0, 1)]
+    #[case("6B", 2, 2, 0, 2)]
+    #[case("7AAB", 4, 4, 0, 0)]
+    #[case("8AAB", 4, 4, 0, 1)]
+    #[case("9AAB", 4, 4, 0, 2)]
+    fn test_sizage(
+        #[case] code: &str,
+        #[case] hs: u32,
+        #[case] ss: u32,
+        #[case] fs: u32,
+        #[case] ls: u32,
+    ) {
+        let s = sizage(code).unwrap();
+        assert_eq!(s.hs, hs);
+        assert_eq!(s.ss, ss);
+        assert_eq!(s.fs, fs);
+        assert_eq!(s.ls, ls);
     }
 
-    #[test]
-    fn test_hardage() {
-        assert_eq!(hardage('A').unwrap(), 1);
-        assert_eq!(hardage('G').unwrap(), 1);
-        assert_eq!(hardage('b').unwrap(), 1);
-        assert_eq!(hardage('z').unwrap(), 1);
-        assert_eq!(hardage('1').unwrap(), 4);
-        assert_eq!(hardage('0').unwrap(), 2);
+    #[rstest]
+    #[case('A', 1)]
+    #[case('G', 1)]
+    #[case('b', 1)]
+    #[case('z', 1)]
+    #[case('1', 4)]
+    #[case('0', 2)]
+    fn test_hardage(#[case] code: char, #[case] hdg: u32) {
+        assert_eq!(hardage(code).unwrap(), hdg);
     }
 
-    #[test]
-    fn test_codes() {
-        assert_eq!(Codex::Ed25519_Seed.code(), "A");
-        assert_eq!(Codex::Ed25519N.code(), "B");
-        assert_eq!(Codex::X25519.code(), "C");
-        assert_eq!(Codex::Ed25519.code(), "D");
-        assert_eq!(Codex::Blake3_256.code(), "E");
-        assert_eq!(Codex::Blake2b_256.code(), "F");
-        assert_eq!(Codex::Blake2s_256.code(), "G");
-        assert_eq!(Codex::SHA3_256.code(), "H");
-        assert_eq!(Codex::SHA2_256.code(), "I");
-        assert_eq!(Codex::ECDSA_256k1_Seed.code(), "J");
-        assert_eq!(Codex::Ed448_Seed.code(), "K");
-        assert_eq!(Codex::X448.code(), "L");
-        assert_eq!(Codex::Short.code(), "M");
-        assert_eq!(Codex::Big.code(), "N");
-        assert_eq!(Codex::X25519_Private.code(), "O");
-        assert_eq!(Codex::X25519_Cipher_Seed.code(), "P");
-        assert_eq!(Codex::Salt_128.code(), "0A");
-        assert_eq!(Codex::Ed25519_Sig.code(), "0B");
-        assert_eq!(Codex::ECDSA_256k1_Sig.code(), "0C");
-        assert_eq!(Codex::Blake3_512.code(), "0D");
-        assert_eq!(Codex::Blake2b_512.code(), "0E");
-        assert_eq!(Codex::SHA3_512.code(), "0F");
-        assert_eq!(Codex::SHA2_512.code(), "0G");
-        assert_eq!(Codex::Long.code(), "0H");
-        assert_eq!(Codex::ECDSA_256k1N.code(), "1AAA");
-        assert_eq!(Codex::ECDSA_256k1.code(), "1AAB");
-        assert_eq!(Codex::Ed448N.code(), "1AAC");
-        assert_eq!(Codex::Ed448.code(), "1AAD");
-        assert_eq!(Codex::Ed448_Sig.code(), "1AAE");
-        assert_eq!(Codex::Tern.code(), "1AAF");
-        assert_eq!(Codex::DateTime.code(), "1AAG");
-        assert_eq!(Codex::X25519_Cipher_Salt.code(), "1AAH");
-        assert_eq!(Codex::TBD1.code(), "2AAA");
-        assert_eq!(Codex::TBD2.code(), "3AAA");
-        assert_eq!(Codex::StrB64_L0.code(), "4A");
-        assert_eq!(Codex::StrB64_L1.code(), "5A");
-        assert_eq!(Codex::StrB64_L2.code(), "6A");
-        assert_eq!(Codex::StrB64_Big_L0.code(), "7AAA");
-        assert_eq!(Codex::StrB64_Big_L1.code(), "8AAA");
-        assert_eq!(Codex::StrB64_Big_L2.code(), "9AAA");
-        assert_eq!(Codex::Bytes_L0.code(), "4B");
-        assert_eq!(Codex::Bytes_L1.code(), "5B");
-        assert_eq!(Codex::Bytes_L2.code(), "6B");
-        assert_eq!(Codex::Bytes_Big_L0.code(), "7AAB");
-        assert_eq!(Codex::Bytes_Big_L1.code(), "8AAB");
-        assert_eq!(Codex::Bytes_Big_L2.code(), "9AAB");
-
-        assert_eq!(Codex::from_code("A").unwrap(), Codex::Ed25519_Seed);
-        assert_eq!(Codex::from_code("B").unwrap(), Codex::Ed25519N);
-        assert_eq!(Codex::from_code("C").unwrap(), Codex::X25519);
-        assert_eq!(Codex::from_code("D").unwrap(), Codex::Ed25519);
-        assert_eq!(Codex::from_code("E").unwrap(), Codex::Blake3_256);
-        assert_eq!(Codex::from_code("F").unwrap(), Codex::Blake2b_256);
-        assert_eq!(Codex::from_code("G").unwrap(), Codex::Blake2s_256);
-        assert_eq!(Codex::from_code("H").unwrap(), Codex::SHA3_256);
-        assert_eq!(Codex::from_code("I").unwrap(), Codex::SHA2_256);
-        assert_eq!(Codex::from_code("J").unwrap(), Codex::ECDSA_256k1_Seed);
-        assert_eq!(Codex::from_code("K").unwrap(), Codex::Ed448_Seed);
-        assert_eq!(Codex::from_code("L").unwrap(), Codex::X448);
-        assert_eq!(Codex::from_code("M").unwrap(), Codex::Short);
-        assert_eq!(Codex::from_code("N").unwrap(), Codex::Big);
-        assert_eq!(Codex::from_code("O").unwrap(), Codex::X25519_Private);
-        assert_eq!(Codex::from_code("P").unwrap(), Codex::X25519_Cipher_Seed);
-        assert_eq!(Codex::from_code("0A").unwrap(), Codex::Salt_128);
-        assert_eq!(Codex::from_code("0B").unwrap(), Codex::Ed25519_Sig);
-        assert_eq!(Codex::from_code("0C").unwrap(), Codex::ECDSA_256k1_Sig);
-        assert_eq!(Codex::from_code("0D").unwrap(), Codex::Blake3_512);
-        assert_eq!(Codex::from_code("0E").unwrap(), Codex::Blake2b_512);
-        assert_eq!(Codex::from_code("0F").unwrap(), Codex::SHA3_512);
-        assert_eq!(Codex::from_code("0G").unwrap(), Codex::SHA2_512);
-        assert_eq!(Codex::from_code("0H").unwrap(), Codex::Long);
-        assert_eq!(Codex::from_code("1AAA").unwrap(), Codex::ECDSA_256k1N);
-        assert_eq!(Codex::from_code("1AAB").unwrap(), Codex::ECDSA_256k1);
-        assert_eq!(Codex::from_code("1AAC").unwrap(), Codex::Ed448N);
-        assert_eq!(Codex::from_code("1AAD").unwrap(), Codex::Ed448);
-        assert_eq!(Codex::from_code("1AAE").unwrap(), Codex::Ed448_Sig);
-        assert_eq!(Codex::from_code("1AAF").unwrap(), Codex::Tern);
-        assert_eq!(Codex::from_code("1AAG").unwrap(), Codex::DateTime);
-        assert_eq!(Codex::from_code("1AAH").unwrap(), Codex::X25519_Cipher_Salt);
-        assert_eq!(Codex::from_code("2AAA").unwrap(), Codex::TBD1);
-        assert_eq!(Codex::from_code("3AAA").unwrap(), Codex::TBD2);
-        assert_eq!(Codex::from_code("4A").unwrap(), Codex::StrB64_L0);
-        assert_eq!(Codex::from_code("5A").unwrap(), Codex::StrB64_L1);
-        assert_eq!(Codex::from_code("6A").unwrap(), Codex::StrB64_L2);
-        assert_eq!(Codex::from_code("7AAA").unwrap(), Codex::StrB64_Big_L0);
-        assert_eq!(Codex::from_code("8AAA").unwrap(), Codex::StrB64_Big_L1);
-        assert_eq!(Codex::from_code("9AAA").unwrap(), Codex::StrB64_Big_L2);
-        assert_eq!(Codex::from_code("4B").unwrap(), Codex::Bytes_L0);
-        assert_eq!(Codex::from_code("5B").unwrap(), Codex::Bytes_L1);
-        assert_eq!(Codex::from_code("6B").unwrap(), Codex::Bytes_L2);
-        assert_eq!(Codex::from_code("7AAB").unwrap(), Codex::Bytes_Big_L0);
-        assert_eq!(Codex::from_code("8AAB").unwrap(), Codex::Bytes_Big_L1);
-        assert_eq!(Codex::from_code("9AAB").unwrap(), Codex::Bytes_Big_L2);
+    #[rstest]
+    #[case(Codex::Ed25519_Seed, "A")]
+    #[case(Codex::Ed25519N, "B")]
+    #[case(Codex::X25519, "C")]
+    #[case(Codex::Ed25519, "D")]
+    #[case(Codex::Blake3_256, "E")]
+    #[case(Codex::Blake2b_256, "F")]
+    #[case(Codex::Blake2s_256, "G")]
+    #[case(Codex::SHA3_256, "H")]
+    #[case(Codex::SHA2_256, "I")]
+    #[case(Codex::ECDSA_256k1_Seed, "J")]
+    #[case(Codex::Ed448_Seed, "K")]
+    #[case(Codex::X448, "L")]
+    #[case(Codex::Short, "M")]
+    #[case(Codex::Big, "N")]
+    #[case(Codex::X25519_Private, "O")]
+    #[case(Codex::X25519_Cipher_Seed, "P")]
+    #[case(Codex::Salt_128, "0A")]
+    #[case(Codex::Ed25519_Sig, "0B")]
+    #[case(Codex::ECDSA_256k1_Sig, "0C")]
+    #[case(Codex::Blake3_512, "0D")]
+    #[case(Codex::Blake2b_512, "0E")]
+    #[case(Codex::SHA3_512, "0F")]
+    #[case(Codex::SHA2_512, "0G")]
+    #[case(Codex::Long, "0H")]
+    #[case(Codex::ECDSA_256k1N, "1AAA")]
+    #[case(Codex::ECDSA_256k1, "1AAB")]
+    #[case(Codex::Ed448N, "1AAC")]
+    #[case(Codex::Ed448, "1AAD")]
+    #[case(Codex::Ed448_Sig, "1AAE")]
+    #[case(Codex::Tern, "1AAF")]
+    #[case(Codex::DateTime, "1AAG")]
+    #[case(Codex::X25519_Cipher_Salt, "1AAH")]
+    #[case(Codex::TBD1, "2AAA")]
+    #[case(Codex::TBD2, "3AAA")]
+    #[case(Codex::StrB64_L0, "4A")]
+    #[case(Codex::StrB64_L1, "5A")]
+    #[case(Codex::StrB64_L2, "6A")]
+    #[case(Codex::StrB64_Big_L0, "7AAA")]
+    #[case(Codex::StrB64_Big_L1, "8AAA")]
+    #[case(Codex::StrB64_Big_L2, "9AAA")]
+    #[case(Codex::Bytes_L0, "4B")]
+    #[case(Codex::Bytes_L1, "5B")]
+    #[case(Codex::Bytes_L2, "6B")]
+    #[case(Codex::Bytes_Big_L0, "7AAB")]
+    #[case(Codex::Bytes_Big_L1, "8AAB")]
+    #[case(Codex::Bytes_Big_L2, "9AAB")]
+    fn test_codes(#[case] variant: Codex, #[case] code: &str) {
+        assert_eq!(variant.code(), code);
+        assert_eq!(Codex::from_code(code).unwrap(), variant);
     }
 
     #[test]

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -262,36 +262,40 @@ pub fn nab_sextets(binary: &[u8], count: usize) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod util_tests {
     use crate::core::util;
+    use rstest::rstest;
 
-    #[test]
-    fn test_u32_to_b64() {
-        assert_eq!(util::u32_to_b64(0, 1).unwrap(), "A");
-        assert_eq!(util::u32_to_b64(1, 1).unwrap(), "B");
-        assert_eq!(util::u32_to_b64(0, 2).unwrap(), "AA");
-        assert_eq!(util::u32_to_b64(1, 2).unwrap(), "AB");
-        assert_eq!(util::u32_to_b64(4095, 2).unwrap(), "__");
-        assert_eq!(util::u32_to_b64(16777215, 4).unwrap(), "____");
+    #[rstest]
+    #[case(0, 1, "A")]
+    #[case(1, 1, "B")]
+    #[case(0, 2, "AA")]
+    #[case(1, 2, "AB")]
+    #[case(4095, 2, "__")]
+    #[case(16777215, 4, "____")]
+    fn test_u32_to_b64(#[case] n: u32, #[case] length: usize, #[case] b64: &str) {
+        assert_eq!(util::u32_to_b64(n, length).unwrap(), b64);
     }
 
-    #[test]
-    fn test_b64_to_u32() {
-        assert_eq!(util::b64_to_u32("A").unwrap(), 0);
-        assert_eq!(util::b64_to_u32("B").unwrap(), 1);
-        assert_eq!(util::b64_to_u32("AA").unwrap(), 0);
-        assert_eq!(util::b64_to_u32("AB").unwrap(), 1);
-        assert_eq!(util::b64_to_u32("__").unwrap(), 4095);
-        assert_eq!(util::b64_to_u32("____").unwrap(), 16777215);
+    #[rstest]
+    #[case(0, "A")]
+    #[case(1, "B")]
+    #[case(0, "AA")]
+    #[case(1, "AB")]
+    #[case(4095, "__")]
+    #[case(16777215, "____")]
+    fn test_b64_to_u32(#[case] n: u32, #[case] b64: &str) {
+        assert_eq!(util::b64_to_u32(b64).unwrap(), n);
     }
 
-    #[test]
-    fn test_b64_to_u64() {
-        assert_eq!(util::b64_to_u64("A").unwrap(), 0);
-        assert_eq!(util::b64_to_u64("B").unwrap(), 1);
-        assert_eq!(util::b64_to_u64("AA").unwrap(), 0);
-        assert_eq!(util::b64_to_u64("AB").unwrap(), 1);
-        assert_eq!(util::b64_to_u64("__").unwrap(), 4095);
-        assert_eq!(util::b64_to_u64("____").unwrap(), 16777215);
-        assert_eq!(util::b64_to_u64("________").unwrap(), 281474976710655);
+    #[rstest]
+    #[case(0, "A")]
+    #[case(1, "B")]
+    #[case(0, "AA")]
+    #[case(1, "AB")]
+    #[case(4095, "__")]
+    #[case(16777215, "____")]
+    #[case(281474976710655, "________")]
+    fn test_b64_to_u64(#[case] n: u64, #[case] b64: &str) {
+        assert_eq!(util::b64_to_u64(b64).unwrap(), n);
     }
 
     #[test]
@@ -313,41 +317,44 @@ mod util_tests {
         }
     }
 
-    #[test]
-    fn test_code_b2_to_b64() {
-        assert_eq!(util::code_b2_to_b64(&vec![0], 1).unwrap(), "A");
-        assert_eq!(util::code_b2_to_b64(&vec![0, 0, 0, 0, 0, 0], 8).unwrap(), "AAAAAAAA");
-        assert_eq!(util::code_b2_to_b64(&vec![8, 68, 145], 4).unwrap(), "CESR");
-        assert_eq!(util::code_b2_to_b64(&vec![40, 68, 72, 0, 32, 194], 8).unwrap(), "KERIACDC");
-        assert_eq!(util::code_b2_to_b64(&vec![252], 1).unwrap(), "_");
-        assert_eq!(
-            util::code_b2_to_b64(&vec![255, 255, 255, 255, 255, 255], 8).unwrap(),
-            "________"
-        );
-        assert_eq!(util::code_b2_to_b64(&vec![244, 0, 1], 4).unwrap(), "9AAB");
+    #[rstest]
+    #[case(&vec![0], 1, "A")]
+    #[case(&vec![0, 0, 0, 0, 0, 0], 8, "AAAAAAAA")]
+    #[case(&vec![8, 68, 145], 4, "CESR")]
+    #[case(&vec![40, 68, 72, 0, 32, 194], 8, "KERIACDC")]
+    #[case(&vec![252], 1, "_")]
+    #[case(&vec![255, 255, 255, 255, 255, 255], 8, "________")]
+    #[case(&vec![244, 0, 1], 4, "9AAB")]
+    fn test_code_b2_to_b64(#[case] b2: &Vec<u8>, #[case] length: usize, #[case] b64: &str) {
+        assert_eq!(util::code_b2_to_b64(b2, length).unwrap(), b64);
     }
 
-    #[test]
-    fn test_code_b64_to_b2() {
-        assert_eq!(util::code_b64_to_b2("A").unwrap(), vec![0]);
-        assert_eq!(util::code_b64_to_b2("AAAAAAAA").unwrap(), vec![0, 0, 0, 0, 0, 0]);
-        assert_eq!(util::code_b64_to_b2("CESR").unwrap(), vec![8, 68, 145]);
-        assert_eq!(util::code_b64_to_b2("KERIACDC").unwrap(), vec![40, 68, 72, 0, 32, 194]);
-        assert_eq!(util::code_b64_to_b2("_").unwrap(), vec![252]);
-        assert_eq!(util::code_b64_to_b2("________").unwrap(), vec![255, 255, 255, 255, 255, 255]);
-        assert_eq!(util::code_b64_to_b2("9AAB").unwrap(), vec![244, 0, 1]);
+    #[rstest]
+    #[case(vec![0], "A")]
+    #[case(vec![0, 0, 0, 0, 0, 0], "AAAAAAAA")]
+    #[case(vec![8, 68, 145], "CESR")]
+    #[case(vec![40, 68, 72, 0, 32, 194], "KERIACDC")]
+    #[case(vec![252], "_")]
+    #[case(vec![255, 255, 255, 255, 255, 255], "________")]
+    #[case(vec![244, 0, 1], "9AAB")]
+    fn test_code_b64_to_b2(#[case] b2: Vec<u8>, #[case] b64: &str) {
+        assert_eq!(util::code_b64_to_b2(b64).unwrap(), b2);
     }
 
-    #[test]
-    fn test_nab_sextets() {
-        assert_eq!(util::nab_sextets(&[255, 255, 255], 4).unwrap(), vec![63, 63, 63, 63]);
+    #[rstest]
+    #[case(&[255, 255, 255], 4, vec![63, 63, 63, 63])]
+    #[case(&[255, 255, 255], 4, vec![63, 63, 63, 63])]
+    #[case(&[255, 255, 255, 0, 0, 0], 8, vec![63, 63, 63, 63, 0, 0, 0, 0])]
+    #[case(&[255], 1, vec![63])]
+    #[case(&[127, 127], 2, vec![31, 55])]
+    fn test_nab_sextets(#[case] binary: &[u8], #[case] length: usize, #[case] result: Vec<u8>) {
+        assert_eq!(util::nab_sextets(binary, length).unwrap(), result);
         assert_eq!(
             util::nab_sextets(&[255, 255, 255, 0, 0, 0], 8).unwrap(),
             vec![63, 63, 63, 63, 0, 0, 0, 0]
         );
         assert_eq!(util::nab_sextets(&[255], 1).unwrap(), vec![63]);
         assert_eq!(util::nab_sextets(&[127, 127], 2).unwrap(), vec![31, 55]);
-        assert!(util::nab_sextets(&[127, 127], 3).is_err());
     }
 
     #[test]
@@ -356,5 +363,6 @@ mod util_tests {
         assert!(util::b64_index_to_char(64).is_err());
         assert!(util::code_b2_to_b64(&[0], 2).is_err());
         assert!(util::code_b2_to_b64(&[0; 32], 9).is_err());
+        assert!(util::nab_sextets(&[127, 127], 3).is_err());
     }
 }

--- a/src/core/verfer.rs
+++ b/src/core/verfer.rs
@@ -115,7 +115,8 @@ impl Verfer for Matter {
 
 #[cfg(test)]
 mod test_verfer {
-    use super::{matter, Matter, Verfer};
+    use crate::core::matter::{tables as matter, Matter};
+    use crate::core::verfer::Verfer;
     use hex_literal::hex;
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,7 +75,7 @@ pub(crate) use err;
 
 #[cfg(test)]
 mod test {
-    use super::{Error, Result};
+    use crate::error::{Error, Result};
 
     fn explode() -> Result<()> {
         return err!(Error::Prepad());


### PR DESCRIPTION
## Rationale

I started this after the primary contributers discussed in #70 - and it really cleans things up. In my opinion, the modified tests are far easier to scan and reason about.

## Changes

- creates parameterized inputs for tests using `rstest`, where appropriate
- standardizes on using the full path for test imports, which would allow us to more easily copy/paste them somewhere else if need be

## Notes

- I didn't look at `Indexer` as @m00sey is working on that and didn't want to create conflicts. If this gets merged I'll create yet another issue to track the `Indexer` `rstest` status.
- I took a look at the diff and this one came out a bit confusing. Play with the presentation settings for an easier review.