### PR TITLE
Option<T> refactor

### DIFF
--- a/src/core/diger.rs
+++ b/src/core/diger.rs
@@ -40,38 +40,46 @@ fn validate_code(code: &str) -> Result<()> {
 }
 
 impl Diger {
-    fn new_with_code_and_raw(code: &str, raw: &[u8]) -> Result<Self> {
-        validate_code(code)?;
-        Matter::new_with_code_and_raw(code, raw)
+    pub fn new(
+        ser: Option<&[u8]>,
+        code: Option<&str>,
+        raw: Option<&[u8]>,
+        qb64b: Option<&mut Vec<u8>>,
+        qb64: Option<&str>,
+        qb2: Option<&mut Vec<u8>>,
+        strip: Option<bool>,
+    ) -> Result<Self> {
+        let result = Matter::new(code, raw, qb64b, qb64, qb2, strip);
+        if result.is_ok() {
+            let diger: Self = result?;
+            validate_code(&diger.code())?;
+            Ok(diger)
+        } else if let Some(ser) = ser {
+            Self::new_with_code_and_ser(code.unwrap_or(matter::Codex::Blake3_256), ser)
+        } else {
+            err!(Error::Validation("failure creating diger".to_string()))
+        }
     }
 
-    fn new_with_qb64(qb64: &str) -> Result<Self> {
-        let diger: Diger = Matter::new_with_qb64(qb64)?;
-        validate_code(&diger.code)?;
-        Ok(diger)
+    pub fn verify(&self, ser: &[u8]) -> Result<bool> {
+        let dig = hash::digest(&self.code(), ser)?;
+        Ok(dig == self.raw())
     }
 
-    fn new_with_qb64b(qb64b: &[u8]) -> Result<Self> {
-        let diger: Diger = Matter::new_with_qb64b(qb64b)?;
-        validate_code(&diger.code)?;
-        Ok(diger)
+    pub fn compare(&self, ser: &[u8], dig: Option<&[u8]>, diger: Option<&Diger>) -> Result<bool> {
+        if let Some(dig) = dig {
+            self.compare_dig(ser, dig)
+        } else if let Some(diger) = diger {
+            self.compare_diger(ser, diger)
+        } else {
+            err!(Error::Value("both dig and diger may not be none".to_string()))
+        }
     }
 
-    fn new_with_qb2(qb2: &[u8]) -> Result<Self> {
-        let diger: Diger = Matter::new_with_qb2(qb2)?;
-        validate_code(&diger.code)?;
-        Ok(diger)
-    }
-
-    pub fn new_with_code_and_ser(code: &str, ser: &[u8]) -> Result<Self> {
+    fn new_with_code_and_ser(code: &str, ser: &[u8]) -> Result<Self> {
         validate_code(code)?;
         let dig = hash::digest(code, ser)?;
         Matter::new_with_code_and_raw(code, &dig)
-    }
-
-    fn verify(&self, ser: &[u8]) -> Result<bool> {
-        let dig = hash::digest(&self.code(), ser)?;
-        Ok(dig == self.raw())
     }
 
     fn compare_dig(&self, ser: &[u8], dig: &[u8]) -> Result<bool> {
@@ -79,7 +87,7 @@ impl Diger {
             return Ok(true);
         }
 
-        let diger = <Diger as Matter>::new_with_qb64b(dig)?;
+        let diger = <Diger as Matter>::new(None, None, Some(&mut dig.to_vec()), None, None, None)?;
 
         if diger.code() == self.code() {
             return Ok(false);
@@ -142,53 +150,56 @@ mod test {
     use crate::core::matter::{tables as matter, Matter};
     use crate::crypto::hash;
     use hex_literal::hex;
+    use rstest::rstest;
+
+    #[rstest]
+    fn conversions(
+        #[values(matter::Codex::Blake3_256)] _code: &str,
+        #[values(b"abcdefghijklmnopqrstuvwxyz0123456789")] _ser: &[u8],
+        #[values(Diger::new(Some(_ser), Some(_code), None, None, None, None, None).unwrap())]
+        control: Diger,
+        #[values(
+            Diger::new(None, Some(_code), Some(&control.raw()), None, None, None, None).unwrap(),
+            Diger::new(None, None, None, Some(&mut control.qb64b().unwrap()), None, None, None).unwrap(),
+            Diger::new(None, None, None, None, Some(&control.qb64().unwrap()), None, None).unwrap(),
+            Diger::new(None, None, None, None, None, Some(&mut control.qb2().unwrap()), None).unwrap()
+        )]
+        diger: Diger,
+    ) {
+        assert_eq!(diger.qb64().unwrap(), control.qb64().unwrap());
+        assert_eq!(diger.qb64b().unwrap(), control.qb64b().unwrap());
+        assert_eq!(diger.qb2().unwrap(), control.qb2().unwrap());
+        assert_eq!(diger.code(), control.code());
+    }
+
+    #[rstest]
+    fn invalid(
+        #[values(matter::Codex::Blake3_256)] _code: &str,
+        #[values(b"abcdefghijklmnopqrstuvwxyz0123456789")] _raw: &[u8],
+        #[values(<Diger as Matter>::new(Some(matter::Codex::Ed25519), Some(_raw), None, None, None, None).unwrap())]
+        _control: Diger,
+        #[values(
+            Diger::new(None, None, None, Some(&mut _control.qb64b().unwrap()), None, None, None).is_err(),
+            Diger::new(None, None, None, None, Some(&_control.qb64().unwrap()), None, None).is_err(),
+            Diger::new(None, None, None, None, None, Some(&mut _control.qb2().unwrap()), None).is_err()
+        )]
+        result: bool,
+    ) {
+        assert!(result);
+    }
 
     #[test]
-    fn new_with_code_and_raw() {
-        let raw = hex!("0123456789abcdef00001111222233334444555566667777888899990000aaaa");
+    fn compare() {
         let code = matter::Codex::Blake3_256;
+        let raw = hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f");
+        let ser = vec![0, 1, 2];
 
-        let d = Diger::new_with_code_and_raw(code, &raw).unwrap();
-        assert_eq!(d.raw(), raw);
-    }
-
-    #[test]
-    fn new_with_qb64() {
-        let raw = b"abcdefghijklmnopqrstuvwxyz012345";
-
-        let valid_diger: Diger =
-            Matter::new_with_code_and_raw(matter::Codex::Blake3_256, raw).unwrap();
-        let invalid_diger: Diger =
-            Matter::new_with_code_and_raw(matter::Codex::Ed25519, raw).unwrap();
-
-        assert!(Diger::new_with_qb64(&valid_diger.qb64().unwrap()).is_ok());
-        assert!(Diger::new_with_qb64(&invalid_diger.qb64().unwrap()).is_err());
-    }
-
-    #[test]
-    fn new_with_qb64b() {
-        let raw = b"abcdefghijklmnopqrstuvwxyz012345";
-
-        let valid_diger: Diger =
-            Matter::new_with_code_and_raw(matter::Codex::Blake3_256, raw).unwrap();
-        let invalid_diger: Diger =
-            Matter::new_with_code_and_raw(matter::Codex::Ed25519, raw).unwrap();
-
-        assert!(Diger::new_with_qb64b(&valid_diger.qb64b().unwrap()).is_ok());
-        assert!(Diger::new_with_qb64b(&invalid_diger.qb64b().unwrap()).is_err());
-    }
-
-    #[test]
-    fn new_with_qb2() {
-        let raw = b"abcdefghijklmnopqrstuvwxyz012345";
-
-        let valid_diger: Diger =
-            Matter::new_with_code_and_raw(matter::Codex::Blake3_256, raw).unwrap();
-        let invalid_diger: Diger =
-            Matter::new_with_code_and_raw(matter::Codex::Ed25519, raw).unwrap();
-
-        assert!(Diger::new_with_qb2(&valid_diger.qb2().unwrap()).is_ok());
-        assert!(Diger::new_with_qb2(&invalid_diger.qb2().unwrap()).is_err());
+        // dig == self.qb64b() - should return true
+        let diger = Diger::new(None, Some(code), Some(&raw), None, None, None, None).unwrap();
+        let qb64b = diger.qb64b().unwrap();
+        assert!(diger.compare(&ser, Some(&qb64b), None).unwrap());
+        assert!(diger.compare(&ser, None, Some(&diger)).unwrap());
+        assert!(diger.compare(&ser, None, None).is_err());
     }
 
     #[test]
@@ -196,8 +207,10 @@ mod test {
         let raw = hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"
                                  "5b49b82f805a538c68915c1ae8035c900fd1d4b13902920fd05e1450822f36de");
 
-        let d = Diger::new_with_code_and_raw(matter::Codex::Blake3_512, &raw).unwrap();
-        assert!(d.verify(&vec![0, 1, 2]).unwrap());
+        let diger =
+            Diger::new(None, Some(matter::Codex::Blake3_512), Some(&raw), None, None, None, None)
+                .unwrap();
+        assert!(diger.verify(&vec![0, 1, 2]).unwrap());
     }
 
     #[test]
@@ -207,26 +220,26 @@ mod test {
         let ser = vec![0, 1, 2];
 
         // dig == self.qb64b() - should return true
-        let d = Diger::new_with_code_and_raw(code, &raw).unwrap();
-        let mut qb64b = d.qb64b().unwrap();
-        assert!(d.compare_dig(&ser, &qb64b).unwrap());
+        let diger = Diger::new(None, Some(code), Some(&raw), None, None, None, None).unwrap();
+        let mut qb64b = diger.qb64b().unwrap();
+        assert!(diger.compare(&ser, Some(&qb64b), None).unwrap());
 
         // diger.code == self.code, dig != qb64b - should return false
         let mut x = qb64b[30]; // break a piece of the value, without breaking encoding
         x = if x == 0 { 63 } else { x - 1 };
         qb64b[30] = x;
-        assert!(!d.compare_dig(&ser, &qb64b).unwrap());
+        assert!(!diger.compare(&ser, Some(&qb64b), None).unwrap());
 
         // same ser, different algorithm - should return true
-        let code2 = matter::Codex::Blake2b_256;
-        let raw2 = hash::digest(code2, &ser).unwrap();
-        let m2: Diger = Matter::new_with_code_and_raw(code2, &raw2).unwrap();
-        assert!(d.compare_dig(&ser, &m2.qb64b().unwrap()).unwrap());
+        let code = matter::Codex::Blake2b_256;
+        let raw = hash::digest(code, &ser).unwrap();
+        let matter: Diger = Matter::new(Some(code), Some(&raw), None, None, None, None).unwrap();
+        assert!(diger.compare(&ser, Some(&matter.qb64b().unwrap()), None).unwrap());
 
         // different ser, different algorithm - should return false
-        let raw2 = hash::digest(code2, &vec![0, 1, 2, 3]).unwrap();
-        let m2: Diger = Matter::new_with_code_and_raw(code2, &raw2).unwrap();
-        assert!(!d.compare_dig(&ser, &m2.qb64b().unwrap()).unwrap());
+        let raw = hash::digest(code, &vec![0, 1, 2, 3]).unwrap();
+        let matter: Diger = Matter::new(Some(code), Some(&raw), None, None, None, None).unwrap();
+        assert!(!diger.compare(&ser, Some(&matter.qb64b().unwrap()), None).unwrap());
     }
 
     #[test]
@@ -236,28 +249,28 @@ mod test {
         let ser = vec![0, 1, 2];
 
         // diger.qb64b() == self.qb64b() - should return true
-        let d = Diger::new_with_code_and_raw(code, &raw).unwrap();
-        let mut qb64b = d.qb64b().unwrap();
-        let d2 = Diger::new_with_qb64b(&qb64b).unwrap();
-        assert!(d.compare_diger(&ser, &d2).unwrap());
+        let diger = Diger::new(None, Some(code), Some(&raw), None, None, None, None).unwrap();
+        let mut qb64b = diger.qb64b().unwrap();
+        let d2 = Diger::new(None, None, None, Some(&mut qb64b), None, None, None).unwrap();
+        assert!(diger.compare(&ser, None, Some(&d2)).unwrap());
 
         // diger.code == self.code, diger.qb64() != self.qb64b() - should return false
         let mut x = qb64b[30]; // break a piece of the value, without breaking encoding
         x = if x == 0 { 63 } else { x - 1 };
         qb64b[30] = x;
-        let d2 = Diger::new_with_qb64b(&qb64b).unwrap();
-        assert!(!d.compare_diger(&ser, &d2).unwrap());
+        let d2 = Diger::new(None, None, None, Some(&mut qb64b), None, None, None).unwrap();
+        assert!(!diger.compare(&ser, None, Some(&d2)).unwrap());
 
         // same ser, different algorithm - should return true
         let code2 = matter::Codex::Blake2b_256;
         let raw2 = hash::digest(code2, &ser).unwrap();
-        let d2 = Diger::new_with_code_and_raw(code2, &raw2).unwrap();
-        assert!(d.compare_diger(&ser, &d2).unwrap());
+        let d2 = Diger::new(None, Some(code2), Some(&raw2), None, None, None, None).unwrap();
+        assert!(diger.compare(&ser, None, Some(&d2)).unwrap());
 
         // different ser, different algorithm - should return false
         let raw2 = hash::digest(code2, &vec![0, 1, 2, 3]).unwrap();
-        let d2 = Diger::new_with_code_and_raw(code2, &raw2).unwrap();
-        assert!(!d.compare_diger(&ser, &d2).unwrap());
+        let d2 = Diger::new(None, Some(code2), Some(&raw2), None, None, None, None).unwrap();
+        assert!(!diger.compare(&ser, None, Some(&d2)).unwrap());
     }
 
     #[test]
@@ -265,33 +278,42 @@ mod test {
         // compare() will exercise the most code
         let ser = b"abcdefghijklmnopqrstuvwxyz0123456789";
 
-        let diger0 = Diger::new_with_code_and_ser(matter::Codex::Blake3_256, ser).unwrap();
-        let diger1 = Diger::new_with_code_and_ser(matter::Codex::SHA3_256, ser).unwrap();
-        let diger2 = Diger::new_with_code_and_ser(matter::Codex::Blake2b_256, ser).unwrap();
+        let diger0 =
+            Diger::new(Some(ser), Some(matter::Codex::Blake3_256), None, None, None, None, None)
+                .unwrap();
+        let diger1 =
+            Diger::new(Some(ser), Some(matter::Codex::SHA3_256), None, None, None, None, None)
+                .unwrap();
+        let diger2 =
+            Diger::new(Some(ser), Some(matter::Codex::Blake2b_256), None, None, None, None, None)
+                .unwrap();
 
-        assert!(diger0.compare_diger(ser, &diger1).unwrap());
-        assert!(diger0.compare_diger(ser, &diger2).unwrap());
-        assert!(diger1.compare_diger(ser, &diger2).unwrap());
+        assert!(diger0.compare(ser, None, Some(&diger1)).unwrap());
+        assert!(diger0.compare(ser, None, Some(&diger2)).unwrap());
+        assert!(diger1.compare(ser, None, Some(&diger2)).unwrap());
 
-        assert!(diger0.compare_dig(ser, &diger1.qb64b().unwrap()).unwrap());
-        assert!(diger0.compare_dig(ser, &diger2.qb64b().unwrap()).unwrap());
-        assert!(diger1.compare_dig(ser, &diger2.qb64b().unwrap()).unwrap());
+        assert!(diger0.compare(ser, Some(&diger1.qb64b().unwrap()), None).unwrap());
+        assert!(diger0.compare(ser, Some(&diger2.qb64b().unwrap()), None).unwrap());
+        assert!(diger1.compare(ser, Some(&diger2.qb64b().unwrap()), None).unwrap());
 
         let ser1 = b"ABCDEFGHIJKLMNOPQSTUVWXYXZabcdefghijklmnopqrstuvwxyz0123456789";
-        let diger = Diger::new_with_code_and_ser(matter::Codex::Blake3_256, ser1).unwrap();
+        let diger =
+            Diger::new(Some(ser1), Some(matter::Codex::Blake3_256), None, None, None, None, None)
+                .unwrap();
 
-        assert!(!diger0.compare_diger(ser, &diger).unwrap()); // codes match
-        assert!(!diger0.compare_dig(ser, &diger.qb64b().unwrap()).unwrap()); // codes match
+        assert!(!diger0.compare(ser, None, Some(&diger)).unwrap());
+        assert!(!diger0.compare(ser, Some(&diger.qb64b().unwrap()), None).unwrap());
 
-        let diger = Diger::new_with_code_and_ser(matter::Codex::SHA3_256, ser1).unwrap();
+        let diger =
+            Diger::new(Some(ser1), Some(matter::Codex::SHA3_256), None, None, None, None, None)
+                .unwrap();
 
-        assert!(!diger0.compare_diger(ser, &diger).unwrap()); // codes match
-        assert!(!diger0.compare_dig(ser, &diger.qb64b().unwrap()).unwrap());
-        // codes match
+        assert!(!diger0.compare(ser, None, Some(&diger)).unwrap());
+        assert!(!diger0.compare(ser, Some(&diger.qb64b().unwrap()), None).unwrap());
     }
 
     #[test]
     fn unhappy_paths() {
-        assert!(hash::digest(matter::Codex::Big, &[]).is_err());
+        assert!(Diger::new(None, None, None, None, None, None, None).is_err());
     }
 }

--- a/src/core/sadder.rs
+++ b/src/core/sadder.rs
@@ -56,7 +56,7 @@ fn exhale(ked: &Value, kind: Option<&str>) -> Result<ExhaleResult> {
     })
 }
 
-pub trait Sadder: Default + Clone {
+pub(crate) trait Sadder: Default + Clone {
     fn code(&self) -> String;
     fn raw(&self) -> Vec<u8>;
     fn ked(&self) -> Value;
@@ -106,7 +106,18 @@ pub trait Sadder: Default + Clone {
         self.set_kind(&result.kind);
         self.set_size(result.size);
         self.set_version(&result.version);
-        self.set_saider(&Saider::new_with_qb64(&result.ked[Ids::d].to_string()?)?);
+        self.set_saider(&Saider::new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&result.ked[Ids::d].to_string()?),
+            None,
+            None,
+        )?);
 
         if self.code() != self.saider().code() {
             return err!(Error::Validation(
@@ -126,7 +137,18 @@ pub trait Sadder: Default + Clone {
         self.set_kind(&result.kind);
         self.set_size(result.raw.len() as u32);
         self.set_version(&result.version);
-        self.set_saider(&Saider::new_with_qb64(&result.ked[Ids::d].to_string()?)?);
+        self.set_saider(&Saider::new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&result.ked[Ids::d].to_string()?),
+            None,
+            None,
+        )?);
 
         if self.code() != self.saider().code() {
             return err!(Error::Validation(
@@ -146,7 +168,18 @@ pub trait Sadder: Default + Clone {
         self.set_kind(&result.kind);
         self.set_size(result.raw.len() as u32);
         self.set_version(&result.version);
-        self.set_saider(&Saider::new_with_qb64(&result.ked[Ids::d].to_string()?)?);
+        self.set_saider(&Saider::new(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&result.ked[Ids::d].to_string()?),
+            None,
+            None,
+        )?);
 
         if self.code() != self.saider().code() {
             return err!(Error::Validation(
@@ -312,8 +345,6 @@ mod test {
         });
 
         let (saider, ked) = Saider::saidify(&ked, None, None, None, None).unwrap();
-        // let said = saider.qb64().unwrap();
-
         let mut ked2 = ked.clone();
         ked2["v"] = data!("KERI11JSON000000_");
 
@@ -376,7 +407,7 @@ mod test {
 
         let sadder = TestSadder::new(None, None, None, Some(&ked), None).unwrap();
 
-        println!("{}", sadder.pretty(None).unwrap());
-        println!("{}", sadder.pretty(Some(10)).unwrap());
+        assert_eq!(sadder.pretty(None).unwrap(), "{\n  \"v\": \"KERI10JSON00004c_\",\n  \"d\": \"EN5gqodYDGPSYQvdixCjfD2leqb6zhPoDYcB21hfqu8d\"\n}");
+        assert_eq!(sadder.pretty(Some(10)).unwrap(), "{\n  \"v\": \"");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,11 +9,10 @@ mod error;
 
 pub use crate::core::{
     cigar::Cigar,
-    counter::{tables as counter, Counter},
+    counter::{tables as counter, Counter}, // This seems like it shoudl be an abstract class
     diger::Diger,
-    indexer::{tables as indexer, Indexer},
-    matter::{tables as matter, Matter},
-    sadder::Sadder,
+    indexer::tables as indexer,
+    matter::tables as matter,
     saider::Saider,
     siger::Siger,
     signer::Signer,


### PR DESCRIPTION
## Rationale

This PR adds `new()` methods with optional parameters to all the primitives, bringing us closer to `KERIpy`.

## Changes

- cleanup after #91
- adds `new()` methods, allowing for `strip` param
- refactors all tests to use `new()`/public methods
- removes unnecessary creation methods
- evaluates and updates scoping of exposed structs, traits and functions
- adds some more rstest things

## Testing

I tested all the paths in these new functions. My largest concern is that I may be incorrectly assigning or not assigning a default somewhere. I was quite careful though, I thought through all the use cases.

```
make clean preflight
```

## Notes

`Counter` remains a bit of a mess. I'm making another ticket, but essentially it is called an abstract class but I do not see its use in `coring.py`.. So it should probably be a trait, but it's not.