### PR TITLE
saider

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,18 +14,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Install stable toolchain
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           override: true
 
+      - name: Format
+        run: cargo fmt --all -- --check
+
       - name: Check
         run: cargo check
 
       - name: Clippy
-        run: RUSTFLAGS="-Dwarnings" cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings
 
       - name: Build
         run: cargo build --release
@@ -33,13 +38,10 @@ jobs:
       - name: Test
         run: cargo test --release
 
-      - name: Format
-        run: cargo fmt --all -- --check
-
-      - name: Security Audit
+      - name: Audit
         run: cargo audit
 
-      - name: Run cargo-tarpaulin
+      - name: Tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
           version: '0.22.0'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,13 @@ blake2 = "~0.10"
 blake3 = "~1"
 chrono = { version = "~0.4", default-features = false, features = ["clock"] }
 ed25519-dalek = "~1"
+indexmap = "~1"
 k256 = "~0.12"
 lazy_static = "~1"
 rand = "0.7.0" # this needs pinning for one of the seeding pieces of a signing suite
 rand_core = "~0.6"
+regex = "~1"
+serde_json = { version = "~1", features = ["preserve_order"] }
 sha2 = "~0.10"
 sha3 = "~0.10"
 thiserror = "~1"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Cryptographic primitives for use with Composable Event Streaming Representation (CESR).
 
+This library is **currently under construction**. If you want to help build, see [contributing](#contributing) below.
+
 ## Important Reference Material
 - WebOfTrust/[ietf-cesr](https://github.com/WebOfTrust/ietf-cesr) repository - IETF draft specification for CESR
 - Design Assumptions, Use Cases, and ToDo list - [HackMD link](https://hackmd.io/W2Z39cuSSTmD2TovVLvAPg?view)

--- a/src/core/cigar.rs
+++ b/src/core/cigar.rs
@@ -104,13 +104,13 @@ impl Matter for Cigar {
 }
 
 #[cfg(test)]
-mod test_cigar {
+mod test {
     use crate::core::cigar::Cigar;
     use crate::core::matter::{tables as matter, Matter};
     use crate::core::verfer::Verfer;
 
     #[test]
-    fn test_new_with_code_and_raw() {
+    fn new_with_code_and_raw() {
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
         let verfer = Verfer::new_with_code_and_raw(vcode, vraw).unwrap();
@@ -126,7 +126,7 @@ mod test_cigar {
 
     // this test was ported from KERIpy
     #[test]
-    fn test_new_with_qb64() {
+    fn new_with_qb64() {
         let qsig64 = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ";
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
@@ -142,7 +142,7 @@ mod test_cigar {
     }
 
     #[test]
-    fn test_new_with_qb64b() {
+    fn new_with_qb64b() {
         let qsig64b = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ".as_bytes();
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
@@ -158,7 +158,7 @@ mod test_cigar {
     }
 
     #[test]
-    fn test_new_with_qb2() {
+    fn new_with_qb2() {
         let qb2 = [
             208, 16, 157, 35, 195, 146, 66, 67, 9, 246, 191, 177, 138, 8, 196, 7, 33, 35, 34, 230,
             187, 44, 113, 247, 0, 226, 118, 216, 244, 10, 170, 88, 204, 134, 232, 92, 130, 31, 103,
@@ -179,7 +179,7 @@ mod test_cigar {
     }
 
     #[test]
-    fn test_set_verfer() {
+    fn set_verfer() {
         let qsig64 = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ";
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
@@ -197,7 +197,7 @@ mod test_cigar {
     }
 
     #[test]
-    fn test_unhappy_paths() {
+    fn unhappy_paths() {
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
         let verfer = Verfer::new_with_code_and_raw(vcode, vraw).unwrap();

--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -1,0 +1,209 @@
+use crate::data::{data, Data, Value};
+use crate::error::{err, Error, Result};
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SizeifyResult {
+    pub(crate) raw: Vec<u8>,
+    pub(crate) ident: String,
+    pub(crate) kind: String,
+    pub(crate) ked: Value,
+    pub(crate) version: Version,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DeversifyResult {
+    pub(crate) ident: String,
+    pub(crate) kind: String,
+    pub(crate) version: Version,
+    pub(crate) size: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Version {
+    pub(crate) major: u8,
+    pub(crate) minor: u8,
+}
+
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub(crate) mod Serialage {
+    pub const JSON: &str = "JSON";
+}
+
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub(crate) mod Identage {
+    pub const ACDC: &str = "ACDC";
+    pub const KERI: &str = "KERI";
+}
+
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub(crate) mod Ids {
+    pub const dollar: &str = "$id";
+    pub const at: &str = "@id";
+    pub const id: &str = "id";
+    pub const i: &str = "i";
+    pub const d: &str = "d";
+}
+
+const REVER_STRING: &str = "(?P<ident>[A-Z]{4})(?P<major>[0-9a-f])(?P<minor>[0-9a-f])(?P<kind>[A-Z]{4})(?P<size>[0-9a-f]{6})_";
+const IDENTS: &[&str] = &[Identage::ACDC, Identage::KERI];
+const SERIALS: &[&str] = &[Serialage::JSON];
+
+const CURRENT_VERSION: &Version = &Version { major: 1, minor: 0 };
+
+pub(crate) fn deversify(vs: &str) -> Result<DeversifyResult> {
+    lazy_static! {
+        static ref REVER: Regex = Regex::new(REVER_STRING).unwrap();
+    };
+
+    if REVER.is_match(vs) {
+        let ident = REVER.replace_all(vs, "$ident").to_string();
+        let major = u8::from_str_radix(&REVER.replace_all(vs, "$major"), 16)?;
+        let minor = u8::from_str_radix(&REVER.replace_all(vs, "$minor"), 16)?;
+        let kind = REVER.replace_all(vs, "$kind").to_string();
+        let size = u32::from_str_radix(&REVER.replace_all(vs, "$size"), 16)?;
+
+        if !IDENTS.contains(&ident.as_str()) {
+            return err!(Error::Validation(format!("invalid ident {ident}")));
+        }
+
+        if !SERIALS.contains(&kind.as_str()) {
+            return err!(Error::Validation(format!("invalid serialization kind {kind}")));
+        }
+
+        return Ok(DeversifyResult { ident, kind, version: Version { major, minor }, size });
+    }
+
+    err!(Error::Validation(format!("invalid version string {vs}")))
+}
+
+pub(crate) fn sizeify(ked: &Value, kind: Option<&str>) -> Result<SizeifyResult> {
+    lazy_static! {
+        static ref REVER: Regex = Regex::new(REVER_STRING).unwrap();
+    };
+
+    if !ked.to_map()?.contains_key("v") {
+        return err!(Error::Value("missing or empty version string".to_string()));
+    }
+
+    let result = deversify(&ked["v"].to_string()?)?;
+    if result.version != *CURRENT_VERSION {
+        return err!(Error::Value(format!(
+            "unsupported version {}.{}",
+            result.version.major, result.version.minor
+        )));
+    }
+
+    let kind = if let Some(kind) = kind { kind.to_string() } else { result.kind };
+
+    if !SERIALS.contains(&kind.as_str()) {
+        return err!(Error::Value(format!("invalid serialization kind {kind}")));
+    }
+
+    let raw = &dumps(ked, Some(&kind))?;
+    let size = raw.len();
+
+    let start = match REVER.shortest_match(&String::from_utf8(raw.clone())?) {
+        Some(m) => m - 17,
+        // unreachable - deversify has been called which ensures this will match
+        None => return err!(Error::Value(format!("invalid version string in raw = {raw:?}"))),
+    };
+
+    if start > 12 {
+        return err!(Error::Value(format!(
+            "invalid version string in raw = {raw:?} start = {start}"
+        )));
+    }
+
+    let fore = raw[..start].to_vec();
+    let mut back = raw[start + 17..].to_vec();
+    let vs = versify(Some(&result.ident), Some(&result.version), Some(&kind), Some(size as u32))?;
+
+    let mut raw = fore;
+    raw.append(&mut vs.as_bytes().to_vec());
+    raw.append(&mut back);
+
+    if raw.len() != size {
+        // unreachable as we constructed this
+        return err!(Error::Value(format!("malformed version string size, version string = {vs}")));
+    }
+
+    let mut ked = ked.clone();
+    ked["v"] = data!(&vs);
+
+    Ok(SizeifyResult { raw, ident: result.ident, kind, ked, version: result.version })
+}
+
+pub(crate) fn versify(
+    ident: Option<&str>,
+    version: Option<&Version>,
+    kind: Option<&str>,
+    size: Option<u32>,
+) -> Result<String> {
+    let ident = ident.unwrap_or(Identage::KERI);
+    let version = version.unwrap_or(CURRENT_VERSION);
+    let kind = kind.unwrap_or(Serialage::JSON);
+    let size = size.unwrap_or(0);
+
+    if !IDENTS.contains(&ident) {
+        return err!(Error::Validation(format!("invalid ident {ident}")));
+    }
+
+    if !SERIALS.contains(&kind) {
+        return err!(Error::Validation(format!("invalid serialization kind {kind}")));
+    }
+
+    Ok(format!(
+        "{ident}{major:01x}{minor:01x}{kind}{size:06x}_",
+        major = version.major,
+        minor = version.minor
+    ))
+}
+
+pub(crate) fn dumps(ked: &Value, kind: Option<&str>) -> Result<Vec<u8>> {
+    let kind = kind.unwrap_or(Serialage::JSON);
+    match kind {
+        Serialage::JSON => Ok(ked.to_json()?.as_bytes().to_vec()),
+        _ => err!(Error::Value(format!("invalid serialization kind = {kind}"))),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core::common;
+    use crate::data::data;
+    use rstest::rstest;
+
+    #[test]
+    fn sizeify_sad_paths() {
+        assert!(common::sizeify(&data!({}), None).is_err());
+        assert!(common::sizeify(&data!({"v":"KERIffJSON000000_"}), None).is_err());
+        assert!(common::sizeify(&data!({"v":"KERI10JSON000000_"}), Some("CESR")).is_err());
+        assert!(
+            common::sizeify(&data!({"i":"filler entry","v":"KERI10JSON000000_"}), None).is_err()
+        );
+    }
+
+    #[test]
+    fn versify_sad_paths() {
+        assert!(common::versify(Some("CESR"), None, None, None).is_err());
+        assert!(common::versify(None, None, Some("CESR"), None).is_err());
+    }
+
+    #[rstest]
+    fn deversify_sad_paths(
+        #[values("CESR10JSON000000_", "KERI10CESR000000_", "KERIXXJSON000000_")] vs: &str,
+    ) {
+        assert!(common::deversify(vs).is_err());
+    }
+
+    #[test]
+    fn dumps_sad_paths() {
+        assert!(common::dumps(&data!({}), Some("CESR")).is_err());
+    }
+}

--- a/src/core/counter/tables.rs
+++ b/src/core/counter/tables.rs
@@ -70,8 +70,8 @@ pub mod Codex {
 }
 
 #[cfg(test)]
-mod tables_tests {
-    use crate::core::counter::tables::{bardage, hardage, sizage, Codex};
+mod test {
+    use crate::core::counter::tables as matter;
     use rstest::rstest;
 
     #[rstest]
@@ -90,8 +90,8 @@ mod tables_tests {
     #[case("-V", 2)]
     #[case("-0", 3)]
     #[case("--", 5)]
-    fn test_hardage(#[case] code: &str, #[case] hdg: u32) {
-        assert_eq!(hardage(code).unwrap(), hdg);
+    fn hardage(#[case] code: &str, #[case] hdg: u32) {
+        assert_eq!(matter::hardage(code).unwrap(), hdg);
     }
 
     #[rstest]
@@ -110,8 +110,8 @@ mod tables_tests {
     #[case(&[62, 21], 2)]
     #[case(&[62, 52], 3)]
     #[case(&[62, 62], 5)]
-    fn test_bardage(#[case] bard: &[u8], #[case] bdg: u32) {
-        assert_eq!(bardage(bard).unwrap(), bdg);
+    fn bardage(#[case] bard: &[u8], #[case] bdg: u32) {
+        assert_eq!(matter::bardage(bard).unwrap(), bdg);
     }
 
     #[rstest]
@@ -130,14 +130,14 @@ mod tables_tests {
     #[case("-V", 2, 2, 4, 0)]
     #[case("-0V", 3, 5, 8, 0)]
     #[case("--AAA", 5, 3, 8, 0)]
-    fn test_sizage(
+    fn sizage(
         #[case] code: &str,
         #[case] hs: u32,
         #[case] ss: u32,
         #[case] fs: u32,
         #[case] ls: u32,
     ) {
-        let s = sizage(code).unwrap();
+        let s = matter::sizage(code).unwrap();
         assert_eq!(s.hs, hs);
         assert_eq!(s.ss, ss);
         assert_eq!(s.fs, fs);
@@ -145,28 +145,28 @@ mod tables_tests {
     }
 
     #[rstest]
-    #[case(Codex::ControllerIdxSigs, "-A")]
-    #[case(Codex::WitnessIdxSigs, "-B")]
-    #[case(Codex::NonTransReceiptCouples, "-C")]
-    #[case(Codex::TransReceiptQuadruples, "-D")]
-    #[case(Codex::FirstSeenReplayCouples, "-E")]
-    #[case(Codex::TransIdxSigGroups, "-F")]
-    #[case(Codex::SealSourceCouples, "-G")]
-    #[case(Codex::TransLastIdxSigGroups, "-H")]
-    #[case(Codex::SealSourceTriples, "-I")]
-    #[case(Codex::SadPathSig, "-J")]
-    #[case(Codex::SadPathSigGroup, "-K")]
-    #[case(Codex::PathedMaterialQuadlets, "-L")]
-    #[case(Codex::AttachedMaterialQuadlets, "-V")]
-    #[case(Codex::BigAttachedMaterialQuadlets, "-0V")]
-    #[case(Codex::KERIProtocolStack, "--AAA")]
-    fn test_codex(#[case] code: &str, #[case] value: &str) {
+    #[case(matter::Codex::ControllerIdxSigs, "-A")]
+    #[case(matter::Codex::WitnessIdxSigs, "-B")]
+    #[case(matter::Codex::NonTransReceiptCouples, "-C")]
+    #[case(matter::Codex::TransReceiptQuadruples, "-D")]
+    #[case(matter::Codex::FirstSeenReplayCouples, "-E")]
+    #[case(matter::Codex::TransIdxSigGroups, "-F")]
+    #[case(matter::Codex::SealSourceCouples, "-G")]
+    #[case(matter::Codex::TransLastIdxSigGroups, "-H")]
+    #[case(matter::Codex::SealSourceTriples, "-I")]
+    #[case(matter::Codex::SadPathSig, "-J")]
+    #[case(matter::Codex::SadPathSigGroup, "-K")]
+    #[case(matter::Codex::PathedMaterialQuadlets, "-L")]
+    #[case(matter::Codex::AttachedMaterialQuadlets, "-V")]
+    #[case(matter::Codex::BigAttachedMaterialQuadlets, "-0V")]
+    #[case(matter::Codex::KERIProtocolStack, "--AAA")]
+    fn codex(#[case] code: &str, #[case] value: &str) {
         assert_eq!(code, value);
     }
 
     #[test]
-    fn test_unhappy_paths() {
-        assert!(sizage("CESR").is_err());
-        assert!(bardage(&[63, 0]).is_err());
+    fn unhappy_paths() {
+        assert!(matter::sizage("CESR").is_err());
+        assert!(matter::bardage(&[63, 0]).is_err());
     }
 }

--- a/src/core/dater.rs
+++ b/src/core/dater.rs
@@ -88,7 +88,7 @@ impl Dater {
     }
 
     fn dts(&self) -> Result<String> {
-        let hs = matter::sizage(&self.code)?.hs as usize;
+        let hs = matter::sizage(&self.code())?.hs as usize;
         let qb64 = self.qb64()?;
         Ok(b64_to_iso_8601(&qb64[hs..]))
     }
@@ -125,12 +125,12 @@ impl Matter for Dater {
 }
 
 #[cfg(test)]
-mod test_dater {
+mod test {
     use super::{matter, Dater, Matter};
     use rstest::rstest;
 
     #[rstest]
-    fn test_new_default(
+    fn new_default(
         #[values(
             &Dater::new_with_code_and_raw("", &[]).unwrap(),
             &Dater::new_with_dts("").unwrap(),
@@ -158,7 +158,7 @@ mod test_dater {
         b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xcd4",
         b"\xd4\x00\x06\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xcd4"
     )]
-    fn test_new_with_data(
+    fn new_with_data(
         #[case] dts: &str,
         #[case] dtqb64: &str,
         #[case] dtraw: &[u8],
@@ -190,20 +190,18 @@ mod test_dater {
         b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xff"
     )]
     #[case("", b"\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xcd4")]
-    fn test_unhappy_new_with_code_and_raw(#[case] code: &str, #[case] dtraw: &[u8]) {
+    fn unhappy_new_with_code_and_raw(#[case] code: &str, #[case] dtraw: &[u8]) {
         assert!(Dater::new_with_code_and_raw(code, dtraw).is_err());
     }
 
     #[rstest]
-    fn test_unhappy_new_with_dts(
-        #[values("not a date", "2020-08-22T17:50:09.988921-01")] dts: &str,
-    ) {
+    fn unhappy_new_with_dts(#[values("not a date", "2020-08-22T17:50:09.988921-01")] dts: &str) {
         assert!(Dater::new_with_dts(dts).is_err());
         assert!(Dater::new_with_dtsb(dts.as_bytes()).is_err());
     }
 
     #[rstest]
-    fn test_unhappy_new_with_qb64(
+    fn unhappy_new_with_qb64(
         #[values(
             "1ABG2020-08-22T17c50c09d988921-01c00",
             "1AAG2020-08-22T17c50c09d988921-01c",
@@ -216,7 +214,7 @@ mod test_dater {
     }
 
     #[rstest]
-    fn test_unhappy_new_with_qb2(
+    fn unhappy_new_with_qb2(
         #[values(
             b"\xd4\x01\x06\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5\xcd4",
             b"\xd4\x00\x06\xdbM\xb4\xfbO>\xdbd\xf5\xed\xcetsO]\xf7\xcf=\xdb_\xb4\xd5",

--- a/src/core/diger.rs
+++ b/src/core/diger.rs
@@ -1,10 +1,8 @@
-use blake2::Digest;
 use lazy_static::lazy_static;
 
 use crate::core::matter::{tables as matter, Matter};
+use crate::crypto::hash;
 use crate::error::{err, Error, Result};
-
-type Blake2b256 = blake2::Blake2b<blake2::digest::consts::U32>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Diger {
@@ -67,12 +65,12 @@ impl Diger {
 
     pub fn new_with_code_and_ser(code: &str, ser: &[u8]) -> Result<Self> {
         validate_code(code)?;
-        let dig = derive_digest(code, ser)?;
+        let dig = hash::digest(code, ser)?;
         Matter::new_with_code_and_raw(code, &dig)
     }
 
     fn verify(&self, ser: &[u8]) -> Result<bool> {
-        let dig = derive_digest(&self.code, ser)?;
+        let dig = hash::digest(&self.code(), ser)?;
         Ok(dig == self.raw())
     }
 
@@ -83,7 +81,7 @@ impl Diger {
 
         let diger = <Diger as Matter>::new_with_qb64b(dig)?;
 
-        if diger.code == self.code {
+        if diger.code() == self.code() {
             return Ok(false);
         }
 
@@ -100,7 +98,7 @@ impl Diger {
             return Ok(true);
         }
 
-        if diger.code == self.code {
+        if diger.code() == self.code() {
             return Ok(false);
         }
 
@@ -138,69 +136,15 @@ impl Matter for Diger {
     }
 }
 
-fn derive_digest(code: &str, ser: &[u8]) -> Result<Vec<u8>> {
-    let out = match code {
-        matter::Codex::Blake3_256 => blake3::hash(ser).as_bytes().to_vec(),
-        matter::Codex::Blake3_512 => {
-            let mut hasher = blake3::Hasher::new();
-            hasher.update(ser);
-            let mut buf: [u8; 64] = [0; 64];
-            hasher.finalize_xof().fill(&mut buf);
-            buf.to_vec()
-        }
-        matter::Codex::Blake2b_256 => {
-            let mut hasher = Blake2b256::new();
-            hasher.update(ser);
-            hasher.finalize().to_vec()
-        }
-        matter::Codex::Blake2b_512 => {
-            let mut hasher = blake2::Blake2b512::new();
-            hasher.update(ser);
-            hasher.finalize().to_vec()
-        }
-        matter::Codex::Blake2s_256 => {
-            let mut hasher = blake2::Blake2s256::new();
-            hasher.update(ser);
-            hasher.finalize().to_vec()
-        }
-        matter::Codex::SHA3_256 => {
-            let mut hasher = sha3::Sha3_256::new();
-            hasher.update(ser);
-            hasher.finalize().to_vec()
-        }
-        matter::Codex::SHA3_512 => {
-            let mut hasher = sha3::Sha3_512::new();
-            hasher.update(ser);
-            hasher.finalize().to_vec()
-        }
-        matter::Codex::SHA2_256 => {
-            let mut hasher = sha2::Sha256::new();
-            hasher.update(ser);
-            hasher.finalize().to_vec()
-        }
-        matter::Codex::SHA2_512 => {
-            let mut hasher = sha2::Sha512::new();
-            hasher.update(ser);
-            hasher.finalize().to_vec()
-        }
-        _ => {
-            return err!(Error::UnexpectedCode(format!("unexpected digest code: code = '{code}'",)))
-        }
-    };
-
-    Ok(out)
-}
-
 #[cfg(test)]
-mod test_diger {
-    use super::derive_digest;
+mod test {
     use crate::core::diger::Diger;
     use crate::core::matter::{tables as matter, Matter};
+    use crate::crypto::hash;
     use hex_literal::hex;
-    use rstest::rstest;
 
     #[test]
-    fn test_new_with_code_and_raw() {
+    fn new_with_code_and_raw() {
         let raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa");
         let code = matter::Codex::Blake3_256;
 
@@ -208,41 +152,8 @@ mod test_diger {
         assert_eq!(d.raw(), raw);
     }
 
-    #[rstest]
-    // https://github.com/BLAKE3-team/BLAKE3/blob/master/test_vectors/test_vectors.json
-    #[case(b"\x00\x01\x02", matter::Codex::Blake3_256,
-        &hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"))]
-    #[case(b"\x00\x01\x02", matter::Codex::Blake3_512,
-        &hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"
-              "5b49b82f805a538c68915c1ae8035c900fd1d4b13902920fd05e1450822f36de"))]
-    // https://github.com/jasoncolburne/jason-math/blob/main/spec/jason/math/cryptography/digest/blake_spec.rb
-    #[case(b"abc", matter::Codex::Blake2b_256,
-        &hex!("bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319"))]
-    #[case(b"The quick brown fox jumps over the lazy dog", matter::Codex::Blake2b_512,
-        &hex!("a8add4bdddfd93e4877d2746e62817b116364a1fa7bc148d95090bc7333b3673"
-              "f82401cf7aa2e4cb1ecd90296e3f14cb5413f8ed77be73045b13914cdcd6a918"))]
-    // generated locally
-    #[case(b"\x00\x01\x02", matter::Codex::Blake2s_256,
-        &hex!("e8f91c6ef232a041452ab0e149070cdd7dd1769e75b3a5921be37876c45c9900"))]
-    // https://github.com/jasoncolburne/jason-math/blob/main/spec/jason/math/cryptography/digest/secure_hash_algorithm_spec.rb
-    #[case(b"abc", matter::Codex::SHA3_256,
-        &hex!("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532"))]
-    #[case(b"abc", matter::Codex::SHA3_512,
-        &hex!("b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e"
-              "10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0"))]
-    #[case(b"abc", matter::Codex::SHA2_256,
-        &hex!("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"))]
-    #[case(b"abc", matter::Codex::SHA2_512,
-        &hex!("ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a"
-              "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"))]
-
-    fn test_new_with_code_and_ser(#[case] ser: &[u8], #[case] code: &str, #[case] raw: &[u8]) {
-        let d = Diger::new_with_code_and_ser(code, ser).unwrap();
-        assert_eq!(d.raw(), raw);
-    }
-
     #[test]
-    fn test_new_with_qb64() {
+    fn new_with_qb64() {
         let raw = b"abcdefghijklmnopqrstuvwxyz012345";
 
         let valid_diger: Diger =
@@ -255,7 +166,7 @@ mod test_diger {
     }
 
     #[test]
-    fn test_new_with_qb64b() {
+    fn new_with_qb64b() {
         let raw = b"abcdefghijklmnopqrstuvwxyz012345";
 
         let valid_diger: Diger =
@@ -268,7 +179,7 @@ mod test_diger {
     }
 
     #[test]
-    fn test_new_with_qb2() {
+    fn new_with_qb2() {
         let raw = b"abcdefghijklmnopqrstuvwxyz012345";
 
         let valid_diger: Diger =
@@ -281,7 +192,7 @@ mod test_diger {
     }
 
     #[test]
-    fn test_verify() {
+    fn verify() {
         let raw = hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"
                                  "5b49b82f805a538c68915c1ae8035c900fd1d4b13902920fd05e1450822f36de");
 
@@ -290,7 +201,7 @@ mod test_diger {
     }
 
     #[test]
-    fn test_compare_dig() {
+    fn compare_dig() {
         let code = matter::Codex::Blake3_256;
         let raw = hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f");
         let ser = vec![0, 1, 2];
@@ -308,18 +219,18 @@ mod test_diger {
 
         // same ser, different algorithm - should return true
         let code2 = matter::Codex::Blake2b_256;
-        let raw2 = derive_digest(code2, &ser).unwrap();
+        let raw2 = hash::digest(code2, &ser).unwrap();
         let m2: Diger = Matter::new_with_code_and_raw(code2, &raw2).unwrap();
         assert!(d.compare_dig(&ser, &m2.qb64b().unwrap()).unwrap());
 
         // different ser, different algorithm - should return false
-        let raw2 = derive_digest(code2, &vec![0, 1, 2, 3]).unwrap();
+        let raw2 = hash::digest(code2, &vec![0, 1, 2, 3]).unwrap();
         let m2: Diger = Matter::new_with_code_and_raw(code2, &raw2).unwrap();
         assert!(!d.compare_dig(&ser, &m2.qb64b().unwrap()).unwrap());
     }
 
     #[test]
-    fn test_compare_diger() {
+    fn compare_diger() {
         let code = matter::Codex::Blake3_256;
         let raw = hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f");
         let ser = vec![0, 1, 2];
@@ -339,18 +250,18 @@ mod test_diger {
 
         // same ser, different algorithm - should return true
         let code2 = matter::Codex::Blake2b_256;
-        let raw2 = derive_digest(code2, &ser).unwrap();
+        let raw2 = hash::digest(code2, &ser).unwrap();
         let d2 = Diger::new_with_code_and_raw(code2, &raw2).unwrap();
         assert!(d.compare_diger(&ser, &d2).unwrap());
 
         // different ser, different algorithm - should return false
-        let raw2 = derive_digest(code2, &vec![0, 1, 2, 3]).unwrap();
+        let raw2 = hash::digest(code2, &vec![0, 1, 2, 3]).unwrap();
         let d2 = Diger::new_with_code_and_raw(code2, &raw2).unwrap();
         assert!(!d.compare_diger(&ser, &d2).unwrap());
     }
 
     #[test]
-    fn test_python_interop() {
+    fn python_interop() {
         // compare() will exercise the most code
         let ser = b"abcdefghijklmnopqrstuvwxyz0123456789";
 
@@ -380,7 +291,7 @@ mod test_diger {
     }
 
     #[test]
-    fn test_unhappy_paths() {
-        assert!(derive_digest(matter::Codex::Big, &[]).is_err());
+    fn unhappy_paths() {
+        assert!(hash::digest(matter::Codex::Big, &[]).is_err());
     }
 }

--- a/src/core/indexer/mod.rs
+++ b/src/core/indexer/mod.rs
@@ -461,12 +461,11 @@ pub trait Indexer: Default {
             }
 
             if li != 0 {
-                return if szg.ls == 1 {
-                    err!(Error::NonZeroedLeadByte())
-                } else {
-                    // unreachable - no sizage has ls > 1
-                    err!(Error::NonZeroedLeadBytes())
-                };
+                match szg.ls {
+                    1 => return err!(Error::NonZeroedLeadByte()),
+                    // unreachable since sizage has no ls > 1
+                    _ => return err!(Error::NonZeroedLeadBytes()),
+                }
             }
 
             raw = paw[ps as usize..].to_owned();
@@ -578,12 +577,11 @@ pub trait Indexer: Default {
         } else {
             for value in trim.iter().take((bcs + szg.ls) as usize).skip(bcs as usize) {
                 if *value != 0 {
-                    return if szg.ls == 1 {
-                        err!(Error::NonZeroedLeadByte())
-                    } else {
-                        // unreachable - no sizage has ls > 1
-                        err!(Error::NonZeroedLeadBytes())
-                    };
+                    match szg.ls {
+                        1 => return err!(Error::NonZeroedLeadByte()),
+                        // unreachable since size has no ls > 1
+                        _ => return err!(Error::NonZeroedLeadBytes()),
+                    }
                 }
             }
         }
@@ -606,7 +604,7 @@ pub trait Indexer: Default {
 }
 
 #[cfg(test)]
-mod indexer_tests {
+mod test {
     use base64::{engine::general_purpose as b64_engine, Engine};
 
     use crate::core::{
@@ -668,7 +666,7 @@ mod indexer_tests {
     }
 
     #[test]
-    fn test_python_interop() {
+    fn python_interop() {
         let sig =  b"\x99\xd2<9$$0\x9fk\xfb\x18\xa0\x8c@r\x122.k\xb2\xc7\x1fp\x0e'm\x8f@\xaa\xa5\x8c\xc8n\x85\xc8!\xf6q\x91p\xa9\xec\xcf\x92\xaf)\xde\xca\xfc\x7f~\xd7o|\x17\x82\x1d\xd4<o\"\x81&\t";
         assert_eq!(sig.len(), 64);
 
@@ -741,7 +739,7 @@ mod indexer_tests {
     }
 
     #[test]
-    fn test_exfil_infil_bexfil_binfil() {
+    fn exfil_infil_bexfil_binfil() {
         let qb64 = "AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ";
 
         // basic
@@ -774,7 +772,7 @@ mod indexer_tests {
     }
 
     #[test]
-    fn test_zero_fs() {
+    fn zero_fs() {
         let indexer =
             TestIndexer::new_with_code_and_raw(Codex::TBD0, &[0, 0, 0], 1, Some(1)).unwrap();
         assert!(TestIndexer::new_with_qb64(&indexer.qb64().unwrap()).is_ok());
@@ -783,7 +781,7 @@ mod indexer_tests {
     }
 
     #[test]
-    fn test_unhappy_paths() {
+    fn unhappy_paths() {
         assert!(TestIndexer::new_with_code_and_raw("", &[], 0, None).is_err());
         assert!(TestIndexer::new_with_code_and_raw(Codex::Ed25519, &[], 0, None).is_err());
         assert!(TestIndexer::new_with_qb64("").is_err());

--- a/src/core/indexer/tables.rs
+++ b/src/core/indexer/tables.rs
@@ -164,9 +164,9 @@ pub(crate) fn bardage(b: u8) -> Result<u32> {
 }
 
 #[cfg(test)]
-mod index_tables_tests {
+mod test {
     use crate::core::indexer::tables::{
-        bardage, hardage, sizage, BothSigCodex, Codex, CurrentSigCodex, SigCodex,
+        self as indexer, BothSigCodex, Codex, CurrentSigCodex, SigCodex,
     };
     use rstest::rstest;
 
@@ -186,7 +186,7 @@ mod index_tables_tests {
     #[case(Codex::TBD0, "0z")]
     #[case(Codex::TBD1, "1z")]
     #[case(Codex::TBD4, "4z")]
-    fn test_codex(#[case] code: &str, #[case] value: &str) {
+    fn codex(#[case] code: &str, #[case] value: &str) {
         assert_eq!(code, value);
     }
 
@@ -203,7 +203,7 @@ mod index_tables_tests {
     #[case(SigCodex::ECDSA_256k1_Big_Crt, "2D")]
     #[case(SigCodex::Ed448_Big, "3A")]
     #[case(SigCodex::Ed448_Big_Crt, "3B")]
-    fn test_sig_codex(#[case] code: &str, #[case] value: &str) {
+    fn sig_codex(#[case] code: &str, #[case] value: &str) {
         assert_eq!(code, value);
     }
 
@@ -214,7 +214,7 @@ mod index_tables_tests {
     #[case(CurrentSigCodex::Ed25519_Big_Crt, "2B")]
     #[case(CurrentSigCodex::ECDSA_256k1_Big_Crt, "2D")]
     #[case(CurrentSigCodex::Ed448_Big_Crt, "3B")]
-    fn test_current_sig_codex(#[case] code: &str, #[case] value: &str) {
+    fn current_sig_codex(#[case] code: &str, #[case] value: &str) {
         assert_eq!(code, value);
     }
 
@@ -225,7 +225,7 @@ mod index_tables_tests {
     #[case(BothSigCodex::Ed25519_Big, "2A")]
     #[case(BothSigCodex::ECDSA_256k1_Big, "2C")]
     #[case(BothSigCodex::Ed448_Big, "3A")]
-    fn test_both_sig_codex(#[case] code: &str, #[case] value: &str) {
+    fn both_sig_codex(#[case] code: &str, #[case] value: &str) {
         assert_eq!(code, value);
     }
 
@@ -245,7 +245,7 @@ mod index_tables_tests {
     #[case("0z", 2, 2, 0, 0, 0)]
     #[case("1z", 2, 2, 1, 76, 1)]
     #[case("4z", 2, 6, 3, 80, 1)]
-    fn test_sizage(
+    fn sizage(
         #[case] code: &str,
         #[case] hs: u32,
         #[case] ss: u32,
@@ -253,7 +253,7 @@ mod index_tables_tests {
         #[case] fs: u32,
         #[case] ls: u32,
     ) {
-        let s = sizage(code).unwrap();
+        let s = indexer::sizage(code).unwrap();
         assert_eq!(s.hs, hs);
         assert_eq!(s.ss, ss);
         assert_eq!(s.os, os);
@@ -262,8 +262,8 @@ mod index_tables_tests {
     }
 
     #[test]
-    fn test_unkown_size() {
-        assert!(sizage("z").is_err());
+    fn unkown_size() {
+        assert!(indexer::sizage("z").is_err());
     }
 
     #[rstest]
@@ -276,23 +276,23 @@ mod index_tables_tests {
     #[case('2', 2)]
     #[case('3', 2)]
     #[case('4', 2)]
-    fn test_hardage(#[case] code: char, #[case] hdg: u32) {
-        assert_eq!(hardage(code).unwrap(), hdg);
+    fn hardage(#[case] code: char, #[case] hdg: u32) {
+        assert_eq!(indexer::hardage(code).unwrap(), hdg);
     }
 
     #[test]
-    fn test_unexpected_count_code() {
-        assert!(hardage('-').is_err());
+    fn unexpected_count_code() {
+        assert!(indexer::hardage('-').is_err());
     }
 
     #[test]
-    fn test_unexpected_op_code() {
-        assert!(hardage('_').is_err());
+    fn unexpected_op_code() {
+        assert!(indexer::hardage('_').is_err());
     }
 
     #[test]
-    fn test_unknown_hardage() {
-        assert!(hardage('8').is_err());
+    fn unknown_hardage() {
+        assert!(indexer::hardage('8').is_err());
     }
 
     #[rstest]
@@ -353,22 +353,22 @@ mod index_tables_tests {
     #[case(0x36, 2)]
     #[case(0x37, 2)]
     #[case(0x38, 2)]
-    fn test_bardage(#[case] code: u8, #[case] bdg: u32) {
-        assert_eq!(bardage(code).unwrap(), bdg);
+    fn bardage(#[case] code: u8, #[case] bdg: u32) {
+        assert_eq!(indexer::bardage(code).unwrap(), bdg);
     }
 
     #[test]
-    fn test_unexpected_bardage_count_code() {
-        assert!(bardage(0x3e).is_err());
+    fn unexpected_bardage_count_code() {
+        assert!(indexer::bardage(0x3e).is_err());
     }
 
     #[test]
-    fn test_unexpected_bardage_op_code() {
-        assert!(bardage(0x3f).is_err());
+    fn unexpected_bardage_op_code() {
+        assert!(indexer::bardage(0x3f).is_err());
     }
 
     #[test]
-    fn test_unknown_bardage() {
-        assert!(bardage(0x39).is_err());
+    fn unknown_bardage() {
+        assert!(indexer::bardage(0x39).is_err());
     }
 }

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -139,8 +139,8 @@ pub mod Codex {
 }
 
 #[cfg(test)]
-mod tables_tests {
-    use crate::core::matter::tables::{bardage, hardage, sizage, Codex};
+mod test {
+    use crate::core::matter::tables::{self as matter, Codex};
     use rstest::rstest;
 
     #[rstest]
@@ -190,14 +190,14 @@ mod tables_tests {
     #[case("7AAB", 4, 4, 0, 0)]
     #[case("8AAB", 4, 4, 0, 1)]
     #[case("9AAB", 4, 4, 0, 2)]
-    fn test_sizage(
+    fn sizage(
         #[case] code: &str,
         #[case] hs: u32,
         #[case] ss: u32,
         #[case] fs: u32,
         #[case] ls: u32,
     ) {
-        let s = sizage(code).unwrap();
+        let s = matter::sizage(code).unwrap();
         assert_eq!(s.hs, hs);
         assert_eq!(s.ss, ss);
         assert_eq!(s.fs, fs);
@@ -267,8 +267,8 @@ mod tables_tests {
     #[case('7', 4)]
     #[case('8', 4)]
     #[case('9', 4)]
-    fn test_hardage(#[case] code: char, #[case] hdg: u32) {
-        assert_eq!(hardage(code).unwrap(), hdg);
+    fn hardage(#[case] code: char, #[case] hdg: u32) {
+        assert_eq!(matter::hardage(code).unwrap(), hdg);
     }
 
     #[rstest]
@@ -318,15 +318,15 @@ mod tables_tests {
     #[case(Codex::Bytes_Big_L0, "7AAB")]
     #[case(Codex::Bytes_Big_L1, "8AAB")]
     #[case(Codex::Bytes_Big_L2, "9AAB")]
-    fn test_codes(#[case] code: &str, #[case] value: &str) {
+    fn codes(#[case] code: &str, #[case] value: &str) {
         assert_eq!(code, value);
     }
 
     #[test]
-    fn test_unhappy_paths() {
-        assert!(hardage('-').is_err());
-        assert!(hardage('_').is_err());
-        assert!(hardage('#').is_err());
-        assert!(bardage(0x40).is_err());
+    fn unhappy_paths() {
+        assert!(matter::hardage('-').is_err());
+        assert!(matter::hardage('_').is_err());
+        assert!(matter::hardage('#').is_err());
+        assert!(matter::bardage(0x40).is_err());
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,9 +1,11 @@
 pub mod cigar;
+pub mod common;
 pub mod counter;
 pub mod dater;
 pub mod diger;
 pub mod indexer;
 pub mod matter;
+pub mod saider;
 pub mod siger;
 pub mod signer;
 pub mod util;

--- a/src/core/saider.rs
+++ b/src/core/saider.rs
@@ -1,0 +1,520 @@
+use lazy_static::lazy_static;
+
+use crate::core::common::{deversify, dumps, sizeify, Ids, Serialage};
+use crate::core::matter::{tables as matter, Matter};
+use crate::crypto::hash;
+use crate::data::{data, Value};
+use crate::error::{err, Error, Result};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Saider {
+    raw: Vec<u8>,
+    code: String,
+    size: u32,
+}
+
+impl Default for Saider {
+    fn default() -> Self {
+        Saider { raw: vec![], code: matter::Codex::Blake3_256.to_string(), size: 0 }
+    }
+}
+
+fn validate_code(code: &str) -> Result<()> {
+    lazy_static! {
+        static ref CODES: Vec<&'static str> = vec![
+            matter::Codex::Blake3_256,
+            matter::Codex::Blake2b_256,
+            matter::Codex::Blake2s_256,
+            matter::Codex::SHA3_256,
+            matter::Codex::SHA2_256,
+            matter::Codex::Blake3_512,
+            matter::Codex::Blake2b_512,
+            matter::Codex::SHA3_512,
+            matter::Codex::SHA2_512,
+        ];
+    }
+
+    if !CODES.contains(&code) {
+        return err!(Error::UnexpectedCode(code.to_string()));
+    }
+
+    Ok(())
+}
+
+impl Saider {
+    const DUMMY: u8 = b'#';
+
+    pub fn new_with_code_and_raw(
+        code: Option<&str>,
+        raw: Option<&[u8]>,
+        sad: Option<&Value>,
+        label: Option<&str>,
+        kind: Option<&str>,
+        ignore: Option<&[&str]>,
+    ) -> Result<Self> {
+        let label = label.unwrap_or(Ids::d);
+        let (code, raw) = if code.is_none() || raw.is_none() {
+            let code = if let Some(sad) = sad {
+                let map = sad.to_map()?;
+                if !map.contains_key(label) {
+                    return err!(Error::Value(format!(
+                        "cannot find label {label} in sad, code or raw is empty"
+                    )));
+                }
+
+                if let Some(code) = code {
+                    // raw must be empty
+                    code.to_string()
+                } else if sad[label].to_string().is_err() {
+                    return err!(Error::Validation(format!(
+                        "label {label} present but value not a string"
+                    )));
+                } else if sad[label].to_string()?.is_empty() {
+                    matter::Codex::Blake3_256.to_string()
+                } else {
+                    <Saider as Matter>::new_with_qb64(&sad[label].to_string()?)?.code()
+                }
+            } else {
+                return err!(Error::Validation("sad or raw and code must be present".to_string()));
+            };
+
+            validate_code(&code)?;
+
+            let sad = if let Some(sad) = sad { sad.clone() } else { data!({}) };
+            let (raw, _) = Self::derive(&sad, Some(&code), kind, Some(label), ignore)?;
+
+            (code, raw)
+        } else if let Some(code) = code {
+            validate_code(code)?;
+            if let Some(raw) = raw {
+                (code.to_string(), raw.to_vec())
+            } else {
+                // unreachable because we have validated that raw is some above.
+                unreachable!();
+            }
+        } else {
+            // unreachable because we have validated that code is some above.
+            unreachable!();
+        };
+
+        Matter::new_with_code_and_raw(&code, &raw)
+    }
+
+    pub fn new_with_qb64(qb64: &str) -> Result<Self> {
+        let saider: Saider = Matter::new_with_qb64(qb64)?;
+        validate_code(&saider.code())?;
+        Ok(saider)
+    }
+
+    pub fn new_with_qb64b(qb64b: &[u8]) -> Result<Self> {
+        let saider: Saider = Matter::new_with_qb64b(qb64b)?;
+        validate_code(&saider.code())?;
+        Ok(saider)
+    }
+
+    pub fn new_with_qb2(qb2: &[u8]) -> Result<Self> {
+        let saider: Saider = Matter::new_with_qb2(qb2)?;
+        validate_code(&saider.code())?;
+        Ok(saider)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn verify(
+        &self,
+        sad: &Value,
+        prefixed: Option<bool>,
+        versioned: Option<bool>,
+        kind: Option<&str>,
+        label: Option<&str>,
+        ignore: Option<&[&str]>,
+    ) -> Result<bool> {
+        let label = label.unwrap_or(Ids::d);
+        let prefixed = prefixed.unwrap_or(false);
+        let versioned = versioned.unwrap_or(true);
+
+        let (raw, dsad) = match Self::derive(sad, Some(&self.code()), kind, Some(label), ignore) {
+            Ok(r) => r,
+            Err(_) => return Ok(false),
+        };
+
+        let saider = match Self::new_with_code_and_raw(
+            Some(&self.code()),
+            Some(&raw),
+            None,
+            None,
+            None,
+            None,
+        ) {
+            Ok(s) => s,
+            // should be unreachable
+            Err(_) => return Ok(false),
+        };
+
+        if self.qb64()? != saider.qb64()? {
+            return Ok(false);
+        }
+
+        if versioned
+            && sad.to_map()?.contains_key("v")
+            && sad["v"].to_string()? != dsad["v"].to_string()?
+        {
+            return Ok(false);
+        }
+
+        if prefixed && sad[label].to_string()? != self.qb64()? {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
+
+    fn derive(
+        sad: &Value,
+        code: Option<&str>,
+        kind: Option<&str>,
+        label: Option<&str>,
+        ignore: Option<&[&str]>,
+    ) -> Result<(Vec<u8>, Value)> {
+        let label = label.unwrap_or(Ids::d);
+        let code = code.unwrap_or(matter::Codex::Blake3_256);
+
+        validate_code(code)?;
+
+        let szg = matter::sizage(code)?;
+        let mut sad = sad.clone();
+
+        sad[label] = data!(&String::from_utf8(vec![Self::DUMMY; szg.fs as usize])?);
+
+        let (kind, sad) = if sad.to_map()?.contains_key("v") {
+            let result = sizeify(&sad, kind)?;
+            (Some(result.kind), result.ked)
+        } else {
+            let kind = kind.map(|kind| kind.to_string());
+            (kind, sad)
+        };
+
+        let mut map = sad.to_map()?;
+        for key in ignore.unwrap_or(&[]) {
+            if map.contains_key(*key) {
+                map.remove(*key);
+            }
+        }
+        let ser = data!(&map);
+
+        let cpa = if let Some(kind) = kind {
+            Self::serialize(&ser, Some(&kind))?
+        } else {
+            Self::serialize(&ser, None)?
+        };
+        let digest = hash::digest(code, &cpa)?;
+
+        Ok((digest, sad))
+    }
+
+    fn serialize(sad: &Value, kind: Option<&str>) -> Result<Vec<u8>> {
+        let knd = if sad.to_map()?.contains_key("v") {
+            let result = deversify(&sad["v"].to_string()?)?;
+            result.kind
+        } else {
+            Serialage::JSON.to_string()
+        };
+        let kind = if let Some(kind) = kind { Some(kind) } else { Some(knd.as_str()) };
+        dumps(sad, kind)
+    }
+
+    pub fn saidify(
+        sad: &Value,
+        code: Option<&str>,
+        kind: Option<&str>,
+        label: Option<&str>,
+        ignore: Option<&[&str]>,
+    ) -> Result<(Saider, Value)> {
+        let code = code.unwrap_or(matter::Codex::Blake3_256);
+        let label = label.unwrap_or(Ids::d);
+
+        if !sad.to_map()?.contains_key(label) {
+            return err!(Error::Validation(format!("missing id field labelled={label}")));
+        }
+
+        let (raw, sad) = Self::derive(sad, Some(code), kind, Some(label), ignore)?;
+        let saider = Self::new_with_code_and_raw(
+            Some(code),
+            Some(&raw),
+            Some(&sad),
+            Some(label),
+            kind,
+            ignore,
+        )?;
+        let mut sad = sad;
+        sad[label] = data!(&saider.qb64()?);
+
+        Ok((saider, sad))
+    }
+}
+
+impl Matter for Saider {
+    fn code(&self) -> String {
+        self.code.clone()
+    }
+
+    fn raw(&self) -> Vec<u8> {
+        self.raw.clone()
+    }
+
+    fn size(&self) -> u32 {
+        self.size
+    }
+
+    fn set_code(&mut self, code: &str) {
+        self.code = code.to_string();
+    }
+
+    fn set_raw(&mut self, raw: &[u8]) {
+        self.raw = raw.to_vec();
+    }
+
+    fn set_size(&mut self, size: u32) {
+        self.size = size;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::validate_code;
+    use crate::core::common::{versify, Identage, Ids, Serialage, Version};
+    use crate::core::matter::{tables as matter, Matter};
+    use crate::core::saider::Saider;
+    use crate::data::data;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(matter::Codex::Blake3_256, "EBG9LuUbFzV4OV5cGS9IeQWzy9SuyVFyVrpRc4l1xzPA")]
+    #[case(matter::Codex::Blake2b_256, "FG1_1lgNJ69QPnJK-pD5s8cinFFYhnGN8nuyz8Mdrezg")]
+    fn new_with_qb64(#[case] code: &str, #[case] said: &str) {
+        // Test with valid said qb64
+        let saider = Saider::new_with_qb64(said).unwrap();
+        assert_eq!(saider.code(), code);
+        assert_eq!(saider.qb64().unwrap(), said);
+    }
+
+    #[rstest]
+    #[case("EMRvS7lGxc1eDleXBkvSHkFs8vUrslRcla6UXOJdcczw", None, None, Some(Ids::dollar))]
+    #[case(
+        "EMRvS7lGxc1eDleXBkvSHkFs8vUrslRcla6UXOJdcczw",
+        Some(matter::Codex::Blake3_256),
+        None,
+        Some(Ids::dollar)
+    )]
+    #[case(
+        "EMRvS7lGxc1eDleXBkvSHkFs8vUrslRcla6UXOJdcczw",
+        None,
+        Some(Serialage::JSON),
+        Some(Ids::dollar)
+    )]
+    #[case(
+        "EMRvS7lGxc1eDleXBkvSHkFs8vUrslRcla6UXOJdcczw",
+        Some(matter::Codex::Blake3_256),
+        Some(Serialage::JSON),
+        Some(Ids::dollar)
+    )]
+    #[case(
+        "FFtf9ZYDSevUD5ySvqQ-bPHIpxRWIZxjfJ7ss_DHa3s4",
+        Some(matter::Codex::Blake2b_256),
+        None,
+        Some(Ids::dollar)
+    )]
+    fn basic(
+        #[case] said: &str,
+        #[case] code: Option<&str>,
+        #[case] kind: Option<&str>,
+        #[case] label: Option<&str>,
+    ) {
+        let sad1 = data!({
+            "$id": "",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "a": {"type":"string"},
+                "b": {"type":"number"},
+                "c": {"type":"string","format":"date-time"}
+            }
+        });
+
+        let (saider, _) = Saider::saidify(&sad1, code, kind, label, None).unwrap();
+        assert_eq!(saider.qb64().unwrap(), said);
+
+        let sad2 = data!({
+            "$id": said,
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "a": {"type":"string"},
+                "b": {"type":"number"},
+                "c": {"type":"string","format":"date-time"}
+            }
+        });
+
+        assert!(saider.verify(&sad2, Some(true), None, None, label, None).unwrap());
+        assert!(saider.verify(&sad1, Some(false), None, None, label, None).unwrap());
+        assert!(!saider.verify(&sad1, Some(true), None, None, label, None).unwrap());
+    }
+
+    #[test]
+    fn keri() {
+        // test with default id field label Ids.d == 'd' and contains 'v' field
+        let label = Ids::d;
+        let code = matter::Codex::Blake3_256;
+
+        let vs = versify(
+            Some(Identage::KERI),
+            Some(&Version { major: 1, minor: 0 }),
+            Some(Serialage::JSON),
+            Some(0),
+        )
+        .unwrap();
+        assert_eq!(vs, "KERI10JSON000000_");
+        let sad6 = data!({
+            "v": &vs,
+            "t": "rep",
+            "d": "",
+            "dt": "2020-08-22T17:50:12.988921+00:00",
+            "r": "logs/processor",
+            "a": {
+                "d":"EBabiu_JCkE0GbiglDXNB5C4NQq-hiGgxhHKXBxkiojg",
+                "i":"EB0_D51cTh_q6uOQ-byFiv5oNXZ-cxdqCqBAa4JmBLtb",
+                "name":"John Jones",
+                "role":"Founder",
+            },
+        });
+        let saider =
+            Saider::new_with_code_and_raw(Some(code), None, Some(&sad6), Some(label), None, None)
+                .unwrap();
+        assert_eq!(saider.code(), code);
+        assert_eq!(saider.qb64().unwrap(), "ELzewBpZHSENRP-sL_G_2Ji4YDdNkns9AzFzufleJqdw");
+        assert!(saider.verify(&sad6, Some(false), Some(false), None, None, None).unwrap());
+        assert!(!saider.verify(&sad6, Some(false), None, None, None, None).unwrap());
+        assert!(!saider.verify(&sad6, Some(true), Some(false), None, None, None).unwrap());
+
+        let mut sad7 = sad6.clone();
+        sad7[label] = data!(&saider.qb64().unwrap());
+        assert!(saider.verify(&sad7, Some(true), Some(false), None, None, None).unwrap());
+
+        let mut sad8 = sad7.clone();
+        let (_, dsad) = Saider::derive(&sad6, Some(code), None, Some(label), None).unwrap();
+        sad8["v"] = data!(&dsad["v"].to_string().unwrap());
+        assert!(saider.verify(&sad8, Some(true), None, None, None, None).unwrap());
+
+        // let said8 = saider.qb64().unwrap();
+
+        let sad9 = data!({
+            "d": "",
+            "first": "John",
+            "last": "Doe",
+            "read": false
+        });
+
+        let saider = Saider::new_with_code_and_raw(
+            Some(code),
+            None,
+            Some(&sad9),
+            None,
+            None,
+            Some(&vec!["read"]),
+        )
+        .unwrap();
+        let said9 = "EBam6rzvfq0yF6eI7Czrg3dUVhqg2cwNkSoJvyHWPj3p";
+        assert_eq!(saider.qb64().unwrap(), said9);
+
+        let (saider1, mut sad10) =
+            Saider::saidify(&sad9, Some(code), None, Some(Ids::d), Some(&vec!["read"])).unwrap();
+        assert_eq!(saider.qb64().unwrap(), saider1.qb64().unwrap());
+        assert_eq!(sad10[Ids::d].to_string().unwrap(), said9);
+        assert!(!sad10["read"].to_bool().unwrap());
+
+        assert!(saider1
+            .verify(&sad10, Some(true), None, None, Some(Ids::d), Some(&vec!["read"]))
+            .unwrap());
+
+        // Change the 'read' field that is ignored and make sure it still verifies
+        sad10["read"] = data!(true);
+        assert!(saider1
+            .verify(&sad10, Some(true), None, None, Some(Ids::d), Some(&vec!["read"]))
+            .unwrap());
+
+        let saider2 = Saider::new_with_code_and_raw(
+            Some(code),
+            None,
+            Some(&sad10),
+            None,
+            None,
+            Some(&vec!["read"]),
+        )
+        .unwrap();
+        assert_eq!(saider1.qb64().unwrap(), saider2.qb64().unwrap());
+        assert_eq!(sad10["read"].to_bool().unwrap(), true);
+    }
+
+    #[test]
+    fn new() {
+        let saider = Saider::new_with_code_and_raw(
+            None,
+            None,
+            Some(&data!({"d":""})),
+            Some(Ids::d),
+            None,
+            None,
+        )
+        .unwrap();
+        let saider2 = Saider::new_with_code_and_raw(
+            None,
+            None,
+            Some(&data!({"d":&saider.qb64().unwrap()})),
+            Some(Ids::d),
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(saider.code(), saider2.code());
+        assert_eq!(saider.qb64().unwrap(), saider2.qb64().unwrap());
+        let saider3 = Saider::new_with_qb64b(&saider.qb64b().unwrap()).unwrap();
+        assert_eq!(saider.code(), saider3.code());
+        assert_eq!(saider.qb64().unwrap(), saider3.qb64().unwrap());
+        let mut saider4 = Saider::new_with_qb2(&saider.qb2().unwrap()).unwrap();
+        assert_eq!(saider.code(), saider4.code());
+        assert_eq!(saider.qb64().unwrap(), saider2.qb64().unwrap());
+        let mut v = vec![saider4.raw[0] ^ 0xff];
+        v.append(&mut saider4.raw[1..].to_vec());
+        saider4.raw = v;
+        assert!(!saider4
+            .verify(&data!({"d":&saider.qb64().unwrap()}), None, None, None, None, None)
+            .unwrap());
+    }
+
+    #[test]
+    fn sad_paths() {
+        assert!(validate_code(matter::Codex::Ed25519).is_err());
+        assert!(Saider::new_with_code_and_raw(
+            None,
+            None,
+            Some(&data!({})),
+            Some(Ids::d),
+            None,
+            None
+        )
+        .is_err());
+        assert!(Saider::new_with_code_and_raw(
+            None,
+            None,
+            Some(&data!({"d":true})),
+            Some(Ids::d),
+            None,
+            None
+        )
+        .is_err());
+        assert!(Saider::new_with_code_and_raw(None, None, None, None, None, None).is_err());
+        assert!(!Saider { code: "CESR".to_string(), raw: vec![], size: 0 }
+            .verify(&data!({}), None, None, None, None, None)
+            .unwrap());
+        assert!(Saider::saidify(&data!({}), None, None, None, None).is_err());
+    }
+}

--- a/src/core/siger.rs
+++ b/src/core/siger.rs
@@ -140,14 +140,14 @@ impl Indexer for Siger {
 }
 
 #[cfg(test)]
-mod test_siger {
+mod test {
     use super::{indexer, Indexer, Siger, Verfer};
     use crate::core::matter::tables as matter;
     use base64::{engine::general_purpose as b64_engine, Engine};
     use hex_literal::hex;
 
     #[test]
-    fn test_python_interop() {
+    fn python_interop() {
         assert!(Siger::new_with_code_and_raw(None, "", b"", 0, Some(0)).is_err());
 
         let qsig64 = "AACdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ";
@@ -187,7 +187,7 @@ mod test_siger {
     }
 
     #[test]
-    fn test_new_with_code_and_raw() {
+    fn new_with_code_and_raw() {
         let verfer_raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa");
 
         let verfer_code = matter::Codex::Ed25519;
@@ -204,7 +204,7 @@ mod test_siger {
     }
 
     #[test]
-    fn test_new_with_qb64b() {
+    fn new_with_qb64b() {
         let verfer_raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa");
 
         let verfer_code = matter::Codex::Ed25519;
@@ -218,7 +218,7 @@ mod test_siger {
     }
 
     #[test]
-    fn test_new_with_qb2() {
+    fn new_with_qb2() {
         let verfer_raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa");
 
         let verfer_code = matter::Codex::Ed25519;
@@ -231,7 +231,7 @@ mod test_siger {
     }
 
     #[test]
-    fn test_unhappy_paths() {
+    fn unhappy_paths() {
         // invalid code
         assert!(Siger::new_with_code_and_raw(None, "CESR", &[], 0, None).is_err());
     }

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -66,9 +66,7 @@ pub fn b64_char_to_index(c: char) -> Result<u8> {
         '9' => 61,
         '-' => 62,
         '_' => 63,
-        _ => {
-            return err!(Error::InvalidBase64Character(c));
-        }
+        _ => return err!(Error::InvalidBase64Character(c)),
     })
 }
 
@@ -138,9 +136,7 @@ pub fn b64_index_to_char(i: u8) -> Result<char> {
         61 => '9',
         62 => '-',
         63 => '_',
-        _ => {
-            return err!(Error::InvalidBase64Index(i));
-        }
+        _ => return err!(Error::InvalidBase64Index(i)),
     })
 }
 
@@ -264,7 +260,7 @@ pub fn nab_sextets(binary: &[u8], count: usize) -> Result<Vec<u8>> {
 }
 
 #[cfg(test)]
-mod util_tests {
+mod test {
     use crate::core::util;
     use rstest::rstest;
 
@@ -276,7 +272,7 @@ mod util_tests {
     #[case(1, 2, "AB")]
     #[case(4095, 2, "__")]
     #[case(16777215, 4, "____")]
-    fn test_u32_to_b64(#[case] n: u32, #[case] length: usize, #[case] b64: &str) {
+    fn u32_to_b64(#[case] n: u32, #[case] length: usize, #[case] b64: &str) {
         assert_eq!(util::u32_to_b64(n, length).unwrap(), b64);
     }
 
@@ -287,7 +283,7 @@ mod util_tests {
     #[case(1, "AB")]
     #[case(4095, "__")]
     #[case(16777215, "____")]
-    fn test_b64_to_u32(#[case] n: u32, #[case] b64: &str) {
+    fn b64_to_u32(#[case] n: u32, #[case] b64: &str) {
         assert_eq!(util::b64_to_u32(b64).unwrap(), n);
     }
 
@@ -299,12 +295,12 @@ mod util_tests {
     #[case(4095, "__")]
     #[case(16777215, "____")]
     #[case(281474976710655, "________")]
-    fn test_b64_to_u64(#[case] n: u64, #[case] b64: &str) {
+    fn b64_to_u64(#[case] n: u64, #[case] b64: &str) {
         assert_eq!(util::b64_to_u64(b64).unwrap(), n);
     }
 
     #[test]
-    fn test_b64_char_to_index() {
+    fn b64_char_to_index() {
         let s = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
         let mut i = 0;
@@ -315,7 +311,7 @@ mod util_tests {
     }
 
     #[test]
-    fn test_b64_index_to_char() {
+    fn b64_index_to_char() {
         let mut chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_".chars();
         for i in 0..63 {
             assert_eq!(util::b64_index_to_char(i).unwrap(), chars.next().unwrap());
@@ -331,7 +327,7 @@ mod util_tests {
     #[case(&vec![255, 255, 255, 255, 255, 255], 8, "________")]
     #[case(&vec![244, 0, 1], 4, "9AAB")]
     #[case(&vec![244, 0, 1], 0, "")]
-    fn test_code_b2_to_b64(#[case] b2: &Vec<u8>, #[case] length: usize, #[case] b64: &str) {
+    fn code_b2_to_b64(#[case] b2: &Vec<u8>, #[case] length: usize, #[case] b64: &str) {
         assert_eq!(util::code_b2_to_b64(b2, length).unwrap(), b64);
     }
 
@@ -343,7 +339,7 @@ mod util_tests {
     #[case(vec![252], "_")]
     #[case(vec![255, 255, 255, 255, 255, 255], "________")]
     #[case(vec![244, 0, 1], "9AAB")]
-    fn test_code_b64_to_b2(#[case] b2: Vec<u8>, #[case] b64: &str) {
+    fn code_b64_to_b2(#[case] b2: Vec<u8>, #[case] b64: &str) {
         assert_eq!(util::code_b64_to_b2(b64).unwrap(), b2);
     }
 
@@ -353,7 +349,7 @@ mod util_tests {
     #[case(&[255, 255, 255, 0, 0, 0], 8, vec![63, 63, 63, 63, 0, 0, 0, 0])]
     #[case(&[255], 1, vec![63])]
     #[case(&[127, 127], 2, vec![31, 55])]
-    fn test_nab_sextets(#[case] binary: &[u8], #[case] length: usize, #[case] result: Vec<u8>) {
+    fn nab_sextets(#[case] binary: &[u8], #[case] length: usize, #[case] result: Vec<u8>) {
         assert_eq!(util::nab_sextets(binary, length).unwrap(), result);
         assert_eq!(
             util::nab_sextets(&[255, 255, 255, 0, 0, 0], 8).unwrap(),
@@ -364,7 +360,7 @@ mod util_tests {
     }
 
     #[test]
-    fn test_unhappy_paths() {
+    fn unhappy_paths() {
         assert!(util::b64_char_to_index('#').is_err());
         assert!(util::b64_index_to_char(64).is_err());
         assert!(util::code_b2_to_b64(&[0], 2).is_err());

--- a/src/crypto/hash.rs
+++ b/src/crypto/hash.rs
@@ -1,0 +1,103 @@
+use blake2::Digest;
+
+use crate::core::matter::tables as matter;
+use crate::error::{err, Error, Result};
+
+type Blake2b256 = blake2::Blake2b<blake2::digest::consts::U32>;
+
+pub(crate) fn digest(code: &str, ser: &[u8]) -> Result<Vec<u8>> {
+    let out = match code {
+        matter::Codex::Blake3_256 => blake3::hash(ser).as_bytes().to_vec(),
+        matter::Codex::Blake3_512 => {
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(ser);
+            let mut buf: [u8; 64] = [0; 64];
+            hasher.finalize_xof().fill(&mut buf);
+            buf.to_vec()
+        }
+        matter::Codex::Blake2b_256 => {
+            let mut hasher = Blake2b256::new();
+            hasher.update(ser);
+            hasher.finalize().to_vec()
+        }
+        matter::Codex::Blake2b_512 => {
+            let mut hasher = blake2::Blake2b512::new();
+            hasher.update(ser);
+            hasher.finalize().to_vec()
+        }
+        matter::Codex::Blake2s_256 => {
+            let mut hasher = blake2::Blake2s256::new();
+            hasher.update(ser);
+            hasher.finalize().to_vec()
+        }
+        matter::Codex::SHA3_256 => {
+            let mut hasher = sha3::Sha3_256::new();
+            hasher.update(ser);
+            hasher.finalize().to_vec()
+        }
+        matter::Codex::SHA3_512 => {
+            let mut hasher = sha3::Sha3_512::new();
+            hasher.update(ser);
+            hasher.finalize().to_vec()
+        }
+        matter::Codex::SHA2_256 => {
+            let mut hasher = sha2::Sha256::new();
+            hasher.update(ser);
+            hasher.finalize().to_vec()
+        }
+        matter::Codex::SHA2_512 => {
+            let mut hasher = sha2::Sha512::new();
+            hasher.update(ser);
+            hasher.finalize().to_vec()
+        }
+        _ => {
+            return err!(Error::UnexpectedCode(format!("unexpected digest code: code = '{code}'",)))
+        }
+    };
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core::matter::tables as matter;
+    use crate::crypto::hash;
+    use hex_literal::hex;
+    use rstest::rstest;
+
+    #[rstest]
+    // https://github.com/BLAKE3-team/BLAKE3/blob/master/test_vectors/test_vectors.json
+    #[case(b"\x00\x01\x02", matter::Codex::Blake3_256,
+        &hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"))]
+    #[case(b"\x00\x01\x02", matter::Codex::Blake3_512,
+        &hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"
+              "5b49b82f805a538c68915c1ae8035c900fd1d4b13902920fd05e1450822f36de"))]
+    // https://github.com/jasoncolburne/jason-math/blob/main/spec/jason/math/cryptography/digest/blake_spec.rb
+    #[case(b"abc", matter::Codex::Blake2b_256,
+        &hex!("bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319"))]
+    #[case(b"The quick brown fox jumps over the lazy dog", matter::Codex::Blake2b_512,
+        &hex!("a8add4bdddfd93e4877d2746e62817b116364a1fa7bc148d95090bc7333b3673"
+              "f82401cf7aa2e4cb1ecd90296e3f14cb5413f8ed77be73045b13914cdcd6a918"))]
+    // generated locally
+    #[case(b"\x00\x01\x02", matter::Codex::Blake2s_256,
+        &hex!("e8f91c6ef232a041452ab0e149070cdd7dd1769e75b3a5921be37876c45c9900"))]
+    // https://github.com/jasoncolburne/jason-math/blob/main/spec/jason/math/cryptography/digest/secure_hash_algorithm_spec.rb
+    #[case(b"abc", matter::Codex::SHA3_256,
+        &hex!("3a985da74fe225b2045c172d6bd390bd855f086e3e9d525b46bfe24511431532"))]
+    #[case(b"abc", matter::Codex::SHA3_512,
+        &hex!("b751850b1a57168a5693cd924b6b096e08f621827444f70d884f5d0240d2712e"
+              "10e116e9192af3c91a7ec57647e3934057340b4cf408d5a56592f8274eec53f0"))]
+    #[case(b"abc", matter::Codex::SHA2_256,
+        &hex!("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"))]
+    #[case(b"abc", matter::Codex::SHA2_512,
+        &hex!("ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a"
+              "2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f"))]
+    fn digest(#[case] ser: &[u8], #[case] code: &str, #[case] dig: &[u8]) {
+        assert_eq!(hash::digest(code, ser).unwrap(), dig);
+    }
+
+    #[test]
+    fn unhappy_paths() {
+        assert!(hash::digest(matter::Codex::Ed25519, &[]).is_err());
+    }
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod hash;
+pub(crate) mod sign;

--- a/src/crypto/sign.rs
+++ b/src/crypto/sign.rs
@@ -1,0 +1,160 @@
+use crate::core::matter::tables as matter;
+use crate::error::{err, Error, Result};
+
+pub(crate) fn generate(code: &str) -> Result<Vec<u8>> {
+    match code {
+        matter::Codex::Ed25519
+        | matter::Codex::Ed25519N
+        | matter::Codex::Ed25519_Seed
+        | matter::Codex::Ed25519_Sig => ed25519::generate(),
+        matter::Codex::ECDSA_256k1
+        | matter::Codex::ECDSA_256k1N
+        | matter::Codex::ECDSA_256k1_Seed
+        | matter::Codex::ECDSA_256k1_Sig => ecdsa_256k1::generate(),
+        _ => err!(Error::UnexpectedCode(code.to_string())),
+    }
+}
+
+pub(crate) fn public_key(code: &str, private_key: &[u8]) -> Result<Vec<u8>> {
+    match code {
+        matter::Codex::Ed25519
+        | matter::Codex::Ed25519N
+        | matter::Codex::Ed25519_Seed
+        | matter::Codex::Ed25519_Sig => ed25519::public_key(private_key),
+        matter::Codex::ECDSA_256k1
+        | matter::Codex::ECDSA_256k1N
+        | matter::Codex::ECDSA_256k1_Seed
+        | matter::Codex::ECDSA_256k1_Sig => ecdsa_256k1::public_key(private_key),
+        _ => err!(Error::UnexpectedCode(code.to_string())),
+    }
+}
+
+pub(crate) fn sign(code: &str, private_key: &[u8], ser: &[u8]) -> Result<Vec<u8>> {
+    match code {
+        matter::Codex::Ed25519
+        | matter::Codex::Ed25519N
+        | matter::Codex::Ed25519_Seed
+        | matter::Codex::Ed25519_Sig => ed25519::sign(private_key, ser),
+        matter::Codex::ECDSA_256k1
+        | matter::Codex::ECDSA_256k1N
+        | matter::Codex::ECDSA_256k1_Seed
+        | matter::Codex::ECDSA_256k1_Sig => ecdsa_256k1::sign(private_key, ser),
+        _ => err!(Error::UnexpectedCode(code.to_string())),
+    }
+}
+
+pub(crate) fn verify(code: &str, public_key: &[u8], sig: &[u8], ser: &[u8]) -> Result<bool> {
+    match code {
+        matter::Codex::Ed25519
+        | matter::Codex::Ed25519N
+        | matter::Codex::Ed25519_Seed
+        | matter::Codex::Ed25519_Sig => ed25519::verify(public_key, sig, ser),
+        matter::Codex::ECDSA_256k1
+        | matter::Codex::ECDSA_256k1N
+        | matter::Codex::ECDSA_256k1_Seed
+        | matter::Codex::ECDSA_256k1_Sig => ecdsa_256k1::verify(public_key, sig, ser),
+        _ => err!(Error::UnexpectedCode(code.to_string())),
+    }
+}
+
+mod ed25519 {
+    use ed25519_dalek::{
+        ed25519::signature::Signer, Keypair, PublicKey, SecretKey, Signature, Verifier,
+    };
+    use rand::rngs::OsRng;
+
+    use crate::error::Result;
+
+    pub(crate) fn generate() -> Result<Vec<u8>> {
+        let mut csprng = OsRng {};
+        let private_key: SecretKey = SecretKey::generate(&mut csprng);
+        Ok(private_key.as_bytes().to_vec())
+    }
+
+    pub(crate) fn public_key(private_key: &[u8]) -> Result<Vec<u8>> {
+        let private_key = SecretKey::from_bytes(private_key)?;
+        let public_key: PublicKey = (&private_key).into();
+        Ok(public_key.as_bytes().to_vec())
+    }
+
+    pub(crate) fn sign(private_key: &[u8], ser: &[u8]) -> Result<Vec<u8>> {
+        let private_key = SecretKey::from_bytes(private_key)?;
+        let public_key: PublicKey = (&private_key).into();
+        Ok(Keypair { secret: private_key, public: public_key }.sign(ser).to_bytes().to_vec())
+    }
+
+    pub(crate) fn verify(public_key: &[u8], sig: &[u8], ser: &[u8]) -> Result<bool> {
+        let public_key = PublicKey::from_bytes(public_key)?;
+        let signature = Signature::from_bytes(sig)?;
+
+        match public_key.verify(ser, &signature) {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+}
+
+mod ecdsa_256k1 {
+    use k256::ecdsa::{
+        signature::{Signer, Verifier},
+        Signature, SigningKey, VerifyingKey,
+    };
+    use rand_core::OsRng;
+
+    use crate::error::{err, Result};
+
+    pub(crate) fn generate() -> Result<Vec<u8>> {
+        let mut csprng = OsRng {};
+        let private_key = SigningKey::random(&mut csprng);
+        Ok(private_key.to_bytes().to_vec())
+    }
+
+    pub(crate) fn public_key(private_key: &[u8]) -> Result<Vec<u8>> {
+        let private_key = SigningKey::from_bytes(private_key)?;
+        let public_key = VerifyingKey::from(private_key);
+        Ok(public_key.to_encoded_point(true).as_bytes().to_vec())
+    }
+
+    pub(crate) fn sign(private_key: &[u8], ser: &[u8]) -> Result<Vec<u8>> {
+        let private_key = SigningKey::from_bytes(private_key)?;
+        Ok(<SigningKey as Signer<Signature>>::sign(&private_key, ser).to_bytes().to_vec())
+    }
+
+    pub(crate) fn verify(public_key: &[u8], sig: &[u8], ser: &[u8]) -> Result<bool> {
+        let public_key = VerifyingKey::from_sec1_bytes(public_key)?;
+        let signature = match Signature::try_from(sig) {
+            Ok(s) => s,
+            Err(e) => return err!(e),
+        };
+
+        match public_key.verify(ser, &signature) {
+            Ok(_) => Ok(true),
+            Err(_) => Ok(false),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core::matter::tables as matter;
+    use crate::crypto::sign;
+    use rstest::rstest;
+
+    #[rstest]
+    fn end_to_end(#[values(matter::Codex::Ed25519, matter::Codex::ECDSA_256k1)] code: &str) {
+        let ser = b"abcdefghijklmnopqrstuvwxyz";
+        let private_key = sign::generate(code).unwrap();
+        let signature = sign::sign(code, &private_key, ser).unwrap();
+        let public_key = sign::public_key(code, &private_key).unwrap();
+        assert!(sign::verify(code, &public_key, &signature, ser).unwrap());
+    }
+
+    #[test]
+    fn unhappy_paths() {
+        let code = matter::Codex::SHA3_256;
+        assert!(sign::generate(code).is_err());
+        assert!(sign::public_key(code, &[]).is_err());
+        assert!(sign::sign(code, &[], &[]).is_err());
+        assert!(sign::verify(code, &[], &[], &[]).is_err());
+    }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,0 +1,670 @@
+#![allow(unused_macros)]
+
+use std::collections::HashMap;
+use std::convert::{From, TryFrom};
+use std::fmt;
+use std::ops::{Index, IndexMut};
+
+use indexmap::IndexMap;
+use serde_json::{json, Value as JsonValue};
+
+use crate::error::{err, BoxedError, Error as CESRError, Result};
+
+pub trait Data {
+    fn to_json(&self) -> Result<String>;
+    fn to_cesr(&self) -> Result<String>;
+    fn to_cesrb(&self) -> Result<Vec<u8>>;
+}
+
+pub type Array = Vec<Value>;
+pub type Object = IndexMap<String, Value>;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Number {
+    f: f64,
+    i: i64,
+    float: bool,
+}
+
+impl From<f64> for Number {
+    fn from(f: f64) -> Self {
+        Self { f, i: 0, float: true }
+    }
+}
+
+impl From<i64> for Number {
+    fn from(i: i64) -> Self {
+        Self { f: 0.0, i, float: false }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Value {
+    Null,
+    Boolean(bool),
+    Number(Number),
+    String(String),
+    Array(Array),
+    Object(Object),
+}
+
+impl Value {
+    pub fn to_bool(&self) -> Result<bool> {
+        bool::try_from(self)
+    }
+
+    #[allow(clippy::inherent_to_string_shadow_display)]
+    pub fn to_string(&self) -> Result<String> {
+        String::try_from(self)
+    }
+
+    pub fn to_i64(&self) -> Result<i64> {
+        i64::try_from(self)
+    }
+
+    pub fn to_f64(&self) -> Result<f64> {
+        f64::try_from(self)
+    }
+
+    pub fn to_vec(&self) -> Result<Vec<Value>> {
+        Vec::try_from(self)
+    }
+
+    pub fn to_map(&self) -> Result<IndexMap<String, Value>> {
+        IndexMap::try_from(self)
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let json = match self.to_json() {
+            Ok(j) => j,
+            // hopefully unreachable (.to_json() should never blow up)
+            Err(_) => return Err(fmt::Error),
+        };
+        write!(f, "{}", json)
+    }
+}
+
+impl Index<usize> for Value {
+    type Output = Value;
+    fn index(&self, i: usize) -> &Self::Output {
+        match self {
+            Value::Array(a) => &a[i],
+            Value::Object(o) => &o[i],
+            _ => panic!("attempted to index non-indexable Value object with usize"),
+        }
+    }
+}
+
+impl Index<&str> for Value {
+    type Output = Value;
+    fn index(&self, i: &str) -> &Self::Output {
+        match self {
+            Value::Object(o) => &o[i],
+            _ => panic!("attempted to index non-indexable Value object with string"),
+        }
+    }
+}
+
+impl IndexMut<usize> for Value {
+    fn index_mut(&mut self, i: usize) -> &mut Value {
+        match self {
+            Value::Array(a) => &mut a[i],
+            Value::Object(o) => &mut o[i],
+            _ => panic!("attempted to mutably index non-indexable Value object with usize"),
+        }
+    }
+}
+
+impl IndexMut<&str> for Value {
+    fn index_mut(&mut self, i: &str) -> &mut Value {
+        match self {
+            Value::Object(o) => &mut o[i],
+            _ => panic!("attempted to mutably index non-indexable Value object with string"),
+        }
+    }
+}
+
+impl Data for Value {
+    fn to_json(&self) -> Result<String> {
+        Ok(match self {
+            Self::Null => "null".to_string(),
+            Self::Boolean(b) => json!(b).to_string(),
+            Self::Number(n) => {
+                if n.float {
+                    json!(n.f).to_string()
+                } else {
+                    json!(n.i).to_string()
+                }
+            }
+            Self::String(s) => json!(s).to_string(),
+            Self::Array(a) => {
+                let mut v = Vec::new();
+                for element in a {
+                    v.push(element.to_json()?);
+                }
+                format!("[{}]", v.join(","))
+            }
+            Self::Object(o) => {
+                let mut v = Vec::new();
+                for (key, value) in o {
+                    v.push(format!("{}:{}", json!(key), value.to_json()?));
+                }
+                format!("{{{}}}", v.join(","))
+            }
+        })
+    }
+
+    fn to_cesr(&self) -> Result<String> {
+        unimplemented!();
+    }
+
+    fn to_cesrb(&self) -> Result<Vec<u8>> {
+        unimplemented!();
+    }
+}
+
+impl From<f32> for Value {
+    fn from(x: f32) -> Self {
+        Self::Number(Number::from(x as f64))
+    }
+}
+
+impl From<f64> for Value {
+    fn from(x: f64) -> Self {
+        Self::Number(Number::from(x))
+    }
+}
+
+impl From<i8> for Value {
+    fn from(i: i8) -> Self {
+        Self::Number(Number::from(i as i64))
+    }
+}
+
+impl From<i16> for Value {
+    fn from(i: i16) -> Self {
+        Self::Number(Number::from(i as i64))
+    }
+}
+
+impl From<i32> for Value {
+    fn from(i: i32) -> Self {
+        Self::Number(Number::from(i as i64))
+    }
+}
+
+impl From<i64> for Value {
+    fn from(i: i64) -> Self {
+        Self::Number(Number::from(i))
+    }
+}
+
+impl From<u8> for Value {
+    fn from(i: u8) -> Self {
+        Self::Number(Number::from(i as i64))
+    }
+}
+
+impl From<u16> for Value {
+    fn from(i: u16) -> Self {
+        Self::Number(Number::from(i as i64))
+    }
+}
+
+impl From<u32> for Value {
+    fn from(i: u32) -> Self {
+        Self::Number(Number::from(i as i64))
+    }
+}
+
+impl From<&str> for Value {
+    fn from(s: &str) -> Self {
+        Self::String(s.to_string())
+    }
+}
+
+impl From<&String> for Value {
+    fn from(s: &String) -> Self {
+        Self::String(s.clone())
+    }
+}
+
+impl From<&[Value]> for Value {
+    fn from(a: &[Value]) -> Self {
+        Self::Array(a.to_vec())
+    }
+}
+
+impl From<&HashMap<String, Value>> for Value {
+    fn from(h: &HashMap<String, Value>) -> Self {
+        let mut map = IndexMap::new();
+        for (k, v) in h {
+            map.insert(k.to_string(), v.clone());
+        }
+        Self::Object(map)
+    }
+}
+
+impl From<&IndexMap<String, Value>> for Value {
+    fn from(m: &IndexMap<String, Value>) -> Self {
+        Self::Object(m.clone())
+    }
+}
+
+impl From<&JsonValue> for Value {
+    fn from(v: &JsonValue) -> Self {
+        match v {
+            JsonValue::Null => Self::Null,
+            JsonValue::Bool(b) => Self::Boolean(*b),
+            JsonValue::Number(n) => {
+                if n.to_string().contains('.') {
+                    Self::Number(Number::from(n.as_f64().unwrap()))
+                } else {
+                    Self::Number(Number::from(n.as_i64().unwrap()))
+                }
+            }
+            JsonValue::String(s) => Self::String(s.clone()),
+            JsonValue::Array(a) => {
+                let mut v = Array::new();
+                for e in a {
+                    v.push(Self::from(e));
+                }
+                Self::Array(v)
+            }
+            JsonValue::Object(o) => {
+                let mut m = Object::new();
+                for (k, v) in o {
+                    m.insert(k.clone(), Self::from(v));
+                }
+                Self::Object(m)
+            }
+        }
+    }
+}
+
+impl TryFrom<&Value> for String {
+    type Error = BoxedError;
+
+    fn try_from(v: &Value) -> Result<Self> {
+        match v {
+            Value::String(s) => Ok(s.clone()),
+            _ => err!(CESRError::Conversion("could not convert value to string".to_string())),
+        }
+    }
+}
+
+impl TryFrom<&Value> for bool {
+    type Error = BoxedError;
+
+    fn try_from(v: &Value) -> Result<Self> {
+        match v {
+            Value::Boolean(b) => Ok(*b),
+            _ => err!(CESRError::Conversion("could not convert value to bool".to_string())),
+        }
+    }
+}
+
+impl TryFrom<&Value> for i64 {
+    type Error = BoxedError;
+
+    fn try_from(v: &Value) -> Result<Self> {
+        match v {
+            Value::Number(n) => {
+                if !n.float {
+                    Ok(n.i)
+                } else {
+                    Ok(n.f as i64)
+                }
+            }
+            _ => err!(CESRError::Conversion("could not convert value to integer".to_string())),
+        }
+    }
+}
+
+impl TryFrom<&Value> for f64 {
+    type Error = BoxedError;
+
+    fn try_from(v: &Value) -> Result<Self> {
+        match v {
+            Value::Number(n) => {
+                if n.float {
+                    Ok(n.f)
+                } else {
+                    Ok(n.i as f64)
+                }
+            }
+            _ => err!(CESRError::Conversion("could not convert value to float".to_string())),
+        }
+    }
+}
+
+impl TryFrom<&Value> for Vec<Value> {
+    type Error = BoxedError;
+
+    fn try_from(v: &Value) -> Result<Self> {
+        match v {
+            Value::Array(a) => Ok(a.clone()),
+            _ => err!(CESRError::Conversion("could not convert value to array".to_string())),
+        }
+    }
+}
+
+impl TryFrom<&Value> for IndexMap<String, Value> {
+    type Error = BoxedError;
+
+    fn try_from(v: &Value) -> Result<Self> {
+        match v {
+            Value::Object(o) => Ok(o.clone()),
+            _ => err!(CESRError::Conversion("could not convert value to map".to_string())),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! data {
+    ($($data:tt)+) => {
+        data_internal!($($data)+)
+    };
+}
+
+macro_rules! data_internal {
+    // arrays
+
+    // Done with trailing comma.
+    (@array [$($elems:expr,)*]) => {
+        data_internal_vec![$($elems,)*]
+    };
+
+    // Done without trailing comma.
+    (@array [$($elems:expr),*]) => {
+        data_internal_vec![$($elems),*]
+    };
+
+    // Next element is `null`.
+    (@array [$($elems:expr,)*] null $($rest:tt)*) => {
+        data_internal!(@array [$($elems,)* data_internal!(null)] $($rest)*)
+    };
+
+    // Next element is `true`.
+    (@array [$($elems:expr,)*] true $($rest:tt)*) => {
+        data_internal!(@array [$($elems,)* data_internal!(true)] $($rest)*)
+    };
+
+    // Next element is `false`.
+    (@array [$($elems:expr,)*] false $($rest:tt)*) => {
+        data_internal!(@array [$($elems,)* data_internal!(false)] $($rest)*)
+    };
+
+    // Next element is an array.
+    (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
+        data_internal!(@array [$($elems,)* data_internal!([$($array)*])] $($rest)*)
+    };
+
+    // Next element is a map.
+    (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
+        data_internal!(@array [$($elems,)* data_internal!({$($map)*})] $($rest)*)
+    };
+
+    // Next element is an expression followed by comma.
+    (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
+        data_internal!(@array [$($elems,)* data_internal!($next),] $($rest)*)
+    };
+
+    // Last element is an expression with no trailing comma.
+    (@array [$($elems:expr,)*] $last:expr) => {
+        data_internal!(@array [$($elems,)* data_internal!($last)])
+    };
+
+    // Comma after the most recent element.
+    (@array [$($elems:expr),*] , $($rest:tt)*) => {
+        data_internal!(@array [$($elems,)*] $($rest)*)
+    };
+
+    // Unexpected token after most recent element.
+    (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
+        data_unexpected!($unexpected)
+    };
+
+    // objects
+
+    // Done.
+    (@object $object:ident () () ()) => {};
+
+    // Insert the current entry followed by trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+        data_internal!(@object $object () ($($rest)*) ($($rest)*));
+    };
+
+    // Current entry followed by unexpected token.
+    (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
+        data_unexpected!($unexpected);
+    };
+
+    // Insert the last entry without trailing comma.
+    (@object $object:ident [$($key:tt)+] ($value:expr)) => {
+        let _ = $object.insert(($($key)+).into(), $value);
+    };
+
+    // Next value is `null`.
+    (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
+        data_internal!(@object $object [$($key)+] (data_internal!(null)) $($rest)*);
+    };
+
+    // Next value is `true`.
+    (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
+        data_internal!(@object $object [$($key)+] (data_internal!(true)) $($rest)*);
+    };
+
+    // Next value is `false`.
+    (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
+        data_internal!(@object $object [$($key)+] (data_internal!(false)) $($rest)*);
+    };
+
+    // Next value is an array.
+    (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
+        data_internal!(@object $object [$($key)+] (data_internal!([$($array)*])) $($rest)*);
+    };
+
+    // Next value is a map.
+    (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
+        data_internal!(@object $object [$($key)+] (data_internal!({$($map)*})) $($rest)*);
+    };
+
+    // Next value is an expression followed by comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
+        data_internal!(@object $object [$($key)+] (data_internal!($value)) , $($rest)*);
+    };
+
+    // Last value is an expression with no trailing comma.
+    (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
+        data_internal!(@object $object [$($key)+] (data_internal!($value)));
+    };
+
+    // Missing value for last entry. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
+        // "unexpected end of macro invocation"
+        data_internal!();
+    };
+
+    // Missing colon and value for last entry. Trigger a reasonable error
+    // message.
+    (@object $object:ident ($($key:tt)+) () $copy:tt) => {
+        // "unexpected end of macro invocation"
+        data_internal!();
+    };
+
+    // Misplaced colon. Trigger a reasonable error message.
+    (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `:`".
+        data_unexpected!($colon);
+    };
+
+    // Found a comma inside a key. Trigger a reasonable error message.
+    (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
+        // Takes no arguments so "no rules expected the token `,`".
+        data_unexpected!($comma);
+    };
+
+    // Key is fully parenthesized. This avoids clippy double_parens false
+    // positives because the parenthesization may be necessary here.
+    (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
+        data_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+    };
+
+    // Refuse to absorb colon token into key expression.
+    (@object $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
+        data_expect_expr_comma!($($unexpected)+);
+    };
+
+    // Munch a token into the current key.
+    (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
+        data_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+    };
+
+    // core logic
+
+    (null) => {
+        $crate::data::Value::Null
+    };
+
+    (true) => {
+        $crate::data::Value::Boolean(true)
+    };
+
+    (false) => {
+        $crate::data::Value::Boolean(false)
+    };
+
+    ([]) => {
+        $crate::data::Value::Array($crate::data::Array::new())
+    };
+
+    ([ $($tt:tt)+ ]) => {{
+        data_internal!(@array [] $($tt)+)
+    }};
+
+    ({}) => {
+        $crate::data::Value::Object($crate::data::Object::new())
+    };
+
+    ({ $($tt:tt)+ }) => {{
+        let mut object = $crate::data::Object::new();
+        data_internal!(@object object () ($($tt)+) ($($tt)+));
+        $crate::data::Value::Object(object)
+    }};
+
+    ($other:expr) => {
+        $crate::data::Value::from($other)
+    }
+}
+
+macro_rules! data_internal_vec {
+    ($($content:tt)*) => {{
+        $crate::data::Value::Array(vec![$($content)*])
+    }};
+}
+
+macro_rules! data_unexpected {
+    () => {};
+}
+
+macro_rules! data_expect_expr_comma {
+    ($e:expr , $($tt:tt)*) => {};
+}
+
+pub use data;
+
+#[cfg(test)]
+mod test {
+    use crate::data::{data, Data, Value};
+
+    #[test]
+    fn macros() {
+        let x: i64 = -1234567890;
+        let s = "string".to_string();
+
+        let mut d = data!({
+            "thing": 2,
+            "other thing": [&s, 1.666, x, true, {"nested array": [{}, []]}],
+            "last thing": null
+        });
+
+        // to_json()
+        assert_eq!(
+            d.to_json().unwrap(),
+            "{\"thing\":2,\"other thing\":[\"string\",1.666,-1234567890,true,{\"nested array\":[{},[]]}],\"last thing\":null}"
+        );
+
+        // query/indexing
+        assert_eq!(d["thing"], d[0]); // we can index into an object with an integer or string key
+        assert_ne!(d["thing"], d[1]);
+
+        // display
+        assert_eq!(format!("{}", d["thing"]), "2");
+
+        // data extraction
+        assert_eq!(d["last thing"], Value::Null);
+        assert!(d["other thing"][3].to_bool().unwrap());
+        assert_eq!(d["thing"].to_i64().unwrap(), 2);
+        assert_eq!(d["other thing"][1].to_f64().unwrap(), 1.666);
+        assert_eq!(d["other thing"][0].to_string().unwrap(), "string");
+        assert_eq!(d["other thing"][4]["nested array"][1].to_vec().unwrap(), vec![]);
+        assert_eq!(
+            d["other thing"][4]["nested array"][0].to_map().unwrap(),
+            indexmap::IndexMap::new()
+        );
+
+        // mutability
+        d["thing"] = data!({"something more complex": {"key": 987654321 }});
+        d[1][1] = data!(true);
+        assert_eq!(
+            d.to_json().unwrap(),
+            "{\"thing\":{\"something more complex\":{\"key\":987654321}},\"other thing\":[\"string\",true,-1234567890,true,{\"nested array\":[{},[]]}],\"last thing\":null}"
+        );
+
+        // serde_json parsing interop
+        let v: serde_json::Value = serde_json::from_str(&d.to_json().unwrap()).unwrap();
+        let d2 = Value::from(&v);
+        assert_eq!(d.to_json().unwrap(), d2.to_json().unwrap());
+    }
+
+    #[test]
+    fn value() {
+        assert!(data!({}).to_json().is_ok());
+        // assert!(data!({}).to_cesr().is_err());
+        // assert!(data!({}).to_cesrb().is_err());
+
+        let array: &[Value] = &[];
+        let mut hash_map = std::collections::HashMap::<String, Value>::new();
+        hash_map.insert("test".to_string(), data!(true));
+        let d = data!({
+            "f32": 0 as f32,
+            "f64": 0 as f64,
+            "i8": 0 as i8,
+            "i16": 0 as i16,
+            "i32": 0 as i32,
+            "i64": 0 as i64,
+            "u8": 0 as u8,
+            "u16": 0 as u16,
+            "u32": 0 as u32,
+            "hash map": &hash_map,
+            "array": array,
+        });
+        let json = d.to_json().unwrap();
+        assert_eq!(json, "{\"f32\":0.0,\"f64\":0.0,\"i8\":0,\"i16\":0,\"i32\":0,\"i64\":0,\"u8\":0,\"u16\":0,\"u32\":0,\"hash map\":{\"test\":true},\"array\":[]}");
+        assert!(d[0].to_bool().is_err());
+        assert!(d["hash map"].to_i64().is_err());
+        assert!(d["hash map"].to_f64().is_err());
+        assert!(d["f32"].to_vec().is_err());
+        assert!(d["f32"].to_map().is_err());
+        assert!(d["f64"].to_i64().is_ok());
+        assert!(d["i64"].to_f64().is_ok());
+
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let d2 = Value::from(&v);
+        assert_eq!(json, d2.to_json().unwrap());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 // TODO: remove before 1.0.0
 #![allow(dead_code)]
 
+#[macro_use]
+mod data;
 mod core;
+mod crypto;
 mod error;
 
 pub use crate::core::{
@@ -9,6 +12,7 @@ pub use crate::core::{
     counter::{tables as counter, Counter},
     diger::Diger,
     matter::{tables as matter, Matter},
+    saider::Saider,
     siger::Siger,
     signer::Signer,
     util,


### PR DESCRIPTION
## Rationale

This is one of the most critical pieces of the KERI space in general. Saidifying data is really the guts of what CESR is all about.

## Changes

- implements `Saider`
- implements `Value` data object and `data!()` macro - these allow us to construct arbitrarily shaped data more easily
- moves crypto to crypto modules `hash` and `sign`
- creates `common` module for common things like `versify()`...
- cleans up code
- uses `Option<>` quite a bit, and this is new for us. I'm thinking to make a ticket and go back to the existing code to do the same, now that I've figured out a few good patterns
- renames test modules to `test` and removes `test_` prefix from functions to eliminate redundancy
- executes `cargo fmt` earlier in CI to save credits
- bumps checkout action version

## Testing

Ported the meat of the KERIpy tests.

```
make clean preflight
```
