### PR TITLE
complete indexer

### DIFF
--- a/src/core/counter/tables.rs
+++ b/src/core/counter/tables.rs
@@ -41,21 +41,10 @@ pub(crate) fn hardage(s: &str) -> Result<u32> {
 
 pub(crate) fn bardage(b: &[u8]) -> Result<u32> {
     match b {
-        [62, 0]
-        | [62, 1]
-        | [62, 2]
-        | [62, 3]
-        | [62, 4]
-        | [62, 5]
-        | [62, 6]
-        | [62, 7]
-        | [62, 8]
-        | [62, 9]
-        | [62, 10]
-        | [62, 11]
-        | [62, 21] => Ok(2),
-        [62, 52] => Ok(3),
-        [62, 62] => Ok(5),
+        b">\x00" | b">\x01" | b">\x02" | b">\x03" | b">\x04" | b">\x05" | b">\x06" | b">\x07"
+        | b">\x08" | b">\x09" | b">\x0a" | b">\x0b" | b">\x15" => Ok(2),
+        b">4" => Ok(3),
+        b">>" => Ok(5),
         _ => err!(Error::UnknownBardage(format!("{b:?}"))),
     }
 }
@@ -129,12 +118,42 @@ mod tables_tests {
 
     #[rstest]
     #[case("-A", 2)]
+    #[case("-B", 2)]
+    #[case("-C", 2)]
+    #[case("-D", 2)]
+    #[case("-E", 2)]
+    #[case("-F", 2)]
     #[case("-G", 2)]
+    #[case("-H", 2)]
+    #[case("-I", 2)]
+    #[case("-J", 2)]
+    #[case("-K", 2)]
+    #[case("-L", 2)]
     #[case("-V", 2)]
     #[case("-0", 3)]
     #[case("--", 5)]
     fn test_hardage(#[case] code: &str, #[case] hdg: u32) {
         assert_eq!(hardage(code).unwrap(), hdg);
+    }
+
+    #[rstest]
+    #[case(&[62, 0], 2)]
+    #[case(&[62, 1], 2)]
+    #[case(&[62, 2], 2)]
+    #[case(&[62, 3], 2)]
+    #[case(&[62, 4], 2)]
+    #[case(&[62, 5], 2)]
+    #[case(&[62, 6], 2)]
+    #[case(&[62, 7], 2)]
+    #[case(&[62, 8], 2)]
+    #[case(&[62, 9], 2)]
+    #[case(&[62, 10], 2)]
+    #[case(&[62, 11], 2)]
+    #[case(&[62, 21], 2)]
+    #[case(&[62, 52], 3)]
+    #[case(&[62, 62], 5)]
+    fn test_bardage(#[case] bard: &[u8], #[case] bdg: u32) {
+        assert_eq!(bardage(bard).unwrap(), bdg);
     }
 
     #[rstest]

--- a/src/core/dater.rs
+++ b/src/core/dater.rs
@@ -3,8 +3,6 @@ use lazy_static::lazy_static;
 use crate::core::matter::{tables as matter, Matter};
 use crate::error::{err, Error, Result};
 
-type Blake2b256 = blake2::Blake2b<blake2::digest::consts::U32>;
-
 pub struct Dater {
     raw: Vec<u8>,
     code: String,

--- a/src/core/indexer/tables.rs
+++ b/src/core/indexer/tables.rs
@@ -288,10 +288,20 @@ pub(crate) fn hardage(c: char) -> Result<u32> {
     }
 }
 
+pub(crate) fn bardage(b: u8) -> Result<u32> {
+    match b {
+        b'\x00'..=b'\x33' => Ok(1),
+        b'\x34'..=b'\x38' => Ok(2),
+        b'\x3e' => Err(Box::new(Error::UnexpectedCode("count code start".to_owned()))),
+        b'\x3f' => Err(Box::new(Error::UnexpectedCode("op code start".to_owned()))),
+        _ => Err(Box::new(Error::UnknownBardage(b.to_string()))),
+    }
+}
+
 #[cfg(test)]
 mod index_tables_tests {
     use crate::core::indexer::tables::{
-        hardage, sizage, BothSigCodex, Codex, CurrentSigCodex, SigCodex,
+        bardage, hardage, sizage, BothSigCodex, Codex, CurrentSigCodex, SigCodex,
     };
     use rstest::rstest;
 
@@ -422,6 +432,83 @@ mod index_tables_tests {
     #[test]
     fn test_unknown_hardage() {
         assert!(hardage('8').is_err());
+    }
+
+    #[rstest]
+    #[case(0x00, 1)]
+    #[case(0x01, 1)]
+    #[case(0x02, 1)]
+    #[case(0x03, 1)]
+    #[case(0x04, 1)]
+    #[case(0x05, 1)]
+    #[case(0x06, 1)]
+    #[case(0x07, 1)]
+    #[case(0x08, 1)]
+    #[case(0x09, 1)]
+    #[case(0x0a, 1)]
+    #[case(0x0b, 1)]
+    #[case(0x0c, 1)]
+    #[case(0x0d, 1)]
+    #[case(0x0e, 1)]
+    #[case(0x0f, 1)]
+    #[case(0x10, 1)]
+    #[case(0x11, 1)]
+    #[case(0x12, 1)]
+    #[case(0x13, 1)]
+    #[case(0x14, 1)]
+    #[case(0x15, 1)]
+    #[case(0x16, 1)]
+    #[case(0x17, 1)]
+    #[case(0x18, 1)]
+    #[case(0x19, 1)]
+    #[case(0x1a, 1)]
+    #[case(0x1b, 1)]
+    #[case(0x1c, 1)]
+    #[case(0x1d, 1)]
+    #[case(0x1e, 1)]
+    #[case(0x1f, 1)]
+    #[case(0x20, 1)]
+    #[case(0x21, 1)]
+    #[case(0x22, 1)]
+    #[case(0x23, 1)]
+    #[case(0x24, 1)]
+    #[case(0x25, 1)]
+    #[case(0x26, 1)]
+    #[case(0x27, 1)]
+    #[case(0x28, 1)]
+    #[case(0x29, 1)]
+    #[case(0x2a, 1)]
+    #[case(0x2b, 1)]
+    #[case(0x2c, 1)]
+    #[case(0x2d, 1)]
+    #[case(0x2e, 1)]
+    #[case(0x2f, 1)]
+    #[case(0x30, 1)]
+    #[case(0x31, 1)]
+    #[case(0x32, 1)]
+    #[case(0x33, 1)]
+    #[case(0x34, 2)]
+    #[case(0x35, 2)]
+    #[case(0x36, 2)]
+    #[case(0x37, 2)]
+    #[case(0x38, 2)]
+    fn test_bardage(#[case] code: u8, #[case] bdg: u32) {
+        assert_eq!(bardage(code).unwrap(), bdg);
+    }
+
+    #[test]
+    fn test_unexpected_bardage_count_code() {
+        assert!(bardage(0x3e).is_err());
+    }
+
+    #[test]
+    fn test_unexpected_bardage_op_code() {
+        assert!(bardage(0x3f).is_err());
+    }
+
+    #[test]
+    fn test_unknown_bardage() {
+        assert!(bardage(0x39).is_err());
     }
 
     #[test]

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -76,6 +76,17 @@ pub(crate) fn hardage(c: char) -> Result<u32> {
     }
 }
 
+pub(crate) fn bardage(b: u8) -> Result<u32> {
+    match b {
+        b'\x00'..=b'\x33' => Ok(1),
+        b'\x34' | b'\x38'..=b'\x3a' => Ok(2),
+        b'\x35'..=b'\x37' | b'\x3b'..=b'\x3d' => Ok(4),
+        b'\x3e' => err!(Error::UnexpectedCode("count code start".to_string())),
+        b'\x3f' => err!(Error::UnexpectedCode("op code start".to_string())),
+        _ => err!(Error::UnknownBardage(b.to_string())),
+    }
+}
+
 #[allow(non_camel_case_types)]
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Codex {
@@ -234,7 +245,7 @@ impl Codex {
 
 #[cfg(test)]
 mod tables_tests {
-    use crate::core::matter::tables::{hardage, sizage, Codex};
+    use crate::core::matter::tables::{bardage, hardage, sizage, Codex};
     use rstest::rstest;
 
     #[rstest]
@@ -300,11 +311,67 @@ mod tables_tests {
 
     #[rstest]
     #[case('A', 1)]
+    #[case('B', 1)]
+    #[case('C', 1)]
+    #[case('D', 1)]
+    #[case('E', 1)]
+    #[case('F', 1)]
     #[case('G', 1)]
+    #[case('H', 1)]
+    #[case('I', 1)]
+    #[case('J', 1)]
+    #[case('K', 1)]
+    #[case('L', 1)]
+    #[case('M', 1)]
+    #[case('N', 1)]
+    #[case('O', 1)]
+    #[case('P', 1)]
+    #[case('Q', 1)]
+    #[case('R', 1)]
+    #[case('S', 1)]
+    #[case('T', 1)]
+    #[case('U', 1)]
+    #[case('V', 1)]
+    #[case('W', 1)]
+    #[case('X', 1)]
+    #[case('Y', 1)]
+    #[case('Z', 1)]
+    #[case('a', 1)]
     #[case('b', 1)]
+    #[case('c', 1)]
+    #[case('d', 1)]
+    #[case('e', 1)]
+    #[case('f', 1)]
+    #[case('g', 1)]
+    #[case('h', 1)]
+    #[case('i', 1)]
+    #[case('j', 1)]
+    #[case('k', 1)]
+    #[case('l', 1)]
+    #[case('m', 1)]
+    #[case('n', 1)]
+    #[case('o', 1)]
+    #[case('p', 1)]
+    #[case('q', 1)]
+    #[case('r', 1)]
+    #[case('s', 1)]
+    #[case('t', 1)]
+    #[case('u', 1)]
+    #[case('v', 1)]
+    #[case('w', 1)]
+    #[case('x', 1)]
+    #[case('y', 1)]
     #[case('z', 1)]
-    #[case('1', 4)]
     #[case('0', 2)]
+    #[case('4', 2)]
+    #[case('5', 2)]
+    #[case('6', 2)]
+    #[case('1', 4)]
+    #[case('2', 4)]
+    #[case('3', 4)]
+    #[case('7', 4)]
+    #[case('8', 4)]
+    #[case('9', 4)]
     fn test_hardage(#[case] code: char, #[case] hdg: u32) {
         assert_eq!(hardage(code).unwrap(), hdg);
     }
@@ -366,6 +433,7 @@ mod tables_tests {
         assert!(hardage('-').is_err());
         assert!(hardage('_').is_err());
         assert!(hardage('#').is_err());
+        assert!(bardage(0x40).is_err());
         assert!(Codex::from_code("CESR").is_err());
     }
 }

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -177,7 +177,7 @@ pub fn u32_to_b64(n: u32, length: usize) -> Result<String> {
         out.insert(0, 'A');
     }
 
-    Ok(out)
+    Ok(out[..length].to_string())
 }
 
 pub fn u64_to_b64(n: u64, length: usize) -> Result<String> {
@@ -193,10 +193,14 @@ pub fn u64_to_b64(n: u64, length: usize) -> Result<String> {
         out.insert(0, 'A');
     }
 
-    Ok(out)
+    Ok(out[..length].to_string())
 }
 
 pub fn code_b2_to_b64(b2: &[u8], length: usize) -> Result<String> {
+    if length == 0 {
+        return Ok("".to_string());
+    }
+
     let n = ((length + 1) * 3) / 4;
 
     if n > b2.len() {
@@ -265,6 +269,7 @@ mod util_tests {
     use rstest::rstest;
 
     #[rstest]
+    #[case(32, 0, "")]
     #[case(0, 1, "A")]
     #[case(1, 1, "B")]
     #[case(0, 2, "AA")]
@@ -325,6 +330,7 @@ mod util_tests {
     #[case(&vec![252], 1, "_")]
     #[case(&vec![255, 255, 255, 255, 255, 255], 8, "________")]
     #[case(&vec![244, 0, 1], 4, "9AAB")]
+    #[case(&vec![244, 0, 1], 0, "")]
     fn test_code_b2_to_b64(#[case] b2: &Vec<u8>, #[case] length: usize, #[case] b64: &str) {
         assert_eq!(util::code_b2_to_b64(b2, length).unwrap(), b64);
     }


### PR DESCRIPTION
## Rationale

There are a few things that can be cleaned up in the process of completing the `Indexer` work.

- `bexfil()` needs to be completed
- test coverage could improve
- bardages could be consolidated
- `Dater` has misc copy pasta

## Changes

- completes `bexfil()`
- improves test coverage
- consolidates bardages
- fixes a bug in `u32_to_b64()` and `u64_to_b64()`
- removes unused code from `Dater`

## Testing

```
make clean preflight
```