### PR TITLE
convenience

### DIFF
--- a/src/core/cigar.rs
+++ b/src/core/cigar.rs
@@ -40,17 +40,32 @@ impl Cigar {
         verfer: Option<&Verfer>,
         code: Option<&str>,
         raw: Option<&[u8]>,
-        qb64b: Option<&mut Vec<u8>>,
+        qb64b: Option<&[u8]>,
         qb64: Option<&str>,
-        qb2: Option<&mut Vec<u8>>,
-        strip: Option<bool>,
+        qb2: Option<&[u8]>,
     ) -> Result<Self> {
-        let mut cigar: Self = Matter::new(code, raw, qb64b, qb64, qb2, strip)?;
+        let mut cigar: Self = Matter::new(code, raw, qb64b, qb64, qb2)?;
         if let Some(verfer) = verfer {
             cigar.set_verfer(verfer);
         }
         validate_code(&cigar.code())?;
         Ok(cigar)
+    }
+
+    pub fn new_with_raw(raw: &[u8], verfer: Option<&Verfer>, code: Option<&str>) -> Result<Self> {
+        Self::new(verfer, code, Some(raw), None, None, None)
+    }
+
+    pub fn new_with_qb64b(qb64b: &[u8], verfer: Option<&Verfer>) -> Result<Self> {
+        Self::new(verfer, None, None, Some(qb64b), None, None)
+    }
+
+    pub fn new_with_qb64(qb64: &str, verfer: Option<&Verfer>) -> Result<Self> {
+        Self::new(verfer, None, None, None, Some(qb64), None)
+    }
+
+    pub fn new_with_qb2(qb2: &[u8], verfer: Option<&Verfer>) -> Result<Self> {
+        Self::new(verfer, None, None, None, None, Some(qb2))
     }
 
     pub fn verfer(&self) -> Verfer {
@@ -95,27 +110,42 @@ mod test {
     use crate::core::verfer::Verfer;
 
     #[test]
-    fn new() {
+    fn convenience() {
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
-        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None, None).unwrap();
+        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None).unwrap();
         let code = matter::Codex::Ed25519_Sig;
         let raw = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]";
 
-        assert!(Cigar::new(Some(&verfer), Some(code), Some(raw), None, None, None, None).is_ok());
-        assert!(Cigar::new(None, Some(code), Some(raw), None, None, None, None).is_ok());
+        let cigar = Cigar::new(Some(&verfer), Some(code), Some(raw), None, None, None).unwrap();
+
+        assert!(Cigar::new_with_raw(&cigar.raw(), Some(&verfer), Some(&cigar.code())).is_ok());
+        assert!(Cigar::new_with_qb64b(&cigar.qb64b().unwrap(), Some(&verfer)).is_ok());
+        assert!(Cigar::new_with_qb64(&cigar.qb64().unwrap(), Some(&verfer)).is_ok());
+        assert!(Cigar::new_with_qb2(&cigar.qb2().unwrap(), Some(&verfer)).is_ok());
+    }
+
+    #[test]
+    fn new() {
+        let vcode = matter::Codex::Ed25519;
+        let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
+        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None).unwrap();
+        let code = matter::Codex::Ed25519_Sig;
+        let raw = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]";
+
+        assert!(Cigar::new(Some(&verfer), Some(code), Some(raw), None, None, None,).is_ok());
+        assert!(Cigar::new(None, Some(code), Some(raw), None, None, None,).is_ok());
     }
 
     #[test]
     fn new_with_code_and_raw() {
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
-        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None, None).unwrap();
+        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None).unwrap();
         let code = matter::Codex::Ed25519_Sig;
         let raw = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ[]";
 
-        let cigar =
-            Cigar::new(Some(&verfer), Some(code), Some(raw), None, None, None, None).unwrap();
+        let cigar = Cigar::new(Some(&verfer), Some(code), Some(raw), None, None, None).unwrap();
         assert_eq!(cigar.code(), code);
         assert_eq!(cigar.raw(), raw);
         assert_eq!(cigar.verfer().raw(), verfer.raw());
@@ -127,9 +157,9 @@ mod test {
         let qsig64 = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ";
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
-        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None, None).unwrap();
+        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None).unwrap();
 
-        let cigar = Cigar::new(Some(&verfer), None, None, None, Some(qsig64), None, None).unwrap();
+        let cigar = Cigar::new(Some(&verfer), None, None, None, Some(qsig64), None).unwrap();
 
         assert_eq!(cigar.code(), matter::Codex::Ed25519_Sig);
         assert_eq!(cigar.qb64().unwrap(), qsig64);
@@ -142,11 +172,9 @@ mod test {
         let qsig64b = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ".as_bytes();
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
-        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None, None).unwrap();
+        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None).unwrap();
 
-        let cigar =
-            Cigar::new(Some(&verfer), None, None, Some(&mut qsig64b.to_vec()), None, None, None)
-                .unwrap();
+        let cigar = Cigar::new(Some(&verfer), None, None, Some(qsig64b), None, None).unwrap();
 
         assert_eq!(cigar.code(), matter::Codex::Ed25519_Sig);
         assert_eq!(cigar.qb64b().unwrap(), qsig64b);
@@ -164,11 +192,9 @@ mod test {
         ];
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
-        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None, None).unwrap();
+        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None).unwrap();
 
-        let cigar =
-            Cigar::new(Some(&verfer), None, None, None, None, Some(&mut qb2.to_vec()), None)
-                .unwrap();
+        let cigar = Cigar::new(Some(&verfer), None, None, None, None, Some(&qb2)).unwrap();
 
         // this is probably the most critical line (the previous is obviously important too)
         assert_eq!(cigar.code(), matter::Codex::Ed25519_Sig);
@@ -182,14 +208,13 @@ mod test {
         let qsig64 = "0BCdI8OSQkMJ9r-xigjEByEjIua7LHH3AOJ22PQKqljMhuhcgh9nGRcKnsz5KvKd7K_H9-1298F4Id1DxvIoEmCQ";
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
-        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None, None).unwrap();
+        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None).unwrap();
 
-        let mut cigar =
-            Cigar::new(Some(&verfer), None, None, None, Some(qsig64), None, None).unwrap();
+        let mut cigar = Cigar::new(Some(&verfer), None, None, None, Some(qsig64), None).unwrap();
 
         let vcode2 = matter::Codex::Ed25519N;
         let vraw2 = b"abcdefghijklmnopqrstuvwxyz543210";
-        let verfer2 = Verfer::new(Some(vcode2), Some(vraw2), None, None, None, None).unwrap();
+        let verfer2 = Verfer::new(Some(vcode2), Some(vraw2), None, None, None).unwrap();
 
         assert_ne!(cigar.verfer().raw(), vraw2);
         cigar.set_verfer(&verfer2);
@@ -200,8 +225,8 @@ mod test {
     fn unhappy_paths() {
         let vcode = matter::Codex::Ed25519;
         let vraw = b"abcdefghijklmnopqrstuvwxyz012345";
-        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None, None).unwrap();
+        let verfer = Verfer::new(Some(vcode), Some(vraw), None, None, None).unwrap();
 
-        assert!(Cigar::new(Some(&verfer), Some("CESR"), Some(&[]), None, None, None, None).is_err());
+        assert!(Cigar::new(Some(&verfer), Some("CESR"), Some(&[]), None, None, None,).is_err());
     }
 }

--- a/src/core/counter/mod.rs
+++ b/src/core/counter/mod.rs
@@ -14,13 +14,10 @@ impl Counter {
         count: Option<u32>,
         count_b64: Option<&str>,
         code: Option<&str>,
-        qb64b: Option<&mut Vec<u8>>,
+        qb64b: Option<&[u8]>,
         qb64: Option<&str>,
-        qb2: Option<&mut Vec<u8>>,
-        strip: Option<bool>,
+        qb2: Option<&[u8]>,
     ) -> Result<Self> {
-        let strip = strip.unwrap_or(false);
-
         if let Some(code) = code {
             let count = if let Some(count) = count {
                 count
@@ -32,23 +29,11 @@ impl Counter {
 
             Self::new_with_code_and_count(code, count)
         } else if let Some(qb64b) = qb64b {
-            let counter = Self::new_with_qb64b(qb64b)?;
-            if strip {
-                let szg = tables::sizage(&counter.code())?;
-                let length = szg.fs as usize;
-                qb64b.drain(0..length);
-            }
-            Ok(counter)
+            Self::new_with_qb64b(qb64b)
         } else if let Some(qb64) = qb64 {
             Self::new_with_qb64(qb64)
         } else if let Some(qb2) = qb2 {
-            let counter = Self::new_with_qb2(qb2)?;
-            if strip {
-                let szg = tables::sizage(&counter.code())?;
-                let length = (szg.fs * 3 / 4) as usize;
-                qb2.drain(0..length);
-            }
-            Ok(counter)
+            Self::new_with_qb2(qb2)
         } else {
             err!(Error::Validation("need either code and count, qb64b, qb64 or qb2".to_string()))
         }
@@ -337,14 +322,13 @@ mod test {
     #[case("-AAF", 5, "F", counter::Codex::ControllerIdxSigs)]
     #[case("-0VAAAQA", 1024, "QA", counter::Codex::BigAttachedMaterialQuadlets)]
     fn new(#[case] qsc: &str, #[case] count: u32, #[case] count_b64: &str, #[case] code: &str) {
-        assert!(Counter::new(None, None, None, None, None, None, None).is_err());
-        let counter = Counter::new(None, None, Some(code), None, None, None, None).unwrap();
+        assert!(Counter::new(None, None, None, None, None, None).is_err());
+        let counter = Counter::new(None, None, Some(code), None, None, None).unwrap();
         assert_eq!(counter.count(), 1);
 
-        let counter1 = Counter::new(Some(count), None, Some(code), None, None, None, None).unwrap();
-        let counter2 =
-            Counter::new(None, Some(count_b64), Some(code), None, None, None, None).unwrap();
-        let counter3 = Counter::new(None, None, None, None, Some(qsc), None, None).unwrap();
+        let counter1 = Counter::new(Some(count), None, Some(code), None, None, None).unwrap();
+        let counter2 = Counter::new(None, Some(count_b64), Some(code), None, None, None).unwrap();
+        let counter3 = Counter::new(None, None, None, None, Some(qsc), None).unwrap();
 
         assert_eq!(counter1.code(), code);
         assert_eq!(counter2.code(), code);
@@ -353,24 +337,11 @@ mod test {
         assert_eq!(counter2.count(), count);
         assert_eq!(counter3.count(), count);
 
-        let mut qb64b = counter1.qb64b().unwrap();
-        let mut qb2 = counter1.qb2().unwrap();
+        let qb64b = counter1.qb64b().unwrap();
+        let qb2 = counter1.qb2().unwrap();
 
-        assert!(Counter::new(None, None, None, Some(&mut qb64b), None, None, None).is_ok());
-        let length = qb64b.len();
-        qb64b.resize(length + 256, b'\x00');
-        assert_eq!(qb64b.len(), length + 256);
-        assert!(Counter::new(None, None, None, Some(&mut qb64b), None, None, Some(true)).is_ok());
-        assert_eq!(qb64b.len(), 256);
-        assert_eq!(qb64b, vec![b'\x00'; 256]);
-
-        assert!(Counter::new(None, None, None, None, None, Some(&mut qb2), None).is_ok());
-        let length = qb2.len();
-        qb2.resize(length + 256, b'\x00');
-        assert_eq!(qb2.len(), length + 256);
-        assert!(Counter::new(None, None, None, None, None, Some(&mut qb2), Some(true)).is_ok());
-        assert_eq!(qb2.len(), 256);
-        assert_eq!(qb2, vec![b'\x00'; 256]);
+        assert!(Counter::new(None, None, None, Some(&qb64b), None, None).is_ok());
+        assert!(Counter::new(None, None, None, None, None, Some(&qb2)).is_ok());
     }
 
     #[rstest]
@@ -384,15 +355,13 @@ mod test {
         #[case] code: &str,
     ) {
         let qscb = qsc.as_bytes();
-        let mut qscb2 = b64_engine::URL_SAFE.decode(qsc).unwrap();
+        let qscb2 = b64_engine::URL_SAFE.decode(qsc).unwrap();
 
-        let counter1 = Counter::new(Some(count), None, Some(code), None, None, None, None).unwrap();
-        let counter2 =
-            Counter::new(None, Some(count_b64), Some(code), None, None, None, None).unwrap();
-        let counter3 = Counter::new(None, None, None, None, Some(qsc), None, None).unwrap();
-        let counter4 =
-            Counter::new(None, None, None, Some(&mut qscb.to_vec()), None, None, None).unwrap();
-        let counter5 = Counter::new(None, None, None, None, None, Some(&mut qscb2), None).unwrap();
+        let counter1 = Counter::new(Some(count), None, Some(code), None, None, None).unwrap();
+        let counter2 = Counter::new(None, Some(count_b64), Some(code), None, None, None).unwrap();
+        let counter3 = Counter::new(None, None, None, None, Some(qsc), None).unwrap();
+        let counter4 = Counter::new(None, None, None, Some(qscb), None, None).unwrap();
+        let counter5 = Counter::new(None, None, None, None, None, Some(&qscb2)).unwrap();
 
         assert_eq!(counter1.code(), counter2.code());
         assert_eq!(counter1.count(), counter2.count());
@@ -415,15 +384,13 @@ mod test {
     ) {
         let qsc = &format!("{code}{version}");
         let qscb = qsc.as_bytes();
-        let mut qscb2 = b64_engine::URL_SAFE.decode(qsc).unwrap();
+        let qscb2 = b64_engine::URL_SAFE.decode(qsc).unwrap();
 
-        let counter1 = Counter::new(Some(count), None, Some(code), None, None, None, None).unwrap();
-        let counter2 =
-            Counter::new(None, Some(count_b64), Some(code), None, None, None, None).unwrap();
-        let counter3 = Counter::new(None, None, None, None, Some(qsc), None, None).unwrap();
-        let counter4 =
-            Counter::new(None, None, None, Some(&mut qscb.to_vec()), None, None, None).unwrap();
-        let counter5 = Counter::new(None, None, None, None, None, Some(&mut qscb2), None).unwrap();
+        let counter1 = Counter::new(Some(count), None, Some(code), None, None, None).unwrap();
+        let counter2 = Counter::new(None, Some(count_b64), Some(code), None, None, None).unwrap();
+        let counter3 = Counter::new(None, None, None, None, Some(qsc), None).unwrap();
+        let counter4 = Counter::new(None, None, None, Some(qscb), None, None).unwrap();
+        let counter5 = Counter::new(None, None, None, None, None, Some(&qscb2)).unwrap();
 
         assert_eq!(counter1.code(), code);
         assert_eq!(counter1.count(), verint);
@@ -446,7 +413,7 @@ mod test {
     fn b64_overflow_and_underflow(#[values("-AAB")] qsc: &str) {
         // add some chars
         let longqsc64 = &format!("{qsc}ABCD");
-        let counter = Counter::new(None, None, None, None, Some(&longqsc64), None, None).unwrap();
+        let counter = Counter::new(None, None, None, None, Some(&longqsc64), None).unwrap();
         assert_eq!(
             counter.qb64().unwrap().len() as u32,
             counter::sizage(&counter.code()).unwrap().fs
@@ -462,8 +429,7 @@ mod test {
         // add some bytes
         let mut longqscb2 = qscb2.clone();
         longqscb2.resize(longqscb2.len() + 5, 1);
-        let counter =
-            Counter::new(None, None, None, None, None, Some(&mut longqscb2), None).unwrap();
+        let counter = Counter::new(None, None, None, None, None, Some(&longqscb2)).unwrap();
         assert_eq!(counter.qb2().unwrap(), *qscb2);
         assert_eq!(
             counter.qb64().unwrap().len() as u32,
@@ -472,15 +438,14 @@ mod test {
 
         // remove a bytes
         let shortqscb2 = &qscb2[..qscb2.len() - 1];
-        assert!(Counter::new(None, None, None, None, None, Some(&mut shortqscb2.to_vec()), None)
-            .is_err());
+        assert!(Counter::new(None, None, None, None, None, Some(shortqscb2)).is_err());
     }
 
     #[rstest]
     fn exfil_infil_bexfil_binfil(#[values("-0VAAAQA")] qsc: &str) {
-        let counter1 = Counter::new(None, None, None, None, Some(qsc), None, None).unwrap();
-        let mut qb2 = counter1.qb2().unwrap();
-        let counter2 = Counter::new(None, None, None, None, None, Some(&mut qb2), None).unwrap();
+        let counter1 = Counter::new(None, None, None, None, Some(qsc), None).unwrap();
+        let qb2 = counter1.qb2().unwrap();
+        let counter2 = Counter::new(None, None, None, None, None, Some(&qb2)).unwrap();
         assert_eq!(counter1.code(), counter2.code());
         assert_eq!(counter1.count(), counter2.count());
         assert_eq!(counter1.qb2().unwrap(), counter2.qb2().unwrap());
@@ -536,35 +501,32 @@ mod test {
             .qb64()
             .is_err());
 
-        assert!(Counter::new(None, None, None, None, Some(""), None, None).is_err());
-        assert!(Counter::new(None, None, None, None, Some("--"), None, None).is_err());
-        assert!(Counter::new(None, None, None, None, Some("__"), None, None).is_err());
+        assert!(Counter::new(None, None, None, None, Some(""), None).is_err());
+        assert!(Counter::new(None, None, None, None, Some("--"), None).is_err());
+        assert!(Counter::new(None, None, None, None, Some("__"), None).is_err());
         assert!(Counter::new(
             None,
             None,
             None,
             None,
             Some(counter::Codex::ControllerIdxSigs),
-            None,
             None
         )
         .is_err());
 
-        assert!(Counter::new(None, None, None, Some(&mut vec![]), None, None, None).is_err());
+        assert!(Counter::new(None, None, None, Some(&[]), None, None).is_err());
 
-        assert!(Counter::new(None, None, None, None, None, Some(&mut vec![]), None).is_err());
-        assert!(Counter::new(None, None, None, None, None, Some(&mut vec![0xf8, 0]), None).is_err());
-        assert!(Counter::new(None, None, None, None, None, Some(&mut vec![0xfc, 0]), None).is_err());
-        assert!(
-            Counter::new(None, None, None, None, None, Some(&mut vec![0xfb, 0xe0]), None).is_err()
-        );
+        assert!(Counter::new(None, None, None, None, None, Some(&[])).is_err());
+        assert!(Counter::new(None, None, None, None, None, Some(&[0xf8, 0])).is_err());
+        assert!(Counter::new(None, None, None, None, None, Some(&[0xfc, 0])).is_err());
+        assert!(Counter::new(None, None, None, None, None, Some(&[0xfb, 0xe0])).is_err());
     }
 
     #[rstest]
     #[case(counter::Codex::ControllerIdxSigs, 1)]
     fn qb64b(#[case] code: &str, #[case] count: u32) {
         let c = Counter { code: code.to_string(), count };
-        let mut qb64b = c.qb64b().unwrap();
-        assert!(Counter::new(None, None, None, Some(&mut qb64b), None, None, None).is_ok());
+        let qb64b = c.qb64b().unwrap();
+        assert!(Counter::new(None, None, None, Some(&qb64b), None, None).is_ok());
     }
 }

--- a/src/core/diger.rs
+++ b/src/core/diger.rs
@@ -40,21 +40,43 @@ impl Diger {
         ser: Option<&[u8]>,
         code: Option<&str>,
         raw: Option<&[u8]>,
-        qb64b: Option<&mut Vec<u8>>,
+        qb64b: Option<&[u8]>,
         qb64: Option<&str>,
-        qb2: Option<&mut Vec<u8>>,
-        strip: Option<bool>,
+        qb2: Option<&[u8]>,
     ) -> Result<Self> {
-        let result = Matter::new(code, raw, qb64b, qb64, qb2, strip);
+        let result = Matter::new(code, raw, qb64b, qb64, qb2);
         if result.is_ok() {
             let diger: Self = result?;
             validate_code(&diger.code())?;
             Ok(diger)
         } else if let Some(ser) = ser {
-            Self::new_with_code_and_ser(code.unwrap_or(matter::Codex::Blake3_256), ser)
+            let code = code.unwrap_or(matter::Codex::Blake3_256);
+            validate_code(code)?;
+            let dig = hash::digest(code, ser)?;
+            Matter::new(Some(code), Some(&dig), None, None, None)
         } else {
             err!(Error::Validation("failure creating diger".to_string()))
         }
+    }
+
+    pub fn new_with_ser(ser: &[u8], code: Option<&str>) -> Result<Self> {
+        Self::new(Some(ser), code, None, None, None, None)
+    }
+
+    pub fn new_with_raw(raw: &[u8], code: Option<&str>) -> Result<Self> {
+        Self::new(None, code, Some(raw), None, None, None)
+    }
+
+    pub fn new_with_qb64b(qb64b: &[u8]) -> Result<Self> {
+        Self::new(None, None, None, Some(qb64b), None, None)
+    }
+
+    pub fn new_with_qb64(qb64: &str) -> Result<Self> {
+        Self::new(None, None, None, None, Some(qb64), None)
+    }
+
+    pub fn new_with_qb2(qb2: &[u8]) -> Result<Self> {
+        Self::new(None, None, None, None, None, Some(qb2))
     }
 
     pub fn verify(&self, ser: &[u8]) -> Result<bool> {
@@ -72,18 +94,12 @@ impl Diger {
         }
     }
 
-    fn new_with_code_and_ser(code: &str, ser: &[u8]) -> Result<Self> {
-        validate_code(code)?;
-        let dig = hash::digest(code, ser)?;
-        Matter::new_with_code_and_raw(code, &dig)
-    }
-
     fn compare_dig(&self, ser: &[u8], dig: &[u8]) -> Result<bool> {
         if dig == self.qb64b()? {
             return Ok(true);
         }
 
-        let diger = <Diger as Matter>::new(None, None, Some(&mut dig.to_vec()), None, None, None)?;
+        let diger = <Diger as Matter>::new(None, None, Some(dig), None, None)?;
 
         if diger.code() == self.code() {
             return Ok(false);
@@ -148,17 +164,30 @@ mod test {
     use hex_literal::hex;
     use rstest::rstest;
 
+    #[test]
+    fn convenience() {
+        let ser = b"abcdefg";
+
+        let diger = Diger::new(Some(ser), None, None, None, None, None).unwrap();
+
+        assert!(Diger::new_with_ser(ser, None).is_ok());
+        assert!(Diger::new_with_raw(&diger.raw(), Some(&diger.code())).is_ok());
+        assert!(Diger::new_with_qb64b(&diger.qb64b().unwrap()).is_ok());
+        assert!(Diger::new_with_qb64(&diger.qb64().unwrap()).is_ok());
+        assert!(Diger::new_with_qb2(&diger.qb2().unwrap()).is_ok());
+    }
+
     #[rstest]
     fn conversions(
         #[values(matter::Codex::Blake3_256)] _code: &str,
         #[values(b"abcdefghijklmnopqrstuvwxyz0123456789")] _ser: &[u8],
-        #[values(Diger::new(Some(_ser), Some(_code), None, None, None, None, None).unwrap())]
+        #[values(Diger::new(Some(_ser), Some(_code), None, None, None, None).unwrap())]
         control: Diger,
         #[values(
-            Diger::new(None, Some(_code), Some(&control.raw()), None, None, None, None).unwrap(),
-            Diger::new(None, None, None, Some(&mut control.qb64b().unwrap()), None, None, None).unwrap(),
-            Diger::new(None, None, None, None, Some(&control.qb64().unwrap()), None, None).unwrap(),
-            Diger::new(None, None, None, None, None, Some(&mut control.qb2().unwrap()), None).unwrap()
+            Diger::new(None, Some(_code), Some(&control.raw()), None, None, None).unwrap(),
+            Diger::new(None, None, None, Some(&control.qb64b().unwrap()), None, None).unwrap(),
+            Diger::new(None, None, None, None, Some(&control.qb64().unwrap()), None).unwrap(),
+            Diger::new(None, None, None, None, None, Some(&control.qb2().unwrap())).unwrap()
         )]
         diger: Diger,
     ) {
@@ -172,12 +201,12 @@ mod test {
     fn invalid(
         #[values(matter::Codex::Blake3_256)] _code: &str,
         #[values(b"abcdefghijklmnopqrstuvwxyz0123456789")] _raw: &[u8],
-        #[values(<Diger as Matter>::new(Some(matter::Codex::Ed25519), Some(_raw), None, None, None, None).unwrap())]
+        #[values(<Diger as Matter>::new(Some(matter::Codex::Ed25519), Some(_raw), None, None, None).unwrap())]
         _control: Diger,
         #[values(
-            Diger::new(None, None, None, Some(&mut _control.qb64b().unwrap()), None, None, None).is_err(),
-            Diger::new(None, None, None, None, Some(&_control.qb64().unwrap()), None, None).is_err(),
-            Diger::new(None, None, None, None, None, Some(&mut _control.qb2().unwrap()), None).is_err()
+            Diger::new(None, None, None, Some(&_control.qb64b().unwrap()), None, None).is_err(),
+            Diger::new(None, None, None, None, Some(&_control.qb64().unwrap()), None).is_err(),
+            Diger::new(None, None, None, None, None, Some(&_control.qb2().unwrap())).is_err()
         )]
         result: bool,
     ) {
@@ -191,7 +220,7 @@ mod test {
         let ser = vec![0, 1, 2];
 
         // dig == self.qb64b() - should return true
-        let diger = Diger::new(None, Some(code), Some(&raw), None, None, None, None).unwrap();
+        let diger = Diger::new(None, Some(code), Some(&raw), None, None, None).unwrap();
         let qb64b = diger.qb64b().unwrap();
         assert!(diger.compare(&ser, Some(&qb64b), None).unwrap());
         assert!(diger.compare(&ser, None, Some(&diger)).unwrap());
@@ -203,9 +232,8 @@ mod test {
         let raw = hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"
                                  "5b49b82f805a538c68915c1ae8035c900fd1d4b13902920fd05e1450822f36de");
 
-        let diger =
-            Diger::new(None, Some(matter::Codex::Blake3_512), Some(&raw), None, None, None, None)
-                .unwrap();
+        let diger = Diger::new(None, Some(matter::Codex::Blake3_512), Some(&raw), None, None, None)
+            .unwrap();
         assert!(diger.verify(&vec![0, 1, 2]).unwrap());
     }
 
@@ -216,7 +244,7 @@ mod test {
         let ser = vec![0, 1, 2];
 
         // dig == self.qb64b() - should return true
-        let diger = Diger::new(None, Some(code), Some(&raw), None, None, None, None).unwrap();
+        let diger = Diger::new(None, Some(code), Some(&raw), None, None, None).unwrap();
         let mut qb64b = diger.qb64b().unwrap();
         assert!(diger.compare(&ser, Some(&qb64b), None).unwrap());
 
@@ -229,12 +257,12 @@ mod test {
         // same ser, different algorithm - should return true
         let code = matter::Codex::Blake2b_256;
         let raw = hash::digest(code, &ser).unwrap();
-        let matter: Diger = Matter::new(Some(code), Some(&raw), None, None, None, None).unwrap();
+        let matter: Diger = Matter::new(Some(code), Some(&raw), None, None, None).unwrap();
         assert!(diger.compare(&ser, Some(&matter.qb64b().unwrap()), None).unwrap());
 
         // different ser, different algorithm - should return false
         let raw = hash::digest(code, &vec![0, 1, 2, 3]).unwrap();
-        let matter: Diger = Matter::new(Some(code), Some(&raw), None, None, None, None).unwrap();
+        let matter: Diger = Matter::new(Some(code), Some(&raw), None, None, None).unwrap();
         assert!(!diger.compare(&ser, Some(&matter.qb64b().unwrap()), None).unwrap());
     }
 
@@ -245,27 +273,27 @@ mod test {
         let ser = vec![0, 1, 2];
 
         // diger.qb64b() == self.qb64b() - should return true
-        let diger = Diger::new(None, Some(code), Some(&raw), None, None, None, None).unwrap();
+        let diger = Diger::new(None, Some(code), Some(&raw), None, None, None).unwrap();
         let mut qb64b = diger.qb64b().unwrap();
-        let d2 = Diger::new(None, None, None, Some(&mut qb64b), None, None, None).unwrap();
+        let d2 = Diger::new(None, None, None, Some(&qb64b), None, None).unwrap();
         assert!(diger.compare(&ser, None, Some(&d2)).unwrap());
 
         // diger.code == self.code, diger.qb64() != self.qb64b() - should return false
         let mut x = qb64b[30]; // break a piece of the value, without breaking encoding
         x = if x == 0 { 63 } else { x - 1 };
         qb64b[30] = x;
-        let d2 = Diger::new(None, None, None, Some(&mut qb64b), None, None, None).unwrap();
+        let d2 = Diger::new(None, None, None, Some(&qb64b), None, None).unwrap();
         assert!(!diger.compare(&ser, None, Some(&d2)).unwrap());
 
         // same ser, different algorithm - should return true
         let code2 = matter::Codex::Blake2b_256;
         let raw2 = hash::digest(code2, &ser).unwrap();
-        let d2 = Diger::new(None, Some(code2), Some(&raw2), None, None, None, None).unwrap();
+        let d2 = Diger::new(None, Some(code2), Some(&raw2), None, None, None).unwrap();
         assert!(diger.compare(&ser, None, Some(&d2)).unwrap());
 
         // different ser, different algorithm - should return false
         let raw2 = hash::digest(code2, &vec![0, 1, 2, 3]).unwrap();
-        let d2 = Diger::new(None, Some(code2), Some(&raw2), None, None, None, None).unwrap();
+        let d2 = Diger::new(None, Some(code2), Some(&raw2), None, None, None).unwrap();
         assert!(!diger.compare(&ser, None, Some(&d2)).unwrap());
     }
 
@@ -275,13 +303,11 @@ mod test {
         let ser = b"abcdefghijklmnopqrstuvwxyz0123456789";
 
         let diger0 =
-            Diger::new(Some(ser), Some(matter::Codex::Blake3_256), None, None, None, None, None)
-                .unwrap();
+            Diger::new(Some(ser), Some(matter::Codex::Blake3_256), None, None, None, None).unwrap();
         let diger1 =
-            Diger::new(Some(ser), Some(matter::Codex::SHA3_256), None, None, None, None, None)
-                .unwrap();
+            Diger::new(Some(ser), Some(matter::Codex::SHA3_256), None, None, None, None).unwrap();
         let diger2 =
-            Diger::new(Some(ser), Some(matter::Codex::Blake2b_256), None, None, None, None, None)
+            Diger::new(Some(ser), Some(matter::Codex::Blake2b_256), None, None, None, None)
                 .unwrap();
 
         assert!(diger0.compare(ser, None, Some(&diger1)).unwrap());
@@ -293,16 +319,14 @@ mod test {
         assert!(diger1.compare(ser, Some(&diger2.qb64b().unwrap()), None).unwrap());
 
         let ser1 = b"ABCDEFGHIJKLMNOPQSTUVWXYXZabcdefghijklmnopqrstuvwxyz0123456789";
-        let diger =
-            Diger::new(Some(ser1), Some(matter::Codex::Blake3_256), None, None, None, None, None)
-                .unwrap();
+        let diger = Diger::new(Some(ser1), Some(matter::Codex::Blake3_256), None, None, None, None)
+            .unwrap();
 
         assert!(!diger0.compare(ser, None, Some(&diger)).unwrap());
         assert!(!diger0.compare(ser, Some(&diger.qb64b().unwrap()), None).unwrap());
 
         let diger =
-            Diger::new(Some(ser1), Some(matter::Codex::SHA3_256), None, None, None, None, None)
-                .unwrap();
+            Diger::new(Some(ser1), Some(matter::Codex::SHA3_256), None, None, None, None).unwrap();
 
         assert!(!diger0.compare(ser, None, Some(&diger)).unwrap());
         assert!(!diger0.compare(ser, Some(&diger.qb64b().unwrap()), None).unwrap());
@@ -310,6 +334,6 @@ mod test {
 
     #[test]
     fn unhappy_paths() {
-        assert!(Diger::new(None, None, None, None, None, None, None).is_err());
+        assert!(Diger::new(None, None, None, None, None, None).is_err());
     }
 }

--- a/src/core/indexer/mod.rs
+++ b/src/core/indexer/mod.rs
@@ -32,13 +32,11 @@ pub(crate) trait Indexer: Default {
         ondex: Option<u32>,
         code: Option<&str>,
         raw: Option<&[u8]>,
-        qb64b: Option<&mut Vec<u8>>,
+        qb64b: Option<&[u8]>,
         qb64: Option<&str>,
-        qb2: Option<&mut Vec<u8>>,
-        strip: Option<bool>,
+        qb2: Option<&[u8]>,
     ) -> Result<Self> {
         let index = index.unwrap_or(0);
-        let strip = strip.unwrap_or(false);
 
         if let Some(raw) = raw {
             let code = if let Some(code) = code {
@@ -49,26 +47,11 @@ pub(crate) trait Indexer: Default {
 
             Self::new_with_code_and_raw(code, raw, index, ondex)
         } else if let Some(qb64b) = qb64b {
-            let s = Self::new_with_qb64b(qb64b)?;
-            if strip {
-                let szg = tables::sizage(&s.code())?;
-                let length =
-                    if szg.fs == 0 { szg.hs + szg.ss + s.index() * 4 } else { szg.fs } as usize;
-                qb64b.drain(0..length);
-            }
-            Ok(s)
+            Self::new_with_qb64b(qb64b)
         } else if let Some(qb64) = qb64 {
             Self::new_with_qb64(qb64)
         } else if let Some(qb2) = qb2 {
-            let s = Self::new_with_qb2(qb2)?;
-            if strip {
-                let szg = tables::sizage(&s.code())?;
-                let length = (if szg.fs == 0 { szg.hs + szg.ss + s.index() * 4 } else { szg.fs }
-                    * 3
-                    / 4) as usize;
-                qb2.drain(0..length);
-            }
-            Ok(s)
+            Self::new_with_qb2(qb2)
         } else {
             err!(Error::Validation("must specify raw and code, qb64b, qb64 or qb2".to_string()))
         }
@@ -714,78 +697,39 @@ mod test {
 
     #[test]
     fn new_variable_length() {
-        assert!(TestIndexer::new(None, None, None, None, None, None, None, None).is_err());
-        assert!(TestIndexer::new(None, None, None, Some(&[]), None, None, None, None).is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, None, None).is_err());
+        assert!(TestIndexer::new(None, None, None, Some(&[]), None, None, None).is_err());
 
         let code = indexer::Codex::TBD0;
         let raw = &vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
         let indexer =
-            TestIndexer::new(None, None, Some(code), Some(raw), None, None, None, None).unwrap();
+            TestIndexer::new(None, None, Some(code), Some(raw), None, None, None).unwrap();
         let qb64 = &indexer.qb64().unwrap();
-        let mut qb64b = indexer.qb64b().unwrap();
-        let mut qb2 = indexer.qb2().unwrap();
+        let qb64b = indexer.qb64b().unwrap();
+        let qb2 = indexer.qb2().unwrap();
 
-        assert!(TestIndexer::new(None, None, Some(code), Some(raw), None, None, None, None).is_ok());
-
-        assert!(
-            TestIndexer::new(None, None, None, None, Some(&mut qb64b), None, None, None).is_ok()
-        );
-        let length = qb64b.len();
-        qb64b.resize(length + 256, b'\x00');
-        assert_eq!(qb64b.len(), length + 256);
-        assert!(TestIndexer::new(None, None, None, None, Some(&mut qb64b), None, None, Some(true))
-            .is_ok());
-        assert_eq!(qb64b.len(), 256);
-        assert_eq!(qb64b, vec![b'\x00'; 256]);
-
-        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None, None).is_ok());
-
-        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&mut qb2), None).is_ok());
-        let length = qb2.len();
-        qb2.resize(length + 256, b'\x00');
-        assert_eq!(qb2.len(), length + 256);
-        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&mut qb2), Some(true))
-            .is_ok());
-        assert_eq!(qb2.len(), 256);
-        assert_eq!(qb2, vec![b'\x00'; 256]);
+        assert!(TestIndexer::new(None, None, Some(code), Some(raw), None, None, None).is_ok());
+        assert!(TestIndexer::new(None, None, None, None, Some(&qb64b), None, None).is_ok());
+        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None).is_ok());
+        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&qb2)).is_ok());
     }
 
     #[test]
     fn new() {
-        assert!(TestIndexer::new(None, None, None, None, None, None, None, None).is_err());
-        assert!(TestIndexer::new(None, None, None, Some(&[]), None, None, None, None).is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, None, None).is_err());
+        assert!(TestIndexer::new(None, None, None, Some(&[]), None, None, None).is_err());
 
         let code = indexer::Codex::Ed25519;
         let qb64 = "AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ";
-        let indexer =
-            TestIndexer::new(None, None, None, None, None, Some(qb64), None, None).unwrap();
+        let indexer = TestIndexer::new(None, None, None, None, None, Some(qb64), None).unwrap();
         let raw = &indexer.raw();
-        let mut qb64b = indexer.qb64b().unwrap();
-        let mut qb2 = indexer.qb2().unwrap();
+        let qb64b = indexer.qb64b().unwrap();
+        let qb2 = indexer.qb2().unwrap();
 
-        assert!(TestIndexer::new(None, None, Some(code), Some(raw), None, None, None, None).is_ok());
-
-        assert!(
-            TestIndexer::new(None, None, None, None, Some(&mut qb64b), None, None, None).is_ok()
-        );
-        let length = qb64b.len();
-        qb64b.resize(length + 256, b'\x00');
-        assert_eq!(qb64b.len(), length + 256);
-        assert!(TestIndexer::new(None, None, None, None, Some(&mut qb64b), None, None, Some(true))
-            .is_ok());
-        assert_eq!(qb64b.len(), 256);
-        assert_eq!(qb64b, vec![b'\x00'; 256]);
-
-        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None, None).is_ok());
-
-        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&mut qb2), None).is_ok());
-        let length = qb2.len();
-        qb2.resize(length + 256, b'\x00');
-        assert_eq!(qb2.len(), length + 256);
-        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&mut qb2), Some(true))
-            .is_ok());
-        assert_eq!(qb2.len(), 256);
-        assert_eq!(qb2, vec![b'\x00'; 256]);
+        assert!(TestIndexer::new(None, None, Some(code), Some(raw), None, None, None).is_ok());
+        assert!(TestIndexer::new(None, None, None, None, Some(&qb64b), None, None).is_ok());
+        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None).is_ok());
+        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&qb2)).is_ok());
     }
 
     #[rstest]
@@ -795,10 +739,10 @@ mod test {
         #[values(b"\x00\x00\x99\xd2<9$$0\x9fk\xfb\x18\xa0\x8c@r\x122.k\xb2\xc7\x1fp\x0e'm\x8f@\xaa\xa5\x8c\xc8n\x85\xc8!\xf6q\x91p\xa9\xec\xcf\x92\xaf)\xde\xca\xfc\x7f~\xd7o|\x17\x82\x1d\xd4<o\"\x81&\t")]
         qsig2: &[u8],
         #[values(
-            TestIndexer::new(None, None, Some(indexer::Codex::Ed25519), Some(sig), None, None, None, None).unwrap(),
-            TestIndexer::new(None, None, None, None, None, Some("AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ"), None, None).unwrap(),
-            TestIndexer::new(None, None, None, None, Some(&mut "AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ".as_bytes().to_vec()), None, None, None).unwrap(),
-            TestIndexer::new(None, None, None, None, None, None, Some(&mut qsig2.to_vec()), None).unwrap(),
+            TestIndexer::new(None, None, Some(indexer::Codex::Ed25519), Some(sig), None, None, None).unwrap(),
+            TestIndexer::new(None, None, None, None, None, Some("AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ"), None).unwrap(),
+            TestIndexer::new(None, None, None, None, Some("AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ".as_bytes()), None, None).unwrap(),
+            TestIndexer::new(None, None, None, None, None, None, Some(qsig2)).unwrap(),
         )]
         idx: TestIndexer,
     ) {
@@ -841,12 +785,12 @@ mod test {
     fn exfil_infil_bexfil_binfil(
         #[values("AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ")]
         qb64: &str,
-        #[values(TestIndexer::new(None, None, None, None, None, Some(qb64), None, None).unwrap())]
+        #[values(TestIndexer::new(None, None, None, None, None, Some(qb64), None).unwrap())]
         control: TestIndexer,
         #[values(
-            TestIndexer::new(None, None, Some(&control.code()), Some(&control.raw()), None, None, None, None).unwrap(),
-            TestIndexer::new(None, None, None, None, Some(&mut control.qb64b().unwrap()), None, None, None).unwrap(),
-            TestIndexer::new(None, None, None, None, None, None, Some(&mut control.qb2().unwrap()), None).unwrap(),
+            TestIndexer::new(None, None, Some(&control.code()), Some(&control.raw()), None, None, None).unwrap(),
+            TestIndexer::new(None, None, None, None, Some(&control.qb64b().unwrap()), None, None).unwrap(),
+            TestIndexer::new(None, None, None, None, None, None, Some(&control.qb2().unwrap())).unwrap(),
         )]
         indexer: TestIndexer,
     ) {
@@ -869,7 +813,6 @@ mod test {
             None,
             None,
             None,
-            None,
         )
         .unwrap();
         assert!(TestIndexer::new(
@@ -880,7 +823,6 @@ mod test {
             None,
             Some(&indexer.qb64().unwrap()),
             None,
-            None
         )
         .is_ok());
         assert!(TestIndexer::new(
@@ -888,10 +830,9 @@ mod test {
             None,
             None,
             None,
-            Some(&mut indexer.qb64b().unwrap()),
+            Some(&indexer.qb64b().unwrap()),
             None,
             None,
-            None
         )
         .is_ok());
         assert!(TestIndexer::new(
@@ -901,8 +842,7 @@ mod test {
             None,
             None,
             None,
-            Some(&mut indexer.qb2().unwrap()),
-            None
+            Some(&indexer.qb2().unwrap()),
         )
         .is_ok());
     }
@@ -910,7 +850,7 @@ mod test {
     #[test]
     fn unhappy_paths() {
         // empty inputs
-        assert!(TestIndexer::new(None, None, Some(""), Some(&[]), None, None, None, None).is_err());
+        assert!(TestIndexer::new(None, None, Some(""), Some(&[]), None, None, None,).is_err());
         assert!(TestIndexer::new(
             None,
             None,
@@ -919,24 +859,17 @@ mod test {
             None,
             None,
             None,
-            None
         )
         .is_err());
-        assert!(
-            TestIndexer::new(None, None, None, None, Some(&mut vec![]), None, None, None).is_err()
-        );
-        assert!(TestIndexer::new(None, None, None, None, None, Some(""), None, None).is_err());
-        assert!(
-            TestIndexer::new(None, None, None, None, None, None, Some(&mut vec![]), None).is_err()
-        );
+        assert!(TestIndexer::new(None, None, None, None, Some(&[]), None, None,).is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, Some(""), None,).is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&[]),).is_err());
 
         // unknown sizage
-        assert!(
-            TestIndexer::new(None, None, Some("CESR"), Some(&[]), None, None, None, None).is_err()
-        );
+        assert!(TestIndexer::new(None, None, Some("CESR"), Some(&[]), None, None, None,).is_err());
 
         // shortage
-        assert!(TestIndexer::new(None, None, None, None, None, Some("0"), None, None).is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, Some("0"), None,).is_err());
 
         // index too large
         assert!(TestIndexer::new(
@@ -947,7 +880,6 @@ mod test {
             None,
             None,
             None,
-            None
         )
         .is_err());
 
@@ -960,7 +892,6 @@ mod test {
             None,
             None,
             None,
-            None
         )
         .is_err());
 
@@ -973,7 +904,6 @@ mod test {
             None,
             None,
             None,
-            None
         )
         .is_err());
 
@@ -986,7 +916,6 @@ mod test {
             None,
             None,
             None,
-            None
         )
         .is_err());
 
@@ -1039,110 +968,49 @@ mod test {
             None,
             Some(indexer::Codex::Ed25519),
             None,
-            None
         )
         .is_err());
 
         // invalid ondex for current sig
         let qb64 = "0BAB";
-        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None, None).is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None).is_err());
 
         // not enough material
         let qb64 = "0AAA";
-        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None, None).is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None).is_err());
 
         // prepad
         let qb64 = "AA_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None, None).is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None).is_err());
 
         // lead byte
         let qb64 = "1zAA_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None, None).is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, Some(qb64), None).is_err());
 
         // not enough for hard
         let qb2 = b"\xd0";
-        assert!(TestIndexer::new(
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&mut qb2.to_vec()),
-            None
-        )
-        .is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, None, Some(qb2),).is_err());
 
         // hard complete, code not
         let qb2 = b"\xd0\x00";
-        assert!(TestIndexer::new(
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&mut qb2.to_vec()),
-            None
-        )
-        .is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, None, Some(qb2)).is_err());
 
         // invalid ondex for current sig
         let qb2 = b"\xd0\x10\x01";
-        assert!(TestIndexer::new(
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&mut qb2.to_vec()),
-            None
-        )
-        .is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, None, Some(qb2)).is_err());
 
         // not enough material
         let qb2 = b64_engine::URL_SAFE.decode("0AAA").unwrap();
-        assert!(TestIndexer::new(
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&mut qb2.to_vec()),
-            None
-        )
-        .is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&qb2)).is_err());
 
         // prepad
         let qb2 = b64_engine::URL_SAFE.decode("AA_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap();
-        assert!(TestIndexer::new(
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&mut qb2.to_vec()),
-            None
-        )
-        .is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&qb2)).is_err());
 
         // lead byte
         let qb2 = b64_engine::URL_SAFE
             .decode("1zAA_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
             .unwrap();
-        assert!(TestIndexer::new(
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&mut qb2.to_vec()),
-            None
-        )
-        .is_err());
+        assert!(TestIndexer::new(None, None, None, None, None, None, Some(&qb2),).is_err());
     }
 }

--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -16,13 +16,10 @@ pub(crate) trait Matter: Default {
     fn new(
         code: Option<&str>,
         raw: Option<&[u8]>,
-        qb64b: Option<&mut Vec<u8>>,
+        qb64b: Option<&[u8]>,
         qb64: Option<&str>,
-        qb2: Option<&mut Vec<u8>>,
-        strip: Option<bool>,
+        qb2: Option<&[u8]>,
     ) -> Result<Self> {
-        let strip = strip.unwrap_or(false);
-
         if let Some(raw) = raw {
             let code = if let Some(code) = code {
                 code
@@ -32,25 +29,11 @@ pub(crate) trait Matter: Default {
 
             Self::new_with_code_and_raw(code, raw)
         } else if let Some(qb64b) = qb64b {
-            let s = Self::new_with_qb64b(qb64b)?;
-            if strip {
-                let szg = tables::sizage(&s.code())?;
-                let length =
-                    if szg.fs == 0 { szg.hs + szg.ss + s.size() * 4 } else { szg.fs } as usize;
-                qb64b.drain(0..length);
-            }
-            Ok(s)
+            Self::new_with_qb64b(qb64b)
         } else if let Some(qb64) = qb64 {
             Self::new_with_qb64(qb64)
         } else if let Some(qb2) = qb2 {
-            let s = Self::new_with_qb2(qb2)?;
-            if strip {
-                let szg = tables::sizage(&s.code())?;
-                let length = (if szg.fs == 0 { szg.hs + szg.ss + s.size() * 4 } else { szg.fs } * 3
-                    / 4) as usize;
-                qb2.drain(0..length);
-            }
-            Ok(s)
+            Self::new_with_qb2(qb2)
         } else {
             err!(Error::Validation("must specify raw and code, qb64b, qb64 or qb2".to_string()))
         }
@@ -544,26 +527,27 @@ mod test {
     }
 
     #[rstest]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_L0)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_L1)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_L2)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_L0)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_L1)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_L2)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_Big_L0)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_Big_L1)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_Big_L2)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_Big_L0)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_Big_L1)]
-    #[case(&vec![0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_Big_L2)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_L0)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_L1)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_L2)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_L0)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_L1)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_L2)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::StrB64_Big_L0)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::StrB64_Big_L1)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6], matter::Codex::StrB64_Big_L2)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6, 7, 8], matter::Codex::Bytes_Big_L0)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6, 7], matter::Codex::Bytes_Big_L1)]
+    #[case(&[0, 1, 2, 3, 4, 5, 6], matter::Codex::Bytes_Big_L2)]
     fn conversion_variable_length(
-        #[case] _raw: &Vec<u8>,
+        #[case] _raw: &[u8],
         #[case] _code: &str,
-        #[values(TestMatter::new(Some(_code), Some(_raw), None, None, None, None).unwrap())]
+        #[values(TestMatter::new(Some(_code), Some(_raw), None, None, None).unwrap())]
         control: TestMatter,
         #[values(
-            TestMatter::new(None, None, None, Some(&control.qb64().unwrap()), None, None).unwrap(),
-            TestMatter::new(None, None, None, None, Some(&mut control.qb2().unwrap()), None).unwrap(),        )]
+            TestMatter::new(None, None, None, Some(&control.qb64().unwrap()), None).unwrap(),
+            TestMatter::new(None, None, None, None, Some(&control.qb2().unwrap())).unwrap(),
+        )]
         matter: TestMatter,
     ) {
         assert_eq!(matter.code(), control.code());
@@ -574,64 +558,34 @@ mod test {
     #[test]
     fn new_variable_length() {
         let code = matter::Codex::Bytes_L0;
-        let raw = &vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
-        let matter = TestMatter::new(Some(code), Some(raw), None, None, None, None).unwrap();
+        let raw = &[0, 1, 2, 3, 4, 5, 6, 7, 8];
+        let matter = TestMatter::new(Some(code), Some(raw), None, None, None).unwrap();
         let qb64 = &matter.qb64().unwrap();
-        let mut qb64b = matter.qb64b().unwrap();
-        let mut qb2 = matter.qb2().unwrap();
+        let qb64b = matter.qb64b().unwrap();
+        let qb2 = matter.qb2().unwrap();
 
-        assert!(TestMatter::new(Some(code), Some(raw), None, None, None, None).is_ok());
-
-        assert!(TestMatter::new(None, None, Some(&mut qb64b), None, None, None).is_ok());
-        let length = qb64b.len();
-        qb64b.resize(length + 256, b'\x00');
-        assert_eq!(qb64b.len(), length + 256);
-        assert!(TestMatter::new(None, None, Some(&mut qb64b), None, None, Some(true)).is_ok());
-        assert_eq!(qb64b.len(), 256);
-        assert_eq!(qb64b, vec![b'\x00'; 256]);
-
-        assert!(TestMatter::new(None, None, None, Some(qb64), None, None).is_ok());
-
-        assert!(TestMatter::new(None, None, None, None, Some(&mut qb2), None).is_ok());
-        let length = qb2.len();
-        qb2.resize(length + 256, b'\x00');
-        assert_eq!(qb2.len(), length + 256);
-        assert!(TestMatter::new(None, None, None, None, Some(&mut qb2), Some(true)).is_ok());
-        assert_eq!(qb2.len(), 256);
-        assert_eq!(qb2, vec![b'\x00'; 256]);
+        assert!(TestMatter::new(Some(code), Some(raw), None, None, None).is_ok());
+        assert!(TestMatter::new(None, None, Some(&qb64b), None, None).is_ok());
+        assert!(TestMatter::new(None, None, None, Some(qb64), None).is_ok());
+        assert!(TestMatter::new(None, None, None, None, Some(&qb2)).is_ok());
     }
 
     #[test]
     fn new() {
-        assert!(TestMatter::new(None, None, None, None, None, None).is_err());
-        assert!(TestMatter::new(None, Some(&[]), None, None, None, None).is_err());
+        assert!(TestMatter::new(None, None, None, None, None).is_err());
+        assert!(TestMatter::new(None, Some(&[]), None, None, None,).is_err());
 
         let code = matter::Codex::Blake3_256;
         let qb64 = "BGlOiUdp5sMmfotHfCWQKEzWR91C72AH0lT84c0um-Qj";
-        let matter = TestMatter::new(None, None, None, Some(qb64), None, None).unwrap();
+        let matter = TestMatter::new(None, None, None, Some(qb64), None).unwrap();
         let raw = &matter.raw();
-        let mut qb64b = matter.qb64b().unwrap();
-        let mut qb2 = matter.qb2().unwrap();
+        let qb64b = matter.qb64b().unwrap();
+        let qb2 = matter.qb2().unwrap();
 
-        assert!(TestMatter::new(Some(code), Some(raw), None, None, None, None).is_ok());
-
-        assert!(TestMatter::new(None, None, Some(&mut qb64b), None, None, None).is_ok());
-        let length = qb64b.len();
-        qb64b.resize(length + 256, b'\x00');
-        assert_eq!(qb64b.len(), length + 256);
-        assert!(TestMatter::new(None, None, Some(&mut qb64b), None, None, Some(true)).is_ok());
-        assert_eq!(qb64b.len(), 256);
-        assert_eq!(qb64b, vec![b'\x00'; 256]);
-
-        assert!(TestMatter::new(None, None, None, Some(qb64), None, None).is_ok());
-
-        assert!(TestMatter::new(None, None, None, None, Some(&mut qb2), None).is_ok());
-        let length = qb2.len();
-        qb2.resize(length + 256, b'\x00');
-        assert_eq!(qb2.len(), length + 256);
-        assert!(TestMatter::new(None, None, None, None, Some(&mut qb2), Some(true)).is_ok());
-        assert_eq!(qb2.len(), 256);
-        assert_eq!(qb2, vec![b'\x00'; 256]);
+        assert!(TestMatter::new(Some(code), Some(raw), None, None, None,).is_ok());
+        assert!(TestMatter::new(None, None, Some(&qb64b), None, None,).is_ok());
+        assert!(TestMatter::new(None, None, None, Some(qb64), None,).is_ok());
+        assert!(TestMatter::new(None, None, None, None, Some(&qb2),).is_ok());
     }
 
     #[test]
@@ -659,12 +613,12 @@ mod test {
     #[rstest]
     fn conversion(
         #[values("BGlOiUdp5sMmfotHfCWQKEzWR91C72AH0lT84c0um-Qj")] qb64: &str,
-        #[values(TestMatter::new(None, None, None, Some(qb64), None, None).unwrap())]
+        #[values(TestMatter::new(None, None, None, Some(qb64), None,).unwrap())]
         control: TestMatter,
         #[values(
-            TestMatter::new(Some(&control.code()), Some(&control.raw()), None, None, None, None).unwrap(),
-            TestMatter::new(None, None, Some(&mut control.qb64b().unwrap()), None, None, None).unwrap(),
-            TestMatter::new(None, None, None, None, Some(&mut control.qb2().unwrap()), None).unwrap(),
+            TestMatter::new(Some(&control.code()), Some(&control.raw()), None, None, None,).unwrap(),
+            TestMatter::new(None, None, Some(&control.qb64b().unwrap()), None, None,).unwrap(),
+            TestMatter::new(None, None, None, None, Some(&control.qb2().unwrap()),).unwrap(),
         )]
         matter: TestMatter,
     ) {
@@ -684,7 +638,6 @@ mod test {
             None,
             None,
             None,
-            None,
         )
         .unwrap();
         assert_eq!(m.raw().len(), 4095 * 3 + 1);
@@ -695,24 +648,18 @@ mod test {
 
     fn unhappy_paths() {
         // empty material
-        assert!(TestMatter::new(None, None, None, None, None, None).is_err());
-        assert!(TestMatter::new(Some(""), Some(&[]), None, None, None, None).is_err());
-        assert!(TestMatter::new(
-            Some(matter::Codex::Blake3_256),
-            Some(&[]),
-            None,
-            None,
-            None,
-            None
-        )
-        .is_err());
-        assert!(TestMatter::new(None, None, Some(&mut vec![]), None, None, None).is_err());
-        assert!(TestMatter::new(None, None, None, Some(""), None, None).is_err());
-        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![]), None).is_err());
-        assert!(TestMatter::new(None, None, None, None, None, None).is_err());
+        assert!(TestMatter::new(None, None, None, None, None,).is_err());
+        assert!(TestMatter::new(Some(""), Some(&[]), None, None, None,).is_err());
+        assert!(
+            TestMatter::new(Some(matter::Codex::Blake3_256), Some(&[]), None, None, None,).is_err()
+        );
+        assert!(TestMatter::new(None, None, Some(&[]), None, None,).is_err());
+        assert!(TestMatter::new(None, None, None, Some(""), None,).is_err());
+        assert!(TestMatter::new(None, None, None, None, Some(&[]),).is_err());
+        assert!(TestMatter::new(None, None, None, None, None,).is_err());
 
         // invalid code
-        assert!(TestMatter::new(Some("CESR"), Some(&[]), None, None, None, None).is_err());
+        assert!(TestMatter::new(Some("CESR"), Some(&[]), None, None, None,).is_err());
 
         // invalid code/raw size combination
         assert!(TestMatter {
@@ -724,22 +671,21 @@ mod test {
         .is_err());
 
         // insufficient hard material
-        assert!(TestMatter::new(None, None, None, Some("0"), None, None).is_err());
-        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![52 << 2]), None).is_err());
+        assert!(TestMatter::new(None, None, None, Some("0"), None,).is_err());
+        assert!(TestMatter::new(None, None, None, None, Some(&[52 << 2]),).is_err());
 
         // insufficient code material
-        assert!(TestMatter::new(None, None, None, Some("4A"), None, None).is_err());
-        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![224, 0]), None).is_err());
+        assert!(TestMatter::new(None, None, None, Some("4A"), None,).is_err());
+        assert!(TestMatter::new(None, None, None, None, Some(&[224, 0]),).is_err());
 
         // insufficient material
-        assert!(TestMatter::new(None, None, None, Some("E"), None, None).is_err());
-        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![4 << 2]), None).is_err());
+        assert!(TestMatter::new(None, None, None, Some("E"), None,).is_err());
+        assert!(TestMatter::new(None, None, None, None, Some(&[4 << 2]),).is_err());
 
         // raw size too large
         assert!(TestMatter::new(
             Some(matter::Codex::Bytes_Big_L2),
             Some(&mut [0; (16777215 * 3 + 1)].to_vec()),
-            None,
             None,
             None,
             None
@@ -748,7 +694,6 @@ mod test {
         assert!(TestMatter::new(
             Some(matter::Codex::Bytes_L2),
             Some(&mut [0; (16777215 * 3 + 1)].to_vec()),
-            None,
             None,
             None,
             None
@@ -790,7 +735,6 @@ mod test {
             None,
             None,
             Some("E___________________________________________"),
-            None,
             None
         )
         .is_err());
@@ -802,36 +746,21 @@ mod test {
             Some(&mut vec![
                 19, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
                 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-            ]),
-            None
+            ])
         )
         .is_err());
 
         // non-zeroed lead byte(s)
-        assert!(TestMatter::new(None, None, None, Some("5AAB____"), None, None).is_err());
-        assert!(TestMatter::new(
-            None,
-            None,
-            None,
-            None,
-            Some(&mut vec![228, 0, 1, 255, 255, 255]),
-            None
-        )
-        .is_err());
-        assert!(TestMatter::new(None, None, None, Some("6AAB____"), None, None).is_err());
-        assert!(TestMatter::new(
-            None,
-            None,
-            None,
-            None,
-            Some(&mut vec![232, 0, 1, 255, 255, 255]),
-            None
-        )
-        .is_err());
+        assert!(TestMatter::new(None, None, None, Some("5AAB____"), None,).is_err());
+        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![228, 0, 1, 255, 255, 255]))
+            .is_err());
+        assert!(TestMatter::new(None, None, None, Some("6AAB____"), None,).is_err());
+        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![232, 0, 1, 255, 255, 255]))
+            .is_err());
 
         // unexpected qb2 codes
-        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![0xf8]), None).is_err()); // count code
-        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![0xfc]), None).is_err());
+        assert!(TestMatter::new(None, None, None, None, Some(&[0xf8]),).is_err()); // count code
+        assert!(TestMatter::new(None, None, None, None, Some(&[0xfc]),).is_err());
         // op code
     }
 }

--- a/src/core/sadder.rs
+++ b/src/core/sadder.rs
@@ -116,7 +116,6 @@ pub(crate) trait Sadder: Default + Clone {
             None,
             Some(&result.ked[Ids::d].to_string()?),
             None,
-            None,
         )?);
 
         if self.code() != self.saider().code() {
@@ -147,7 +146,6 @@ pub(crate) trait Sadder: Default + Clone {
             None,
             Some(&result.ked[Ids::d].to_string()?),
             None,
-            None,
         )?);
 
         if self.code() != self.saider().code() {
@@ -177,7 +175,6 @@ pub(crate) trait Sadder: Default + Clone {
             None,
             None,
             Some(&result.ked[Ids::d].to_string()?),
-            None,
             None,
         )?);
 


### PR DESCRIPTION
## Rationale

This PR adds the convenience methods back by inverting the old pattern. Instead of the generic `new()` method depending on explicit creation methods with repeated custom logic, instead the generic new method pulls this custom logic in and the convenience methods wrap it.

This PR also makes some tweaks to the API after discussion and thought around where certain functionality should live within the package ecosystem. Parside is a better place for stream stripping, so we'll implement there. The `&mut Vec<u8>` inputs then change to simple `&[u8]`s.

## Changes

- adds back convenience methods
- removes strip functionality

## Testing

I actually managed to use regexes to replace everything and nothing broke!

```
make fix clean preflight
```