### PR TITLE
refactor `Matter` into trait

### DIFF
--- a/src/core/cigar.rs
+++ b/src/core/cigar.rs
@@ -1,13 +1,26 @@
 use lazy_static::lazy_static;
 
 use crate::core::matter::{tables as matter, Matter};
+use crate::core::verfer::Verfer;
 use crate::error::{err, Error, Result};
-use crate::Verfer;
 
 #[derive(Debug, Clone)]
 pub struct Cigar {
-    pub(crate) matter: Matter,
-    pub(crate) verfer: Verfer,
+    raw: Vec<u8>,
+    code: String,
+    size: u32,
+    verfer: Verfer,
+}
+
+impl Default for Cigar {
+    fn default() -> Self {
+        Cigar {
+            raw: vec![],
+            code: matter::Codex::Ed25519_Sig.code().to_string(),
+            size: 0,
+            verfer: Verfer::default(),
+        }
+    }
 }
 
 fn validate_code(code: &str) -> Result<()> {
@@ -29,49 +42,30 @@ fn validate_code(code: &str) -> Result<()> {
 impl Cigar {
     pub fn new_with_code_and_raw(verfer: &Verfer, code: &str, raw: &[u8]) -> Result<Cigar> {
         validate_code(code)?;
-        Ok(Cigar { matter: Matter::new_with_code_and_raw(code, raw)?, verfer: verfer.clone() })
+        let mut cigar: Cigar = Matter::new_with_code_and_raw(code, raw)?;
+        cigar.set_verfer(verfer);
+        Ok(cigar)
     }
 
     pub fn new_with_qb64(verfer: &Verfer, qb64: &str) -> Result<Cigar> {
-        let cigar = Cigar { matter: Matter::new_with_qb64(qb64)?, verfer: verfer.clone() };
-        validate_code(&cigar.matter.code)?;
+        let mut cigar: Cigar = Matter::new_with_qb64(qb64)?;
+        cigar.set_verfer(verfer);
+        validate_code(&cigar.code())?;
         Ok(cigar)
     }
 
     pub fn new_with_qb64b(verfer: &Verfer, qb64b: &[u8]) -> Result<Cigar> {
-        let cigar = Cigar { matter: Matter::new_with_qb64b(qb64b)?, verfer: verfer.clone() };
-        validate_code(&cigar.matter.code)?;
+        let mut cigar: Cigar = Matter::new_with_qb64b(qb64b)?;
+        cigar.set_verfer(verfer);
+        validate_code(&cigar.code())?;
         Ok(cigar)
     }
 
     pub fn new_with_qb2(verfer: &Verfer, qb2: &[u8]) -> Result<Cigar> {
-        let cigar = Cigar { matter: Matter::new_with_qb2(qb2)?, verfer: verfer.clone() };
-        validate_code(&cigar.matter.code)?;
+        let mut cigar: Cigar = Matter::new_with_qb2(qb2)?;
+        cigar.set_verfer(verfer);
+        validate_code(&cigar.code())?;
         Ok(cigar)
-    }
-
-    pub fn code(&self) -> String {
-        self.matter.code()
-    }
-
-    pub fn size(&self) -> u32 {
-        self.matter.size()
-    }
-
-    pub fn raw(&self) -> Vec<u8> {
-        self.matter.raw()
-    }
-
-    pub fn qb64(&self) -> Result<String> {
-        self.matter.qb64()
-    }
-
-    pub fn qb64b(&self) -> Result<Vec<u8>> {
-        self.matter.qb64b()
-    }
-
-    pub fn qb2(&self) -> Result<Vec<u8>> {
-        self.matter.qb2()
     }
 
     pub fn verfer(&self) -> Verfer {
@@ -79,14 +73,40 @@ impl Cigar {
     }
 
     pub fn set_verfer(&mut self, verfer: &Verfer) {
-        self.verfer = verfer.clone();
+        self.verfer = verfer.clone()
+    }
+}
+
+impl Matter for Cigar {
+    fn code(&self) -> String {
+        self.code.clone()
+    }
+
+    fn raw(&self) -> Vec<u8> {
+        self.raw.clone()
+    }
+
+    fn size(&self) -> u32 {
+        self.size
+    }
+
+    fn set_code(&mut self, code: &str) {
+        self.code = code.to_string();
+    }
+
+    fn set_raw(&mut self, raw: &[u8]) {
+        self.raw = raw.to_vec();
+    }
+
+    fn set_size(&mut self, size: u32) {
+        self.size = size;
     }
 }
 
 #[cfg(test)]
 mod test_cigar {
     use crate::core::cigar::Cigar;
-    use crate::core::matter::tables as matter;
+    use crate::core::matter::{tables as matter, Matter};
     use crate::core::verfer::Verfer;
 
     #[test]
@@ -174,23 +194,6 @@ mod test_cigar {
         assert_ne!(cigar.verfer().raw(), vraw2);
         cigar.set_verfer(&verfer2);
         assert_eq!(cigar.verfer().raw(), vraw2);
-    }
-
-    #[test]
-    fn test_overridden_methods() {
-        let qsig64 = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ";
-        let vcode = matter::Codex::Ed25519.code();
-        let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
-        let verfer = Verfer::new_with_code_and_raw(vcode, vraw).unwrap();
-
-        let cigar = Cigar::new_with_qb64(&verfer, qsig64).unwrap();
-
-        assert_eq!(cigar.code(), cigar.matter.code());
-        assert_eq!(cigar.raw(), cigar.matter.raw());
-        assert_eq!(cigar.size(), cigar.matter.size());
-        assert_eq!(cigar.qb64().unwrap(), cigar.matter.qb64().unwrap());
-        assert_eq!(cigar.qb64b().unwrap(), cigar.matter.qb64b().unwrap());
-        assert_eq!(cigar.qb2().unwrap(), cigar.matter.qb2().unwrap());
     }
 
     #[test]

--- a/src/lib_python.rs
+++ b/src/lib_python.rs
@@ -7,10 +7,10 @@ mod core;
 mod error;
 mod python;
 
-use crate::core::matter::Matter; 
+use crate::core::diger::Diger; 
 
 #[pymodule]
 fn cesride(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<Matter>()?;
+    m.add_class::<Diger>()?;
     Ok(())
 }

--- a/src/python/diger.rs
+++ b/src/python/diger.rs
@@ -3,27 +3,27 @@ use pyo3::{
     exceptions::{PyException, PyValueError},
 };
 
+use crate::core::diger::Diger;
 use crate::core::matter::Matter;
 
 #[pymethods]
-impl Matter {
+impl Diger {
     #[new]
     fn py_new(
         code: Option<&str>,
         raw: Option<&[u8]>,
-        raw_size: Option<usize>,
         qb64: Option<&str>,
         qb64b: Option<&[u8]>,
         qb2: Option<&[u8]>,
     ) -> PyResult<Self> {
         let result = if let Some(code) = code {
-            let (raw, raw_size) = if raw.is_none() || raw_size.is_none() {
-                return Err(PyValueError::new_err("code present, raw and raw_size missing"));
+            let raw = if raw.is_none() {
+                return Err(PyValueError::new_err("code present, raw missing"));
             } else {
-                (raw.unwrap(), raw_size.unwrap())
+                raw.unwrap()
             };
 
-            Self::new_with_code_and_raw(code, raw, raw_size)
+            Self::new_with_code_and_raw(code, raw)
         } else if let Some(qb64) = qb64 {
             Self::new_with_qb64(qb64)
         } else if let Some(qb64b) = qb64b {

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1,1 +1,1 @@
-mod matter;
+mod diger;


### PR DESCRIPTION
## Rationale

We want to reverse trait modelling to turn `Matter` into an abstract 'class'. Read #72 and #73 for more details.

## Changes

These:
```rust
<Matter as Verfer>::new_with_code_and_raw()
```

become

```rust
Verfer::new_with_code_and_raw()
```

Aso had to wrap up setters and getters for these concrete 'classes' so `Matter` code can interact with them.

Though we will probably move to `uniffi` soon, I also modified the python bindings for `Matter` to  now expose `Diger`. It would be simple to add the other 'classes', but `uniffi` was very nice to me when I tried it out on another complex library.

## Testing

`make clean preflight python python-shell`

