### PR TITLE
constants instead of enums for codexes

### DIFF
--- a/src/core/cigar.rs
+++ b/src/core/cigar.rs
@@ -16,7 +16,7 @@ impl Default for Cigar {
     fn default() -> Self {
         Cigar {
             raw: vec![],
-            code: matter::Codex::Ed25519_Sig.code().to_string(),
+            code: matter::Codex::Ed25519_Sig.to_string(),
             size: 0,
             verfer: Verfer::default(),
         }
@@ -26,9 +26,9 @@ impl Default for Cigar {
 fn validate_code(code: &str) -> Result<()> {
     lazy_static! {
         static ref CODES: Vec<&'static str> = vec![
-            matter::Codex::Ed25519_Sig.code(),
-            matter::Codex::ECDSA_256k1_Sig.code(),
-            // matter::Codex::Ed448_Sig.code(),
+            matter::Codex::Ed25519_Sig,
+            matter::Codex::ECDSA_256k1_Sig,
+            // matter::Codex::Ed448_Sig,
         ];
     }
 
@@ -111,10 +111,10 @@ mod test_cigar {
 
     #[test]
     fn test_new_with_code_and_raw() {
-        let vcode = matter::Codex::Ed25519.code();
+        let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
         let verfer = Verfer::new_with_code_and_raw(vcode, vraw).unwrap();
-        let code = matter::Codex::Ed25519_Sig.code();
+        let code = matter::Codex::Ed25519_Sig;
         let raw = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]";
 
         let cigar = Cigar::new_with_code_and_raw(&verfer, code, raw).unwrap();
@@ -128,14 +128,14 @@ mod test_cigar {
     #[test]
     fn test_new_with_qb64() {
         let qsig64 = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ";
-        let vcode = matter::Codex::Ed25519.code();
+        let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
         let verfer = Verfer::new_with_code_and_raw(vcode, vraw).unwrap();
 
         let cigar = Cigar::new_with_qb64(&verfer, qsig64).unwrap();
 
         // this is probably the most critical line (the previous is obviously important too)
-        assert_eq!(cigar.code(), matter::Codex::Ed25519_Sig.code());
+        assert_eq!(cigar.code(), matter::Codex::Ed25519_Sig);
         assert_eq!(cigar.qb64().unwrap(), qsig64);
         assert_eq!(cigar.verfer().raw(), verfer.raw());
         assert_eq!(cigar.verfer().code(), verfer.code());
@@ -144,14 +144,14 @@ mod test_cigar {
     #[test]
     fn test_new_with_qb64b() {
         let qsig64b = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ".as_bytes();
-        let vcode = matter::Codex::Ed25519.code();
+        let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
         let verfer = Verfer::new_with_code_and_raw(vcode, vraw).unwrap();
 
         let cigar = Cigar::new_with_qb64b(&verfer, qsig64b).unwrap();
 
         // this is probably the most critical line (the previous is obviously important too)
-        assert_eq!(cigar.code(), matter::Codex::Ed25519_Sig.code());
+        assert_eq!(cigar.code(), matter::Codex::Ed25519_Sig);
         assert_eq!(cigar.qb64b().unwrap(), qsig64b);
         assert_eq!(cigar.verfer().raw(), verfer.raw());
         assert_eq!(cigar.verfer().code(), verfer.code());
@@ -165,14 +165,14 @@ mod test_cigar {
             25, 23, 10, 158, 204, 249, 42, 242, 157, 236, 175, 199, 247, 237, 118, 247, 193, 120,
             33, 221, 67, 198, 242, 40, 18, 96, 144,
         ];
-        let vcode = matter::Codex::Ed25519.code();
+        let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
         let verfer = Verfer::new_with_code_and_raw(vcode, vraw).unwrap();
 
         let cigar = Cigar::new_with_qb2(&verfer, &qb2).unwrap();
 
         // this is probably the most critical line (the previous is obviously important too)
-        assert_eq!(cigar.code(), matter::Codex::Ed25519_Sig.code());
+        assert_eq!(cigar.code(), matter::Codex::Ed25519_Sig);
         assert_eq!(cigar.qb2().unwrap(), qb2);
         assert_eq!(cigar.verfer().raw(), verfer.raw());
         assert_eq!(cigar.verfer().code(), verfer.code());
@@ -181,13 +181,13 @@ mod test_cigar {
     #[test]
     fn test_set_verfer() {
         let qsig64 = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ";
-        let vcode = matter::Codex::Ed25519.code();
+        let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
         let verfer = Verfer::new_with_code_and_raw(vcode, vraw).unwrap();
 
         let mut cigar = Cigar::new_with_qb64(&verfer, qsig64).unwrap();
 
-        let vcode2 = matter::Codex::Ed25519N.code();
+        let vcode2 = matter::Codex::Ed25519N;
         let vraw2 = b"abcdefghijklmnopqrstuvwxyz543210";
         let verfer2 = Verfer::new_with_code_and_raw(vcode2, vraw2).unwrap();
 
@@ -198,7 +198,7 @@ mod test_cigar {
 
     #[test]
     fn test_unhappy_paths() {
-        let vcode = matter::Codex::Ed25519.code();
+        let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
         let verfer = Verfer::new_with_code_and_raw(vcode, vraw).unwrap();
 

--- a/src/core/counter/mod.rs
+++ b/src/core/counter/mod.rs
@@ -296,9 +296,9 @@ mod counter_tests {
     use rstest::rstest;
 
     #[rstest]
-    #[case("-AAB", 1, "B", counter::Codex::ControllerIdxSigs.code())]
-    #[case("-AAF", 5, "F", counter::Codex::ControllerIdxSigs.code())]
-    #[case("-0VAAAQA", 1024, "QA", counter::Codex::BigAttachedMaterialQuadlets.code())]
+    #[case("-AAB", 1, "B", counter::Codex::ControllerIdxSigs)]
+    #[case("-AAF", 5, "F", counter::Codex::ControllerIdxSigs)]
+    #[case("-0VAAAQA", 1024, "QA", counter::Codex::BigAttachedMaterialQuadlets)]
     fn test_creation(
         #[case] qsc: &str,
         #[case] count: u32,
@@ -325,7 +325,7 @@ mod counter_tests {
     }
 
     #[rstest]
-    #[case(0, "AAA", 0, "AAA", counter::Codex::KERIProtocolStack.code())]
+    #[case(0, "AAA", 0, "AAA", counter::Codex::KERIProtocolStack)]
     fn test_versioned_creation(
         #[case] verint: u32,
         #[case] version: &str,
@@ -448,23 +448,18 @@ mod counter_tests {
     #[test]
     fn test_unhappy_paths() {
         assert!(Counter::new_with_code_and_count("", 1).is_err());
-        assert!(Counter::new_with_code_and_count(
-            counter::Codex::ControllerIdxSigs.code(),
-            64 * 64
-        )
-        .is_err());
+        assert!(
+            Counter::new_with_code_and_count(counter::Codex::ControllerIdxSigs, 64 * 64).is_err()
+        );
         assert!(Counter::sem_ver_str_to_b64("1.2.3.4").is_err());
         assert!(Counter::sem_ver_str_to_b64("bad.semantic.version").is_err());
-        assert!((Counter {
-            code: counter::Codex::ControllerIdxSigs.code().to_string(),
-            count: 64 * 64
-        })
-        .qb64()
-        .is_err());
+        assert!((Counter { code: counter::Codex::ControllerIdxSigs.to_string(), count: 64 * 64 })
+            .qb64()
+            .is_err());
         assert!(Counter::new_with_qb64("").is_err());
         assert!(Counter::new_with_qb64("--").is_err());
         assert!(Counter::new_with_qb64("__").is_err());
-        assert!(Counter::new_with_qb64(counter::Codex::ControllerIdxSigs.code()).is_err());
+        assert!(Counter::new_with_qb64(counter::Codex::ControllerIdxSigs).is_err());
         assert!(Counter::new_with_qb64b(&[]).is_err());
         assert!(Counter::new_with_qb2(&[]).is_err());
         assert!(Counter::new_with_qb2(&[0xf8, 0]).is_err());
@@ -473,7 +468,7 @@ mod counter_tests {
     }
 
     #[rstest]
-    #[case(counter::Codex::ControllerIdxSigs.code(), 1)]
+    #[case(counter::Codex::ControllerIdxSigs, 1)]
     fn test_qb64b(#[case] code: &str, #[case] count: u32) {
         let c = Counter { code: code.to_string(), count };
         assert!(Counter::new_with_qb64b(&c.qb64b().unwrap()).is_ok());

--- a/src/core/counter/tables.rs
+++ b/src/core/counter/tables.rs
@@ -49,66 +49,24 @@ pub(crate) fn bardage(b: &[u8]) -> Result<u32> {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub enum Codex {
-    ControllerIdxSigs,
-    WitnessIdxSigs,
-    NonTransReceiptCouples,
-    TransReceiptQuadruples,
-    FirstSeenReplayCouples,
-    TransIdxSigGroups,
-    SealSourceCouples,
-    TransLastIdxSigGroups,
-    SealSourceTriples,
-    SadPathSig,
-    SadPathSigGroup,
-    PathedMaterialQuadlets,
-    AttachedMaterialQuadlets,
-    BigAttachedMaterialQuadlets,
-    KERIProtocolStack,
-}
-
-impl Codex {
-    pub(crate) fn code(&self) -> &'static str {
-        match self {
-            Codex::ControllerIdxSigs => "-A", // Qualified Base64 Indexed Signature.
-            Codex::WitnessIdxSigs => "-B",    // Qualified Base64 Indexed Signature.
-            Codex::NonTransReceiptCouples => "-C", // Composed Base64 Couple, pre+cig.
-            Codex::TransReceiptQuadruples => "-D", // Composed Base64 Quadruple, pre+snu+dig+sig.
-            Codex::FirstSeenReplayCouples => "-E", // Composed Base64 Couple, fnu+dts.
-            Codex::TransIdxSigGroups => "-F", // Composed Base64 Group, pre+snu+dig+ControllerIdxSigs group.
-            Codex::SealSourceCouples => "-G", // Composed Base64 couple, snu+dig of given delegators or issuers event
-            Codex::TransLastIdxSigGroups => "-H", // Composed Base64 Group, pre+ControllerIdxSigs group.
-            Codex::SealSourceTriples => "-I", // Composed Base64 triple, pre+snu+dig of anchoring source event
-            Codex::SadPathSig => "-J", // Composed Base64 Group path+TransIdxSigGroup of SAID of content
-            Codex::SadPathSigGroup => "-K", // Composed Base64 Group, root(path)+SaidPathCouples
-            Codex::PathedMaterialQuadlets => "-L", // Composed Grouped Pathed Material Quadlet (4 char each)
-            Codex::AttachedMaterialQuadlets => "-V", // Composed Grouped Attached Material Quadlet (4 char each)
-            Codex::BigAttachedMaterialQuadlets => "-0V", // Composed Grouped Attached Material Quadlet (4 char each)
-            Codex::KERIProtocolStack => "--AAA",         // KERI ACDC Protocol Stack CESR Version
-        }
-    }
-
-    pub(crate) fn from_code(code: &str) -> Result<Self> {
-        Ok(match code {
-            "-A" => Codex::ControllerIdxSigs,
-            "-B" => Codex::WitnessIdxSigs,
-            "-C" => Codex::NonTransReceiptCouples,
-            "-D" => Codex::TransReceiptQuadruples,
-            "-E" => Codex::FirstSeenReplayCouples,
-            "-F" => Codex::TransIdxSigGroups,
-            "-G" => Codex::SealSourceCouples,
-            "-H" => Codex::TransLastIdxSigGroups,
-            "-I" => Codex::SealSourceTriples,
-            "-J" => Codex::SadPathSig,
-            "-K" => Codex::SadPathSigGroup,
-            "-L" => Codex::PathedMaterialQuadlets,
-            "-V" => Codex::AttachedMaterialQuadlets,
-            "-0V" => Codex::BigAttachedMaterialQuadlets,
-            "--AAA" => Codex::KERIProtocolStack,
-            _ => return err!(Error::UnexpectedCode(code.to_string())),
-        })
-    }
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod Codex {
+    pub const ControllerIdxSigs: &str = "-A"; // Qualified Base64 Indexed Signature.
+    pub const WitnessIdxSigs: &str = "-B"; // Qualified Base64 Indexed Signature.
+    pub const NonTransReceiptCouples: &str = "-C"; // Composed Base64 Couple, pre+cig.
+    pub const TransReceiptQuadruples: &str = "-D"; // Composed Base64 Quadruple, pre+snu+dig+sig.
+    pub const FirstSeenReplayCouples: &str = "-E"; // Composed Base64 Couple, fnu+dts.
+    pub const TransIdxSigGroups: &str = "-F"; // Composed Base64 Group, pre+snu+dig+ControllerIdxSigs group.
+    pub const SealSourceCouples: &str = "-G"; // Composed Base64 couple, snu+dig of given delegators or issuers event
+    pub const TransLastIdxSigGroups: &str = "-H"; // Composed Base64 Group, pre+ControllerIdxSigs group.
+    pub const SealSourceTriples: &str = "-I"; // Composed Base64 triple, pre+snu+dig of anchoring source event
+    pub const SadPathSig: &str = "-J"; // Composed Base64 Group path+TransIdxSigGroup of SAID of content
+    pub const SadPathSigGroup: &str = "-K"; // Composed Base64 Group, root(path)+SaidPathCouples
+    pub const PathedMaterialQuadlets: &str = "-L"; // Composed Grouped Pathed Material Quadlet (4 char each)
+    pub const AttachedMaterialQuadlets: &str = "-V"; // Composed Grouped Attached Material Quadlet (4 char each)
+    pub const BigAttachedMaterialQuadlets: &str = "-0V"; // Composed Grouped Attached Material Quadlet (4 char each)
+    pub const KERIProtocolStack: &str = "--AAA"; // KERI ACDC Protocol Stack CESR Version
 }
 
 #[cfg(test)]
@@ -202,15 +160,13 @@ mod tables_tests {
     #[case(Codex::AttachedMaterialQuadlets, "-V")]
     #[case(Codex::BigAttachedMaterialQuadlets, "-0V")]
     #[case(Codex::KERIProtocolStack, "--AAA")]
-    fn test_codex(#[case] variant: Codex, #[case] code: &str) {
-        assert_eq!(variant.code(), code);
-        assert_eq!(Codex::from_code(code).unwrap(), variant);
+    fn test_codex(#[case] code: &str, #[case] value: &str) {
+        assert_eq!(code, value);
     }
 
     #[test]
     fn test_unhappy_paths() {
         assert!(sizage("CESR").is_err());
         assert!(bardage(&[63, 0]).is_err());
-        assert!(Codex::from_code("CESR").is_err());
     }
 }

--- a/src/core/dater.rs
+++ b/src/core/dater.rs
@@ -12,13 +12,13 @@ pub struct Dater {
 
 impl Default for Dater {
     fn default() -> Self {
-        Dater { raw: vec![], code: matter::Codex::DateTime.code().to_string(), size: 0 }
+        Dater { raw: vec![], code: matter::Codex::DateTime.to_string(), size: 0 }
     }
 }
 
 fn validate_code(code: &str) -> Result<()> {
     lazy_static! {
-        static ref CODES: Vec<&'static str> = vec![matter::Codex::DateTime.code(),];
+        static ref CODES: Vec<&'static str> = vec![matter::Codex::DateTime];
     }
 
     if !CODES.contains(&code) {
@@ -52,7 +52,7 @@ impl Dater {
             validate_code(code)?;
         }
         if raw.is_empty() {
-            let qb64 = format!("{}{}", matter::Codex::DateTime.code(), now_as_b64());
+            let qb64 = format!("{}{}", matter::Codex::DateTime, now_as_b64());
             Matter::new_with_qb64(&qb64)
         } else {
             Matter::new_with_code_and_raw(code, raw)
@@ -61,7 +61,7 @@ impl Dater {
 
     fn new_with_dts(dts: &str) -> Result<Self> {
         let b64 = if dts.is_empty() { now_as_b64() } else { iso_8601_to_b64(dts) };
-        let qb64 = format!("{}{}", matter::Codex::DateTime.code(), &b64);
+        let qb64 = format!("{}{}", matter::Codex::DateTime, &b64);
         Matter::new_with_qb64(&qb64)
     }
 
@@ -138,7 +138,7 @@ mod test_dater {
         )]
         dater: &Dater,
     ) {
-        assert_eq!(dater.code, matter::Codex::DateTime.code());
+        assert_eq!(dater.code, matter::Codex::DateTime);
         assert_eq!(dater.raw.len(), 24);
         assert_eq!(dater.qb64().unwrap().len(), 36);
         assert_eq!(dater.qb2().unwrap().len(), 27);
@@ -164,7 +164,7 @@ mod test_dater {
         #[case] dtraw: &[u8],
         #[case] dtqb2: &[u8],
         #[values(
-            &Dater::new_with_code_and_raw(matter::Codex::DateTime.code(), dtraw).unwrap(),
+            &Dater::new_with_code_and_raw(matter::Codex::DateTime, dtraw).unwrap(),
             &Dater::new_with_dts(dts).unwrap(),
             &Dater::new_with_dtsb(dts.as_bytes()).unwrap(),
             &Dater::new_with_qb64(dtqb64).unwrap(),
@@ -173,7 +173,7 @@ mod test_dater {
         )]
         dater: &Dater,
     ) {
-        assert_eq!(dater.code, matter::Codex::DateTime.code());
+        assert_eq!(dater.code, matter::Codex::DateTime);
         assert_eq!(dater.dts().unwrap(), dts);
         assert_eq!(dater.dtsb().unwrap(), dts.as_bytes());
         assert_eq!(dater.raw, dtraw);
@@ -183,17 +183,11 @@ mod test_dater {
     }
 
     #[rstest]
+    #[case(matter::Codex::Big, b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xcd4")]
+    #[case(matter::Codex::DateTime, b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5")]
     #[case(
-            matter::Codex::Big.code(),
-            b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xcd4",
-    )]
-    #[case(
-            matter::Codex::DateTime.code(),
-            b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5",
-    )]
-    #[case(
-            matter::Codex::DateTime.code(),
-            b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xff",
+        matter::Codex::DateTime,
+        b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xff"
     )]
     #[case("", b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xcd4")]
     fn test_unhappy_new_with_code_and_raw(#[case] code: &str, #[case] dtraw: &[u8]) {

--- a/src/core/indexer/mod.rs
+++ b/src/core/indexer/mod.rs
@@ -627,7 +627,7 @@ mod indexer_tests {
         fn default() -> Self {
             TestIndexer {
                 raw: vec![],
-                code: tables::Codex::Ed25519.code().to_string(),
+                code: tables::Codex::Ed25519.to_string(),
                 index: 0,
                 ondex: 0,
             }
@@ -683,7 +683,7 @@ mod indexer_tests {
         assert_eq!(sig64, "AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ");
         assert_eq!(sig64.len(), 88);
 
-        let code = Codex::Ed25519.code();
+        let code = Codex::Ed25519;
         let qsc = format!("{code}{}", util::u32_to_b64(0, 1).unwrap());
         assert_eq!(qsc, "AA");
 
@@ -695,10 +695,9 @@ mod indexer_tests {
         assert_eq!(qsig2b, b"\x00\x00\x99\xd2<9$$0\x9fk\xfb\x18\xa0\x8c@r\x122.k\xb2\xc7\x1fp\x0e'm\x8f@\xaa\xa5\x8c\xc8n\x85\xc8!\xf6q\x91p\xa9\xec\xcf\x92\xaf)\xde\xca\xfc\x7f~\xd7o|\x17\x82\x1d\xd4<o\"\x81&\t");
         assert_eq!(qsig2b.len(), 66);
 
-        let mut idx =
-            TestIndexer::new_with_code_and_raw(Codex::Ed25519.code(), sig, 0, None).unwrap();
-        assert_eq!(idx.code, Codex::Ed25519.code());
-        assert_eq!(idx.code(), Codex::Ed25519.code());
+        let mut idx = TestIndexer::new_with_code_and_raw(Codex::Ed25519, sig, 0, None).unwrap();
+        assert_eq!(idx.code, Codex::Ed25519);
+        assert_eq!(idx.code(), Codex::Ed25519);
         assert_eq!(idx.raw, sig);
         assert_eq!(idx.raw(), sig);
         assert_eq!(idx.index, 0);
@@ -710,8 +709,8 @@ mod indexer_tests {
         idx = TestIndexer::new_with_qb64("AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ").unwrap();
         assert_eq!(idx.raw, sig);
         assert_eq!(idx.raw(), sig);
-        assert_eq!(idx.code, Codex::Ed25519.code());
-        assert_eq!(idx.code(), Codex::Ed25519.code());
+        assert_eq!(idx.code, Codex::Ed25519);
+        assert_eq!(idx.code(), Codex::Ed25519);
         assert_eq!(idx.index, 0);
         assert_eq!(idx.ondex, 0);
         assert_eq!(idx.qb64().unwrap(), sig64);
@@ -721,8 +720,8 @@ mod indexer_tests {
         idx = TestIndexer::new_with_qb64b("AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ".as_bytes()).unwrap();
         assert_eq!(idx.raw, sig);
         assert_eq!(idx.raw(), sig);
-        assert_eq!(idx.code, Codex::Ed25519.code());
-        assert_eq!(idx.code(), Codex::Ed25519.code());
+        assert_eq!(idx.code, Codex::Ed25519);
+        assert_eq!(idx.code(), Codex::Ed25519);
         assert_eq!(idx.index, 0);
         assert_eq!(idx.ondex, 0);
         assert_eq!(idx.qb64().unwrap(), sig64);
@@ -732,8 +731,8 @@ mod indexer_tests {
         idx = TestIndexer::new_with_qb2(&qsig2b).unwrap();
         assert_eq!(idx.raw, sig);
         assert_eq!(idx.raw(), sig);
-        assert_eq!(idx.code, Codex::Ed25519.code());
-        assert_eq!(idx.code(), Codex::Ed25519.code());
+        assert_eq!(idx.code, Codex::Ed25519);
+        assert_eq!(idx.code(), Codex::Ed25519);
         assert_eq!(idx.index, 0);
         assert_eq!(idx.ondex, 0);
         assert_eq!(idx.qb64().unwrap(), sig64);
@@ -747,7 +746,7 @@ mod indexer_tests {
 
         // basic
         let m = TestIndexer::new_with_qb64(qb64).unwrap();
-        assert_eq!(m.code, Codex::Ed25519.code());
+        assert_eq!(m.code, Codex::Ed25519);
 
         // qb64
         let m2 = TestIndexer::new_with_code_and_raw(&m.code, &m.raw, 0, None).unwrap();
@@ -777,7 +776,7 @@ mod indexer_tests {
     #[test]
     fn test_zero_fs() {
         let indexer =
-            TestIndexer::new_with_code_and_raw(Codex::TBD0.code(), &[0, 0, 0], 1, Some(1)).unwrap();
+            TestIndexer::new_with_code_and_raw(Codex::TBD0, &[0, 0, 0], 1, Some(1)).unwrap();
         assert!(TestIndexer::new_with_qb64(&indexer.qb64().unwrap()).is_ok());
         assert!(TestIndexer::new_with_qb64b(&indexer.qb64b().unwrap()).is_ok());
         assert!(TestIndexer::new_with_qb2(&indexer.qb2().unwrap()).is_ok());
@@ -786,7 +785,7 @@ mod indexer_tests {
     #[test]
     fn test_unhappy_paths() {
         assert!(TestIndexer::new_with_code_and_raw("", &[], 0, None).is_err());
-        assert!(TestIndexer::new_with_code_and_raw(Codex::Ed25519.code(), &[], 0, None).is_err());
+        assert!(TestIndexer::new_with_code_and_raw(Codex::Ed25519, &[], 0, None).is_err());
         assert!(TestIndexer::new_with_qb64("").is_err());
         assert!(TestIndexer::new_with_qb64b(&[]).is_err());
         assert!(TestIndexer::new_with_qb2(&[]).is_err());
@@ -798,27 +797,21 @@ mod indexer_tests {
         assert!(TestIndexer::new_with_qb64("0").is_err());
 
         // index too large
-        assert!(
-            TestIndexer::new_with_code_and_raw(Codex::Ed25519.code(), &[], 65536, None).is_err()
-        );
+        assert!(TestIndexer::new_with_code_and_raw(Codex::Ed25519, &[], 65536, None).is_err());
 
         // ondex too large
-        assert!(
-            TestIndexer::new_with_code_and_raw(Codex::Ed448.code(), &[], 0, Some(65535)).is_err()
-        );
+        assert!(TestIndexer::new_with_code_and_raw(Codex::Ed448, &[], 0, Some(65535)).is_err());
 
         // non-none ondex
-        assert!(
-            TestIndexer::new_with_code_and_raw(Codex::Ed25519_Crt.code(), &[], 0, Some(1)).is_err()
-        );
+        assert!(TestIndexer::new_with_code_and_raw(Codex::Ed25519_Crt, &[], 0, Some(1)).is_err());
 
         // non-matching index/ondex
-        assert!(TestIndexer::new_with_code_and_raw(Codex::TBD0.code(), &[], 0, Some(1)).is_err());
+        assert!(TestIndexer::new_with_code_and_raw(Codex::TBD0, &[], 0, Some(1)).is_err());
 
         // index overflow
         let indexer = TestIndexer {
             raw: b"".to_vec(),
-            code: Codex::TBD0.code().to_string(),
+            code: Codex::TBD0.to_string(),
             index: 65536,
             ondex: 0,
         };
@@ -828,7 +821,7 @@ mod indexer_tests {
         // ondex overflow
         let indexer = TestIndexer {
             raw: b"".to_vec(),
-            code: Codex::Ed448.code().to_string(),
+            code: Codex::Ed448.to_string(),
             index: 0,
             ondex: 65536,
         };
@@ -838,7 +831,7 @@ mod indexer_tests {
         // pad size incorrect
         let indexer = TestIndexer {
             raw: b"ab".to_vec(),
-            code: Codex::Ed25519.code().to_string(),
+            code: Codex::Ed25519.to_string(),
             index: 0,
             ondex: 0,
         };
@@ -848,7 +841,7 @@ mod indexer_tests {
         // raw not long enough
         let indexer = TestIndexer {
             raw: b"a".to_vec(),
-            code: Codex::Ed25519_Big.code().to_string(),
+            code: Codex::Ed25519_Big.to_string(),
             index: 0,
             ondex: 0,
         };
@@ -856,7 +849,7 @@ mod indexer_tests {
         assert!(indexer.qb2().is_err());
 
         // hard complete, code not
-        assert!(TestIndexer::new_with_qb64(Codex::Ed25519.code()).is_err());
+        assert!(TestIndexer::new_with_qb64(Codex::Ed25519).is_err());
 
         // invalid ondex for current sig
         let qb64 = "0BAB";

--- a/src/core/indexer/tables.rs
+++ b/src/core/indexer/tables.rs
@@ -1,6 +1,4 @@
-use lazy_static::lazy_static;
-
-use crate::error::{err, Error, Result};
+use crate::error::{Error, Result};
 /// Codex is codex hard (stable) part of all indexer derivation codes.
 ///
 /// Codes indicate which list of keys, current and/or prior next, index is for:
@@ -21,169 +19,66 @@ use crate::error::{err, Error, Result};
 pub(crate) const SMALL_VRZ_BYTES: u32 = 3;
 pub(crate) const LARGE_VRZ_BYTES: u32 = 6;
 
-#[allow(non_camel_case_types)]
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) enum Codex {
-    Ed25519,
-    Ed25519_Crt,
-    ECDSA_256k1,
-    ECDSA_256k1_Crt,
-    Ed448,
-    Ed448_Crt,
-    Ed25519_Big,
-    Ed25519_Big_Crt,
-    ECDSA_256k1_Big,
-    ECDSA_256k1_Big_Crt,
-    Ed448_Big,
-    Ed448_Big_Crt,
-    TBD0,
-    TBD1,
-    TBD4,
-}
-
-impl Codex {
-    pub(crate) fn code(&self) -> &'static str {
-        match self {
-            Codex::Ed25519 => "A",     // Ed25519 sig appears same in both lists if any.
-            Codex::Ed25519_Crt => "B", // Ed25519 sig appears in current list only.
-            Codex::ECDSA_256k1 => "C", // ECDSA secp256k1 sig appears same in both lists if any.
-            Codex::ECDSA_256k1_Crt => "D", // ECDSA secp256k1 sig appears in current list.
-            Codex::Ed448 => "0A",      // Ed448 signature appears in both lists.
-            Codex::Ed448_Crt => "0B",  // Ed448 signature appears in current list only.
-            Codex::Ed25519_Big => "2A", // Ed25519 sig appears in both lists.
-            Codex::Ed25519_Big_Crt => "2B", // Ed25519 sig appears in current list only.
-            Codex::ECDSA_256k1_Big => "2C", // ECDSA secp256k1 sig appears in both lists.
-            Codex::ECDSA_256k1_Big_Crt => "2D", // ECDSA secp256k1 sig appears in current list only.
-            Codex::Ed448_Big => "3A",  // Ed448 signature appears in both lists.
-            Codex::Ed448_Big_Crt => "3B", // Ed448 signature appears in current list only.
-            Codex::TBD0 => "0z", // Test of Var len label L=N*4 <= 4095 char quadlets includes code
-            Codex::TBD1 => "1z", // Test of index sig lead 1
-            Codex::TBD4 => "4z", // Test of index sig lead 1 big
-        }
-    }
-
-    pub(crate) fn from_code(code: &str) -> Result<Self> {
-        Ok(match code {
-            "A" => Codex::Ed25519,
-            "B" => Codex::Ed25519_Crt,
-            "C" => Codex::ECDSA_256k1,
-            "D" => Codex::ECDSA_256k1_Crt,
-            "0A" => Codex::Ed448,
-            "0B" => Codex::Ed448_Crt,
-            "2A" => Codex::Ed25519_Big,
-            "2B" => Codex::Ed25519_Big_Crt,
-            "2C" => Codex::ECDSA_256k1_Big,
-            "2D" => Codex::ECDSA_256k1_Big_Crt,
-            "3A" => Codex::Ed448_Big,
-            "3B" => Codex::Ed448_Big_Crt,
-            "0z" => Codex::TBD0,
-            "1z" => Codex::TBD1,
-            "4z" => Codex::TBD4,
-            _ => return err!(Error::UnexpectedCode(code.to_string())),
-        })
-    }
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod Codex {
+    pub const Ed25519: &str = "A"; // Ed25519 sig appears same in both lists if any.
+    pub const Ed25519_Crt: &str = "B"; // Ed25519 sig appears in current list only.
+    pub const ECDSA_256k1: &str = "C"; // ECDSA secp256k1 sig appears same in both lists if any.
+    pub const ECDSA_256k1_Crt: &str = "D"; // ECDSA secp256k1 sig appears in current list.
+    pub const Ed448: &str = "0A"; // Ed448 signature appears in both lists.
+    pub const Ed448_Crt: &str = "0B"; // Ed448 signature appears in current list only.
+    pub const Ed25519_Big: &str = "2A"; // Ed25519 sig appears in both lists.
+    pub const Ed25519_Big_Crt: &str = "2B"; // Ed25519 sig appears in current list only.
+    pub const ECDSA_256k1_Big: &str = "2C"; // ECDSA secp256k1 sig appears in both lists.
+    pub const ECDSA_256k1_Big_Crt: &str = "2D"; // ECDSA secp256k1 sig appears in current list only.
+    pub const Ed448_Big: &str = "3A"; // Ed448 signature appears in both lists.
+    pub const Ed448_Big_Crt: &str = "3B"; // Ed448 signature appears in current list only.
+    pub const TBD0: &str = "0z"; // Test of Var len label L=N*4 <= 4095 char quadlets includes code
+    pub const TBD1: &str = "1z"; // Test of index sig lead 1
+    pub const TBD4: &str = "4z"; // Test of index sig lead 1 big
 }
 
 /// SigCodex is all indexed signature derivation codes
-#[allow(non_camel_case_types, clippy::enum_variant_names)]
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) enum SigCodex {
-    Ed25519,
-    Ed25519_Crt,
-    ECDSA_256k1,
-    ECDSA_256k1_Crt,
-    Ed448,
-    Ed448_Crt,
-    Ed25519_Big,
-    Ed25519_Big_Crt,
-    ECDSA_256k1_Big,
-    ECDSA_256k1_Big_Crt,
-    Ed448_Big,
-    Ed448_Big_Crt,
-}
-
-impl SigCodex {
-    pub(crate) fn code(&self) -> &'static str {
-        match self {
-            SigCodex::Ed25519 => "A", // Ed25519 sig appears same in both lists if any.
-            SigCodex::Ed25519_Crt => "B", // Ed25519 sig appears in current list only.
-            SigCodex::ECDSA_256k1 => "C", // ECDSA secp256k1 sig appears same in both lists if any.
-            SigCodex::ECDSA_256k1_Crt => "D", // ECDSA secp256k1 sig appears in current list.
-            SigCodex::Ed448 => "0A",  // Ed448 signature appears in both lists.
-            SigCodex::Ed448_Crt => "0B", // Ed448 signature appears in current list only.
-            SigCodex::Ed25519_Big => "2A", // Ed25519 sig appears in both lists.
-            SigCodex::Ed25519_Big_Crt => "2B", // Ed25519 sig appears in current list only.
-            SigCodex::ECDSA_256k1_Big => "2C", // ECDSA secp256k1 sig appears in both lists.
-            SigCodex::ECDSA_256k1_Big_Crt => "2D", // ECDSA secp256k1 sig appears in current list only.
-            SigCodex::Ed448_Big => "3A",           // Ed448 signature appears in both lists.
-            SigCodex::Ed448_Big_Crt => "3B",       // Ed448 signature appears in current list only.
-        }
-    }
-
-    pub(crate) fn from_code(code: &str) -> Result<Self> {
-        Ok(match code {
-            "A" => SigCodex::Ed25519,
-            "B" => SigCodex::Ed25519_Crt,
-            "C" => SigCodex::ECDSA_256k1,
-            "D" => SigCodex::ECDSA_256k1_Crt,
-            "0A" => SigCodex::Ed448,
-            "0B" => SigCodex::Ed448_Crt,
-            "2A" => SigCodex::Ed25519_Big,
-            "2B" => SigCodex::Ed25519_Big_Crt,
-            "2C" => SigCodex::ECDSA_256k1_Big,
-            "2D" => SigCodex::ECDSA_256k1_Big_Crt,
-            "3A" => SigCodex::Ed448_Big,
-            "3B" => SigCodex::Ed448_Big_Crt,
-            _ => return err!(Error::UnexpectedCode(code.to_string())),
-        })
-    }
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod SigCodex {
+    pub const Ed25519: &str = "A"; // Ed25519 sig appears same in both lists if any.
+    pub const Ed25519_Crt: &str = "B"; // Ed25519 sig appears in current list only.
+    pub const ECDSA_256k1: &str = "C"; // ECDSA secp256k1 sig appears same in both lists if any.
+    pub const ECDSA_256k1_Crt: &str = "D"; // ECDSA secp256k1 sig appears in current list.
+    pub const Ed448: &str = "0A"; // Ed448 signature appears in both lists.
+    pub const Ed448_Crt: &str = "0B"; // Ed448 signature appears in current list only.
+    pub const Ed25519_Big: &str = "2A"; // Ed25519 sig appears in both lists.
+    pub const Ed25519_Big_Crt: &str = "2B"; // Ed25519 sig appears in current list only.
+    pub const ECDSA_256k1_Big: &str = "2C"; // ECDSA secp256k1 sig appears in both lists.
+    pub const ECDSA_256k1_Big_Crt: &str = "2D"; // ECDSA secp256k1 sig appears in current list only.
+    pub const Ed448_Big: &str = "3A"; // Ed448 signature appears in both lists.
+    pub const Ed448_Big_Crt: &str = "3B"; // Ed448 signature appears in current list only.
 }
 
 /// CurrentSigCodex is codex indexed signature codes for current list.
-#[allow(non_camel_case_types, clippy::enum_variant_names)]
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) enum CurrentSigCodex {
-    Ed25519_Crt,
-    ECDSA_256k1_Crt,
-    Ed448_Crt,
-    Ed25519_Big_Crt,
-    ECDSA_256k1_Big_Crt,
-    Ed448_Big_Crt,
-}
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod CurrentSigCodex {
+    use lazy_static::lazy_static;
 
-impl CurrentSigCodex {
-    pub(crate) fn code(&self) -> &'static str {
-        match self {
-            CurrentSigCodex::Ed25519_Crt => "B", // Ed25519 sig appears in current list only.
-            CurrentSigCodex::ECDSA_256k1_Crt => "D", // ECDSA secp256k1 sig appears in current list only.
-            CurrentSigCodex::Ed448_Crt => "0B", // Ed448 signature appears in current list only.
-            CurrentSigCodex::Ed25519_Big_Crt => "2B", // Ed25519 sig appears in current list only.
-            CurrentSigCodex::ECDSA_256k1_Big_Crt => "2D", // ECDSA secp256k1 sig appears in current list only.
-            CurrentSigCodex::Ed448_Big_Crt => "3B", // Ed448 signature appears in current list only.
-        }
-    }
-
-    pub(crate) fn from_code(code: &str) -> Result<Self> {
-        Ok(match code {
-            "B" => CurrentSigCodex::Ed25519_Crt,
-            "D" => CurrentSigCodex::ECDSA_256k1_Crt,
-            "0B" => CurrentSigCodex::Ed448_Crt,
-            "2B" => CurrentSigCodex::Ed25519_Big_Crt,
-            "2D" => CurrentSigCodex::ECDSA_256k1_Big_Crt,
-            "3B" => CurrentSigCodex::Ed448_Big_Crt,
-            _ => return Err(Box::new(Error::UnexpectedCode(code.to_string()))),
-        })
-    }
+    pub const Ed25519_Crt: &str = "B"; // Ed25519 sig appears in current list only.
+    pub const ECDSA_256k1_Crt: &str = "D"; // ECDSA secp256k1 sig appears in current list only.
+    pub const Ed448_Crt: &str = "0B"; // Ed448 signature appears in current list only.
+    pub const Ed25519_Big_Crt: &str = "2B"; // Ed25519 sig appears in current list only.
+    pub const ECDSA_256k1_Big_Crt: &str = "2D"; // ECDSA secp256k1 sig appears in current list only.
+    pub const Ed448_Big_Crt: &str = "3B"; // Ed448 signature appears in current list only.
 
     pub(crate) fn has_code(code: &str) -> bool {
         lazy_static! {
             static ref CODES: Vec<&'static str> = vec![
-                CurrentSigCodex::Ed25519_Crt.code(),
-                CurrentSigCodex::ECDSA_256k1_Crt.code(),
-                CurrentSigCodex::Ed448_Crt.code(),
-                CurrentSigCodex::Ed25519_Big_Crt.code(),
-                CurrentSigCodex::ECDSA_256k1_Big_Crt.code(),
-                CurrentSigCodex::Ed448_Big_Crt.code(),
+                Ed25519_Crt,
+                ECDSA_256k1_Crt,
+                Ed448_Crt,
+                Ed25519_Big_Crt,
+                ECDSA_256k1_Big_Crt,
+                Ed448_Big_Crt
             ];
         }
 
@@ -191,52 +86,22 @@ impl CurrentSigCodex {
     }
 }
 
-/// BothSigCodex is codex indexed signature codes for both lists.
-#[allow(non_camel_case_types, clippy::enum_variant_names)]
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub(crate) enum BothSigCodex {
-    Ed25519,
-    ECDSA_256k1,
-    Ed448,
-    Ed25519_Big,
-    ECDSA_256k1_Big,
-    Ed448_Big,
-}
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod BothSigCodex {
+    use lazy_static::lazy_static;
 
-impl BothSigCodex {
-    pub(crate) fn code(&self) -> &'static str {
-        match self {
-            BothSigCodex::Ed25519 => "A", // Ed25519 sig appears same in both lists if any.
-            BothSigCodex::ECDSA_256k1 => "C", // ECDSA secp256k1 sig appears same in both lists if any.
-            BothSigCodex::Ed448 => "0A",      // Ed448 signature appears in both lists.
-            BothSigCodex::Ed25519_Big => "2A", // Ed25519 sig appears in both listsy.
-            BothSigCodex::ECDSA_256k1_Big => "2C", // ECDSA secp256k1 sig appears in both lists.
-            BothSigCodex::Ed448_Big => "3A",  // Ed448 signature appears in both lists.
-        }
-    }
-
-    pub(crate) fn from_code(code: &str) -> Result<Self> {
-        Ok(match code {
-            "A" => BothSigCodex::Ed25519,
-            "C" => BothSigCodex::ECDSA_256k1,
-            "0A" => BothSigCodex::Ed448,
-            "2A" => BothSigCodex::Ed25519_Big,
-            "2C" => BothSigCodex::ECDSA_256k1_Big,
-            "3A" => BothSigCodex::Ed448_Big,
-            _ => return Err(Box::new(Error::UnexpectedCode(code.to_string()))),
-        })
-    }
+    pub const Ed25519: &str = "A"; // Ed25519 sig appears same in both lists if any.
+    pub const ECDSA_256k1: &str = "C"; // ECDSA secp256k1 sig appears same in both lists if any.
+    pub const Ed448: &str = "0A"; // Ed448 signature appears in both lists.
+    pub const Ed25519_Big: &str = "2A"; // Ed25519 sig appears in both listsy.
+    pub const ECDSA_256k1_Big: &str = "2C"; // ECDSA secp256k1 sig appears in both lists.
+    pub const Ed448_Big: &str = "3A"; // Ed448 signature appears in both lists.
 
     pub(crate) fn has_code(code: &str) -> bool {
         lazy_static! {
-            static ref CODES: Vec<&'static str> = vec![
-                BothSigCodex::Ed25519.code(),
-                BothSigCodex::ECDSA_256k1.code(),
-                BothSigCodex::Ed448.code(),
-                BothSigCodex::Ed25519_Big.code(),
-                BothSigCodex::ECDSA_256k1_Big.code(),
-                BothSigCodex::Ed448_Big.code(),
-            ];
+            static ref CODES: Vec<&'static str> =
+                vec![Ed25519, ECDSA_256k1, Ed448, Ed25519_Big, ECDSA_256k1_Big, Ed448_Big];
         }
 
         CODES.contains(&code)
@@ -321,9 +186,8 @@ mod index_tables_tests {
     #[case(Codex::TBD0, "0z")]
     #[case(Codex::TBD1, "1z")]
     #[case(Codex::TBD4, "4z")]
-    fn test_codex(#[case] variant: Codex, #[case] code: &str) {
-        assert_eq!(variant.code(), code);
-        assert_eq!(Codex::from_code(code).unwrap(), variant);
+    fn test_codex(#[case] code: &str, #[case] value: &str) {
+        assert_eq!(code, value);
     }
 
     #[rstest]
@@ -339,9 +203,8 @@ mod index_tables_tests {
     #[case(SigCodex::ECDSA_256k1_Big_Crt, "2D")]
     #[case(SigCodex::Ed448_Big, "3A")]
     #[case(SigCodex::Ed448_Big_Crt, "3B")]
-    fn test_sig_code(#[case] variant: SigCodex, #[case] code: &str) {
-        assert_eq!(variant.code(), code);
-        assert_eq!(SigCodex::from_code(code).unwrap(), variant);
+    fn test_sig_codex(#[case] code: &str, #[case] value: &str) {
+        assert_eq!(code, value);
     }
 
     #[rstest]
@@ -351,9 +214,8 @@ mod index_tables_tests {
     #[case(CurrentSigCodex::Ed25519_Big_Crt, "2B")]
     #[case(CurrentSigCodex::ECDSA_256k1_Big_Crt, "2D")]
     #[case(CurrentSigCodex::Ed448_Big_Crt, "3B")]
-    fn test_current_code(#[case] variant: CurrentSigCodex, #[case] code: &str) {
-        assert_eq!(variant.code(), code);
-        assert_eq!(CurrentSigCodex::from_code(code).unwrap(), variant);
+    fn test_current_sig_codex(#[case] code: &str, #[case] value: &str) {
+        assert_eq!(code, value);
     }
 
     #[rstest]
@@ -363,9 +225,8 @@ mod index_tables_tests {
     #[case(BothSigCodex::Ed25519_Big, "2A")]
     #[case(BothSigCodex::ECDSA_256k1_Big, "2C")]
     #[case(BothSigCodex::Ed448_Big, "3A")]
-    fn test_both_code(#[case] variant: BothSigCodex, #[case] code: &str) {
-        assert_eq!(variant.code(), code);
-        assert_eq!(BothSigCodex::from_code(code).unwrap(), variant);
+    fn test_both_sig_codex(#[case] code: &str, #[case] value: &str) {
+        assert_eq!(code, value);
     }
 
     #[rstest]
@@ -509,25 +370,5 @@ mod index_tables_tests {
     #[test]
     fn test_unknown_bardage() {
         assert!(bardage(0x39).is_err());
-    }
-
-    #[test]
-    fn test_sig_codex_from_code() {
-        assert!(SigCodex::from_code("ZZ").is_err());
-    }
-
-    #[test]
-    fn test_codex_from_code() {
-        assert!(Codex::from_code("ZZ").is_err());
-    }
-
-    #[test]
-    fn test_current_sig_from_code() {
-        assert!(CurrentSigCodex::from_code("ZZ").is_err());
-    }
-
-    #[test]
-    fn test_both_sig_from_code() {
-        assert!(BothSigCodex::from_code("ZZ").is_err());
     }
 }

--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -476,7 +476,7 @@ mod matter_tests {
     }
     impl Default for TestMatter {
         fn default() -> Self {
-            TestMatter { raw: vec![], code: matter::Codex::Blake3_256.code().to_string(), size: 0 }
+            TestMatter { raw: vec![], code: matter::Codex::Blake3_256.to_string(), size: 0 }
         }
     }
     impl Matter for TestMatter {
@@ -506,18 +506,18 @@ mod matter_tests {
     }
 
     #[rstest]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_L0.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_L1.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_L2.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_L0.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_L1.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_L2.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_Big_L0.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_Big_L1.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_Big_L2.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_Big_L0.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_Big_L1.code())]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_Big_L2.code())]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_L0)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_L1)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_L2)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_L0)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_L1)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_L2)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_Big_L0)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_Big_L1)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_Big_L2)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_Big_L0)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_Big_L1)]
+    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_Big_L2)]
     fn test_matter_new_variable_length(#[case] raw: &Vec<u8>, #[case] code: &str) {
         let m = TestMatter::new_with_code_and_raw(code, raw).unwrap();
         let m2 = TestMatter::new_with_qb64(&m.qb64().unwrap()).unwrap();
@@ -534,7 +534,7 @@ mod matter_tests {
     fn test_defaults_and_overrides() {
         // default
         let m = TestMatter::default();
-        assert_eq!(m.code, matter::Codex::Blake3_256.code());
+        assert_eq!(m.code, matter::Codex::Blake3_256);
 
         // partial override
         let m = TestMatter { size: 3, ..Default::default() };
@@ -543,12 +543,12 @@ mod matter_tests {
         // full override
         let m = TestMatter {
             raw: b"a".to_vec(),
-            code: matter::Codex::X25519_Cipher_Seed.code().to_string(),
+            code: matter::Codex::X25519_Cipher_Seed.to_string(),
             size: 1,
         };
 
         assert_eq!(m.raw, b"a".to_vec());
-        assert_eq!(m.code, matter::Codex::X25519_Cipher_Seed.code());
+        assert_eq!(m.code, matter::Codex::X25519_Cipher_Seed);
         assert_eq!(m.size, 1);
     }
 
@@ -558,7 +558,7 @@ mod matter_tests {
 
         // basic
         let m = TestMatter::new_with_qb64(qb64).unwrap();
-        assert_eq!(m.code, matter::Codex::Ed25519N.code());
+        assert_eq!(m.code, matter::Codex::Ed25519N);
 
         // qb64
         let m2 = TestMatter::new_with_code_and_raw(&m.code, &m.raw).unwrap();
@@ -585,17 +585,16 @@ mod matter_tests {
     #[test]
     fn test_big_boundary() {
         let m =
-            TestMatter::new_with_code_and_raw(matter::Codex::Bytes_L2.code(), &[0; 4095 * 3 + 1])
-                .unwrap();
+            TestMatter::new_with_code_and_raw(matter::Codex::Bytes_L2, &[0; 4095 * 3 + 1]).unwrap();
         assert_eq!(m.raw().len(), 4095 * 3 + 1);
-        assert_eq!(m.code(), matter::Codex::Bytes_Big_L2.code());
+        assert_eq!(m.code(), matter::Codex::Bytes_Big_L2);
     }
 
     #[test]
     fn test_unhappy_paths() {
         // empty material
         assert!(TestMatter::new_with_code_and_raw("", &[]).is_err());
-        assert!(TestMatter::new_with_code_and_raw(matter::Codex::Blake3_256.code(), &[]).is_err());
+        assert!(TestMatter::new_with_code_and_raw(matter::Codex::Blake3_256, &[]).is_err());
         assert!(TestMatter::new_with_qb64("").is_err());
         assert!(TestMatter::new_with_qb64b(&[]).is_err());
         assert!(TestMatter::new_with_qb2(&[]).is_err());
@@ -605,7 +604,7 @@ mod matter_tests {
 
         // invalid code/raw size combination
         assert!(TestMatter {
-            code: matter::Codex::Blake3_256.code().to_string(),
+            code: matter::Codex::Blake3_256.to_string(),
             size: 32,
             raw: [0; 31].to_vec(),
         }
@@ -626,39 +625,39 @@ mod matter_tests {
 
         // raw size too large
         assert!(TestMatter::new_with_code_and_raw(
-            matter::Codex::Bytes_Big_L2.code(),
+            matter::Codex::Bytes_Big_L2,
             &[0; (16777215 * 3 + 1)],
         )
         .is_err());
         assert!(TestMatter::new_with_code_and_raw(
-            matter::Codex::Bytes_L2.code(),
+            matter::Codex::Bytes_L2,
             &[0; (16777215 * 3 + 1)],
         )
         .is_err());
 
         assert!(TestMatter {
-            code: matter::Codex::Bytes_L2.code().to_string(),
+            code: matter::Codex::Bytes_L2.to_string(),
             size: 4096,
             raw: [0; 4096].to_vec()
         }
         .qb64()
         .is_err());
         assert!(TestMatter {
-            code: matter::Codex::Bytes_L2.code().to_string(),
+            code: matter::Codex::Bytes_L2.to_string(),
             size: 4096,
             raw: [0; 4096].to_vec(),
         }
         .qb2()
         .is_err());
         assert!(TestMatter {
-            code: matter::Codex::Bytes_L1.code().to_string(),
+            code: matter::Codex::Bytes_L1.to_string(),
             size: 4095,
             raw: [0; 3].to_vec(),
         }
         .qb64()
         .is_err());
         assert!(TestMatter {
-            code: matter::Codex::Bytes_L1.code().to_string(),
+            code: matter::Codex::Bytes_L1.to_string(),
             size: 4095,
             raw: [0; 3].to_vec(),
         }

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -87,160 +87,55 @@ pub(crate) fn bardage(b: u8) -> Result<u32> {
     }
 }
 
-#[allow(non_camel_case_types)]
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub enum Codex {
-    Ed25519_Seed,
-    Ed25519N,
-    X25519,
-    Ed25519,
-    Blake3_256,
-    Blake2b_256,
-    Blake2s_256,
-    SHA3_256,
-    SHA2_256,
-    ECDSA_256k1_Seed,
-    Ed448_Seed,
-    X448,
-    Short,
-    Big,
-    X25519_Private,
-    X25519_Cipher_Seed,
-    Salt_128,
-    Ed25519_Sig,
-    ECDSA_256k1_Sig,
-    Blake3_512,
-    Blake2b_512,
-    SHA3_512,
-    SHA2_512,
-    Long,
-    ECDSA_256k1N,
-    ECDSA_256k1,
-    Ed448N,
-    Ed448,
-    Ed448_Sig,
-    Tern,
-    DateTime,
-    X25519_Cipher_Salt,
-    TBD1,
-    TBD2,
-    StrB64_L0,
-    StrB64_L1,
-    StrB64_L2,
-    StrB64_Big_L0,
-    StrB64_Big_L1,
-    StrB64_Big_L2,
-    Bytes_L0,
-    Bytes_L1,
-    Bytes_L2,
-    Bytes_Big_L0,
-    Bytes_Big_L1,
-    Bytes_Big_L2,
-}
-
-impl Codex {
-    pub(crate) fn code(&self) -> &'static str {
-        match self {
-            Codex::Ed25519_Seed => "A", // Ed25519 256 bit random seed for private key
-            Codex::Ed25519N => "B", // Ed25519 verification key non-transferable, basic derivation.
-            Codex::X25519 => "C", // X25519 public encryption key, converted from Ed25519 or Ed25519N.
-            Codex::Ed25519 => "D", // Ed25519 verification key basic derivation
-            Codex::Blake3_256 => "E", // Blake3 256 bit digest self-addressing derivation.
-            Codex::Blake2b_256 => "F", // Blake2b 256 bit digest self-addressing derivation.
-            Codex::Blake2s_256 => "G", // Blake2s 256 bit digest self-addressing derivation.
-            Codex::SHA3_256 => "H", // SHA3 256 bit digest self-addressing derivation.
-            Codex::SHA2_256 => "I", // SHA2 256 bit digest self-addressing derivation.
-            Codex::ECDSA_256k1_Seed => "J", // ECDSA secp256k1 256 bit random Seed for private key
-            Codex::Ed448_Seed => "K", // Ed448 448 bit random Seed for private key
-            Codex::X448 => "L",   // X448 public encryption key, converted from Ed448
-            Codex::Short => "M",  // Short 2 byte b2 number
-            Codex::Big => "N",    // Big 8 byte b2 number
-            Codex::X25519_Private => "O", // X25519 private decryption key converted from Ed25519
-            Codex::X25519_Cipher_Seed => "P", // X25519 124 char b64 Cipher of 44 char qb64 Seed
-            Codex::Salt_128 => "0A", // 128 bit random salt or 128 bit number (see Huge)
-            Codex::Ed25519_Sig => "0B", // Ed25519 signature.
-            Codex::ECDSA_256k1_Sig => "0C", // ECDSA secp256k1 signature.
-            Codex::Blake3_512 => "0D", // Blake3 512 bit digest self-addressing derivation.
-            Codex::Blake2b_512 => "0E", // Blake2b 512 bit digest self-addressing derivation.
-            Codex::SHA3_512 => "0F", // SHA3 512 bit digest self-addressing derivation.
-            Codex::SHA2_512 => "0G", // SHA2 512 bit digest self-addressing derivation.
-            Codex::Long => "0H",  // Long 4 byte b2 number
-            Codex::ECDSA_256k1N => "1AAA", // ECDSA secp256k1 verification key non-transferable, basic derivation.
-            Codex::ECDSA_256k1 => "1AAB", // Ed25519 public verification or encryption key, basic derivation
-            Codex::Ed448N => "1AAC", // Ed448 non-transferable prefix public signing verification key. Basic derivation.
-            Codex::Ed448 => "1AAD",  // Ed448 public signing verification key. Basic derivation.
-            Codex::Ed448_Sig => "1AAE", // Ed448 signature. Self-signing derivation.
-            Codex::Tern => "1AAF",   // 3 byte b2 number or 4 char B64 str.
-            Codex::DateTime => "1AAG", // Base64 custom encoded 32 char ISO-8601 DateTime
-            Codex::X25519_Cipher_Salt => "1AAH", // X25519 100 char b64 Cipher of 24 char qb64 Salt
-            Codex::TBD1 => "2AAA",   // Testing purposes only fixed with lead size 1
-            Codex::TBD2 => "3AAA",   // Testing purposes only of fixed with lead size 2
-            Codex::StrB64_L0 => "4A", // String Base64 Only Lead Size 0 (4095 * 3 | 4)
-            Codex::StrB64_L1 => "5A", // String Base64 Only Lead Size 1
-            Codex::StrB64_L2 => "6A", // String Base64 Only Lead Size 2
-            Codex::StrB64_Big_L0 => "7AAA", // String Base64 Only Big Lead Size 0 (16777215 * 3 | 4)
-            Codex::StrB64_Big_L1 => "8AAA", // String Base64 Only Big Lead Size 1
-            Codex::StrB64_Big_L2 => "9AAA", // String Base64 Only Big Lead Size 2
-            Codex::Bytes_L0 => "4B", // Byte String Leader Size 0
-            Codex::Bytes_L1 => "5B", // Byte String Leader Size 1
-            Codex::Bytes_L2 => "6B", // Byte String Leader Size 2
-            Codex::Bytes_Big_L0 => "7AAB", // Byte String Big Leader Size 0
-            Codex::Bytes_Big_L1 => "8AAB", // Byte String Big Leader Size 1
-            Codex::Bytes_Big_L2 => "9AAB", // Byte String Big Leader Size 2
-        }
-    }
-
-    pub(crate) fn from_code(code: &str) -> Result<Self> {
-        Ok(match code {
-            "A" => Codex::Ed25519_Seed,
-            "B" => Codex::Ed25519N,
-            "C" => Codex::X25519,
-            "D" => Codex::Ed25519,
-            "E" => Codex::Blake3_256,
-            "F" => Codex::Blake2b_256,
-            "G" => Codex::Blake2s_256,
-            "H" => Codex::SHA3_256,
-            "I" => Codex::SHA2_256,
-            "J" => Codex::ECDSA_256k1_Seed,
-            "K" => Codex::Ed448_Seed,
-            "L" => Codex::X448,
-            "M" => Codex::Short,
-            "N" => Codex::Big,
-            "O" => Codex::X25519_Private,
-            "P" => Codex::X25519_Cipher_Seed,
-            "0A" => Codex::Salt_128,
-            "0B" => Codex::Ed25519_Sig,
-            "0C" => Codex::ECDSA_256k1_Sig,
-            "0D" => Codex::Blake3_512,
-            "0E" => Codex::Blake2b_512,
-            "0F" => Codex::SHA3_512,
-            "0G" => Codex::SHA2_512,
-            "0H" => Codex::Long,
-            "1AAA" => Codex::ECDSA_256k1N,
-            "1AAB" => Codex::ECDSA_256k1,
-            "1AAC" => Codex::Ed448N,
-            "1AAD" => Codex::Ed448,
-            "1AAE" => Codex::Ed448_Sig,
-            "1AAF" => Codex::Tern,
-            "1AAG" => Codex::DateTime,
-            "1AAH" => Codex::X25519_Cipher_Salt,
-            "2AAA" => Codex::TBD1,
-            "3AAA" => Codex::TBD2,
-            "4A" => Codex::StrB64_L0,
-            "5A" => Codex::StrB64_L1,
-            "6A" => Codex::StrB64_L2,
-            "7AAA" => Codex::StrB64_Big_L0,
-            "8AAA" => Codex::StrB64_Big_L1,
-            "9AAA" => Codex::StrB64_Big_L2,
-            "4B" => Codex::Bytes_L0,
-            "5B" => Codex::Bytes_L1,
-            "6B" => Codex::Bytes_L2,
-            "7AAB" => Codex::Bytes_Big_L0,
-            "8AAB" => Codex::Bytes_Big_L1,
-            "9AAB" => Codex::Bytes_Big_L2,
-            _ => return err!(Error::UnexpectedCode(code.to_string())),
-        })
-    }
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod Codex {
+    pub const Ed25519_Seed: &str = "A"; // Ed25519 256 bit random seed for private key
+    pub const Ed25519N: &str = "B"; // Ed25519 verification key non-transferable, basic derivation.
+    pub const X25519: &str = "C"; // X25519 public encryption key, converted from Ed25519 or Ed25519N.
+    pub const Ed25519: &str = "D"; // Ed25519 verification key basic derivation
+    pub const Blake3_256: &str = "E"; // Blake3 256 bit digest self-addressing derivation.
+    pub const Blake2b_256: &str = "F"; // Blake2b 256 bit digest self-addressing derivation.
+    pub const Blake2s_256: &str = "G"; // Blake2s 256 bit digest self-addressing derivation.
+    pub const SHA3_256: &str = "H"; // SHA3 256 bit digest self-addressing derivation.
+    pub const SHA2_256: &str = "I"; // SHA2 256 bit digest self-addressing derivation.
+    pub const ECDSA_256k1_Seed: &str = "J"; // ECDSA secp256k1 256 bit random Seed for private key
+    pub const Ed448_Seed: &str = "K"; // Ed448 448 bit random Seed for private key
+    pub const X448: &str = "L"; // X448 public encryption key, converted from Ed448
+    pub const Short: &str = "M"; // Short 2 byte b2 number
+    pub const Big: &str = "N"; // Big 8 byte b2 number
+    pub const X25519_Private: &str = "O"; // X25519 private decryption key converted from Ed25519
+    pub const X25519_Cipher_Seed: &str = "P"; // X25519 124 char b64 Cipher of 44 char qb64 Seed
+    pub const Salt_128: &str = "0A"; // 128 bit random salt or 128 bit number (see Huge)
+    pub const Ed25519_Sig: &str = "0B"; // Ed25519 signature.
+    pub const ECDSA_256k1_Sig: &str = "0C"; // ECDSA secp256k1 signature.
+    pub const Blake3_512: &str = "0D"; // Blake3 512 bit digest self-addressing derivation.
+    pub const Blake2b_512: &str = "0E"; // Blake2b 512 bit digest self-addressing derivation.
+    pub const SHA3_512: &str = "0F"; // SHA3 512 bit digest self-addressing derivation.
+    pub const SHA2_512: &str = "0G"; // SHA2 512 bit digest self-addressing derivation.
+    pub const Long: &str = "0H"; // Long 4 byte b2 number
+    pub const ECDSA_256k1N: &str = "1AAA"; // ECDSA secp256k1 verification key non-transferable, basic derivation.
+    pub const ECDSA_256k1: &str = "1AAB"; // Ed25519 public verification or encryption key, basic derivation
+    pub const Ed448N: &str = "1AAC"; // Ed448 non-transferable prefix public signing verification key. Basic derivation.
+    pub const Ed448: &str = "1AAD"; // Ed448 public signing verification key. Basic derivation.
+    pub const Ed448_Sig: &str = "1AAE"; // Ed448 signature. Self-signing derivation.
+    pub const Tern: &str = "1AAF"; // 3 byte b2 number or 4 char B64 str.
+    pub const DateTime: &str = "1AAG"; // Base64 custom encoded 32 char ISO-8601 DateTime
+    pub const X25519_Cipher_Salt: &str = "1AAH"; // X25519 100 char b64 Cipher of 24 char qb64 Salt
+    pub const TBD1: &str = "2AAA"; // Testing purposes only fixed with lead size 1
+    pub const TBD2: &str = "3AAA"; // Testing purposes only of fixed with lead size 2
+    pub const StrB64_L0: &str = "4A"; // String Base64 Only Lead Size 0 (4095 * 3 | 4)
+    pub const StrB64_L1: &str = "5A"; // String Base64 Only Lead Size 1
+    pub const StrB64_L2: &str = "6A"; // String Base64 Only Lead Size 2
+    pub const StrB64_Big_L0: &str = "7AAA"; // String Base64 Only Big Lead Size 0 (16777215 * 3 | 4)
+    pub const StrB64_Big_L1: &str = "8AAA"; // String Base64 Only Big Lead Size 1
+    pub const StrB64_Big_L2: &str = "9AAA"; // String Base64 Only Big Lead Size 2
+    pub const Bytes_L0: &str = "4B"; // Byte String Leader Size 0
+    pub const Bytes_L1: &str = "5B"; // Byte String Leader Size 1
+    pub const Bytes_L2: &str = "6B"; // Byte String Leader Size 2
+    pub const Bytes_Big_L0: &str = "7AAB"; // Byte String Big Leader Size 0
+    pub const Bytes_Big_L1: &str = "8AAB"; // Byte String Big Leader Size 1
+    pub const Bytes_Big_L2: &str = "9AAB"; // Byte String Big Leader Size 2
 }
 
 #[cfg(test)]
@@ -423,9 +318,8 @@ mod tables_tests {
     #[case(Codex::Bytes_Big_L0, "7AAB")]
     #[case(Codex::Bytes_Big_L1, "8AAB")]
     #[case(Codex::Bytes_Big_L2, "9AAB")]
-    fn test_codes(#[case] variant: Codex, #[case] code: &str) {
-        assert_eq!(variant.code(), code);
-        assert_eq!(Codex::from_code(code).unwrap(), variant);
+    fn test_codes(#[case] code: &str, #[case] value: &str) {
+        assert_eq!(code, value);
     }
 
     #[test]
@@ -434,6 +328,5 @@ mod tables_tests {
         assert!(hardage('_').is_err());
         assert!(hardage('#').is_err());
         assert!(bardage(0x40).is_err());
-        assert!(Codex::from_code("CESR").is_err());
     }
 }

--- a/src/core/siger.rs
+++ b/src/core/siger.rs
@@ -17,7 +17,7 @@ impl Default for Siger {
     fn default() -> Self {
         Siger {
             raw: vec![],
-            code: indexer::Codex::Ed25519.code().to_string(),
+            code: indexer::Codex::Ed25519.to_string(),
             index: 0,
             ondex: 0,
             verfer: Verfer::default(),
@@ -28,18 +28,18 @@ impl Default for Siger {
 fn validate_code(code: &str) -> Result<()> {
     lazy_static! {
         static ref CODES: Vec<&'static str> = vec![
-            indexer::Codex::Ed25519.code(),
-            indexer::Codex::Ed25519_Crt.code(),
-            indexer::Codex::ECDSA_256k1.code(),
-            indexer::Codex::ECDSA_256k1_Crt.code(),
-            indexer::Codex::Ed448.code(),
-            indexer::Codex::Ed448_Crt.code(),
-            indexer::Codex::Ed25519_Big.code(),
-            indexer::Codex::Ed25519_Big_Crt.code(),
-            indexer::Codex::ECDSA_256k1_Big.code(),
-            indexer::Codex::ECDSA_256k1_Big_Crt.code(),
-            indexer::Codex::Ed448_Big.code(),
-            indexer::Codex::Ed448_Big_Crt.code(),
+            indexer::Codex::Ed25519,
+            indexer::Codex::Ed25519_Crt,
+            indexer::Codex::ECDSA_256k1,
+            indexer::Codex::ECDSA_256k1_Crt,
+            indexer::Codex::Ed448,
+            indexer::Codex::Ed448_Crt,
+            indexer::Codex::Ed25519_Big,
+            indexer::Codex::Ed25519_Big_Crt,
+            indexer::Codex::ECDSA_256k1_Big,
+            indexer::Codex::ECDSA_256k1_Big_Crt,
+            indexer::Codex::Ed448_Big,
+            indexer::Codex::Ed448_Big_Crt,
         ];
     }
 
@@ -154,7 +154,7 @@ mod test_siger {
         let qsig64b = qsig64.as_bytes();
 
         let siger = Siger::new_with_qb64b(None, qsig64b).unwrap();
-        assert_eq!(siger.code(), indexer::Codex::Ed25519.code());
+        assert_eq!(siger.code(), indexer::Codex::Ed25519);
         assert_eq!(siger.index(), 0);
         assert_eq!(siger.ondex(), 0);
         assert_eq!(siger.qb64().unwrap(), qsig64);
@@ -162,7 +162,7 @@ mod test_siger {
         assert_eq!(siger.verfer(), Verfer::default());
 
         let mut siger = Siger::new_with_qb64(None, qsig64).unwrap();
-        assert_eq!(siger.code(), indexer::Codex::Ed25519.code());
+        assert_eq!(siger.code(), indexer::Codex::Ed25519);
         assert_eq!(siger.index(), 0);
         assert_eq!(siger.ondex(), 0);
         assert_eq!(siger.qb64().unwrap(), qsig64);
@@ -171,7 +171,7 @@ mod test_siger {
 
         let verfer_raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa");
 
-        let verfer_code = matter::Codex::Ed25519.code();
+        let verfer_code = matter::Codex::Ed25519;
         let verfer = Verfer::new_with_code_and_raw(verfer_code, &verfer_raw).unwrap();
 
         siger.set_verfer(&verfer);
@@ -182,7 +182,7 @@ mod test_siger {
 
         let raw = b"abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdef";
         let siger =
-            Siger::new_with_code_and_raw(None, indexer::Codex::Ed448.code(), raw, 4, None).unwrap();
+            Siger::new_with_code_and_raw(None, indexer::Codex::Ed448, raw, 4, None).unwrap();
         assert_eq!(siger.qb64().unwrap(), "0AEEYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVm");
     }
 
@@ -190,10 +190,10 @@ mod test_siger {
     fn test_new_with_code_and_raw() {
         let verfer_raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa");
 
-        let verfer_code = matter::Codex::Ed25519.code();
+        let verfer_code = matter::Codex::Ed25519;
         let verfer = Verfer::new_with_code_and_raw(verfer_code, &verfer_raw).unwrap();
 
-        let siger_code = indexer::Codex::Ed25519.code();
+        let siger_code = indexer::Codex::Ed25519;
         let siger_raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa"
                                        "0123456789abcdef00001111222233334444555566667777888899990000aaaa");
 
@@ -207,7 +207,7 @@ mod test_siger {
     fn test_new_with_qb64b() {
         let verfer_raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa");
 
-        let verfer_code = matter::Codex::Ed25519.code();
+        let verfer_code = matter::Codex::Ed25519;
         let verfer = Verfer::new_with_code_and_raw(verfer_code, &verfer_raw).unwrap();
 
         let qsig64 = "AACdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ";
@@ -221,7 +221,7 @@ mod test_siger {
     fn test_new_with_qb2() {
         let verfer_raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa");
 
-        let verfer_code = matter::Codex::Ed25519.code();
+        let verfer_code = matter::Codex::Ed25519;
         let verfer = Verfer::new_with_code_and_raw(verfer_code, &verfer_raw).unwrap();
 
         let qsig2 = b64_engine::URL_SAFE.decode("AACdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ").unwrap();


### PR DESCRIPTION
## Rationale

This cleans up the Codexes and may allow us to bypass the FFI problem we were having with `uniffi`. In general it seems like a really good change, thanks to Joseph for suggesting it in a CESR meeting.

## Changes

In general, this changes code like this:

```
Codex::SomeVariant.code()
```

to this:

```
Codex::SomeVariant
```

- converts `Codex` enums to modules, making the variants constants.
- `has_code()` was easy to modify to be a function in the module, the consuming code didn't change

## Testing

```
make clean preflight
```