### PR TITLE
serder/tholder/bexter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ ed25519-dalek = "~1"
 indexmap = "~1"
 k256 = "~0.12"
 lazy_static = "~1"
+num-rational = "~0.4"
 rand = "0.7.0" # this needs pinning for one of the seeding pieces of a signing suite
 rand_core = "~0.6"
 regex = "~1"

--- a/src/core/bexter.rs
+++ b/src/core/bexter.rs
@@ -1,0 +1,331 @@
+use crate::{
+    core::{
+        matter::{tables as matter, Matter},
+        util::REB64_STRING,
+    },
+    error::{err, Error, Result},
+};
+
+use base64::{engine::general_purpose::URL_SAFE as b64_engine, Engine};
+use lazy_static::lazy_static;
+use regex::Regex;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Bexter {
+    code: String,
+    raw: Vec<u8>,
+    size: u32,
+}
+
+impl Default for Bexter {
+    fn default() -> Self {
+        Bexter { code: matter::Codex::StrB64_L0.to_string(), raw: vec![], size: 0 }
+    }
+}
+
+pub mod tables {
+    #[allow(non_snake_case)]
+    #[allow(non_upper_case_globals)]
+    pub mod Codex {
+        use crate::core::matter::tables as matter;
+
+        const StrB64_L0: &str = matter::Codex::StrB64_L0;
+        const StrB64_L1: &str = matter::Codex::StrB64_L1;
+        const StrB64_L2: &str = matter::Codex::StrB64_L2;
+        const StrB64_Big_L0: &str = matter::Codex::StrB64_Big_L0;
+        const StrB64_Big_L1: &str = matter::Codex::StrB64_Big_L1;
+        const StrB64_Big_L2: &str = matter::Codex::StrB64_Big_L2;
+
+        pub fn has_code(code: &str) -> bool {
+            const CODES: &[&str] =
+                &[StrB64_L0, StrB64_L1, StrB64_L2, StrB64_Big_L0, StrB64_Big_L1, StrB64_Big_L2];
+
+            CODES.contains(&code)
+        }
+    }
+}
+
+fn validate_code(code: &str) -> Result<()> {
+    const CODES: &[&str] = &[
+        matter::Codex::StrB64_L0,
+        matter::Codex::StrB64_L1,
+        matter::Codex::StrB64_L2,
+        matter::Codex::StrB64_Big_L0,
+        matter::Codex::StrB64_Big_L1,
+        matter::Codex::StrB64_Big_L2,
+    ];
+
+    if !CODES.contains(&code) {
+        return err!(Error::UnexpectedCode(code.to_string()));
+    }
+
+    Ok(())
+}
+
+fn rawify(bext: &str) -> Result<Vec<u8>> {
+    let ts = bext.len() % 4;
+    let ws = (4 - ts) % 4;
+    let ls = (3 - ts) % 3;
+    let base = vec!["A"; ws].join("") + bext;
+    Ok(b64_engine.decode(base)?[ls..].to_vec())
+}
+
+impl Bexter {
+    pub fn new(
+        bext: Option<&str>,
+        code: Option<&str>,
+        raw: Option<&[u8]>,
+        qb64b: Option<&[u8]>,
+        qb64: Option<&str>,
+        qb2: Option<&[u8]>,
+    ) -> Result<Self> {
+        lazy_static! {
+            static ref REB64: Regex = Regex::new(REB64_STRING).unwrap();
+        }
+
+        let code = code.unwrap_or(matter::Codex::StrB64_L0);
+
+        let bexter: Bexter = if bext.is_none()
+            && raw.is_none()
+            && qb64b.is_none()
+            && qb64.is_none()
+            && qb2.is_none()
+        {
+            return err!(Error::EmptyMaterial("missing bext string".to_string()));
+        } else if let Some(bext) = bext {
+            if !REB64.is_match(bext) {
+                return err!(Error::Value("invalid base64".to_string()));
+            }
+
+            let raw = rawify(bext)?;
+
+            Matter::new(Some(code), Some(&raw), None, None, None)?
+        } else {
+            Matter::new(Some(code), raw, qb64b, qb64, qb2)?
+        };
+
+        validate_code(&bexter.code())?;
+
+        Ok(bexter)
+    }
+
+    pub fn new_with_bext(bext: &str) -> Result<Self> {
+        Self::new(Some(bext), None, None, None, None, None)
+    }
+
+    pub fn new_with_raw(raw: &[u8], code: Option<&str>) -> Result<Self> {
+        Self::new(None, code, Some(raw), None, None, None)
+    }
+
+    pub fn new_with_qb64b(qb64b: &[u8]) -> Result<Self> {
+        Self::new(None, None, None, Some(qb64b), None, None)
+    }
+
+    pub fn new_with_qb64(qb64: &str) -> Result<Self> {
+        Self::new(None, None, None, None, Some(qb64), None)
+    }
+
+    pub fn new_with_qb2(qb2: &[u8]) -> Result<Self> {
+        Self::new(None, None, None, None, None, Some(qb2))
+    }
+
+    pub fn bext(&self) -> Result<String> {
+        let szg = matter::sizage(&self.code())?;
+
+        let mut full_raw: Vec<u8> = vec![0; szg.ls as usize];
+        full_raw.append(&mut self.raw());
+        let bext = b64_engine.encode(&full_raw);
+
+        let ws = if szg.ls == 0 {
+            usize::from(!bext.is_empty() && bext[0..1] == *"A")
+        } else {
+            (szg.ls as usize + 1) % 4
+        };
+
+        Ok(bext[ws..].to_string())
+    }
+}
+
+impl Matter for Bexter {
+    fn code(&self) -> String {
+        self.code.clone()
+    }
+
+    fn raw(&self) -> Vec<u8> {
+        self.raw.clone()
+    }
+
+    fn size(&self) -> u32 {
+        self.size
+    }
+
+    fn set_code(&mut self, code: &str) {
+        self.code = code.to_string();
+    }
+
+    fn set_raw(&mut self, raw: &[u8]) {
+        self.raw = raw.to_vec();
+    }
+
+    fn set_size(&mut self, size: u32) {
+        self.size = size;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core::bexter::Bexter;
+    use crate::core::matter::{tables as matter, Matter};
+
+    use rstest::rstest;
+
+    #[test]
+    fn convenience() {
+        assert!(Bexter::new_with_bext("A").is_ok());
+        assert!(Bexter::new_with_raw(b"\x00\x00\x00", Some(matter::Codex::StrB64_L0)).is_ok());
+        assert!(Bexter::new_with_qb64b(b"4AABAAAA").is_ok());
+        assert!(Bexter::new_with_qb64("4AABAAAA").is_ok());
+        assert!(Bexter::new_with_qb2(b"\xe0\x00\x01\x00\x00\x00").is_ok());
+    }
+
+    #[test]
+    fn python_interop() {
+        assert!(Bexter::new(None, None, None, None, None, None).is_err());
+
+        let bext = "@!";
+        assert!(Bexter::new(Some(bext), None, None, None, None, None).is_err());
+    }
+
+    #[rstest]
+    #[case(
+        "AAAA",
+        matter::Codex::StrB64_L0,
+        b"\x00\x00\x00",
+        b"4AABAAAA",
+        "4AABAAAA",
+        b"\xe0\x00\x01\x00\x00\x00",
+        "AAA"
+    )]
+    #[case(
+        "ABBB",
+        matter::Codex::StrB64_L0,
+        b"\x00\x10A",
+        b"4AABABBB",
+        "4AABABBB",
+        b"\xe0\x00\x01\x00\x10A",
+        "BBB"
+    )]
+    fn snowflakes(
+        #[case] bext: &str,
+        #[case] code: &str,
+        #[case] raw: &[u8],
+        #[case] qb64b: &[u8],
+        #[case] qb64: &str,
+        #[case] qb2: &[u8],
+        #[case] returned_bext: &str,
+    ) {
+        let bexter = Bexter::new(Some(bext), None, None, None, None, None).unwrap();
+        assert_eq!(bexter.code(), code);
+        assert_eq!(bexter.raw(), raw);
+        assert_eq!(bexter.qb64b().unwrap(), qb64b);
+        assert_eq!(bexter.qb64().unwrap(), qb64);
+        assert_eq!(bexter.qb2().unwrap(), qb2);
+        assert_eq!(bexter.bext().unwrap(), returned_bext);
+    }
+
+    #[rstest]
+    #[case("", matter::Codex::StrB64_L0, b"", b"4AAA", "4AAA", b"\xe0\x00\x00")]
+    #[case("-", matter::Codex::StrB64_L2, b">", b"6AABAAA-", "6AABAAA-", b"\xe8\x00\x01\x00\x00>")]
+    #[case(
+        "-A",
+        matter::Codex::StrB64_L1,
+        b"\x0f\x80",
+        b"5AABAA-A",
+        "5AABAA-A",
+        b"\xe4\x00\x01\x00\x0f\x80"
+    )]
+    #[case(
+        "-A-",
+        matter::Codex::StrB64_L0,
+        b"\x03\xe0>",
+        b"4AABA-A-",
+        "4AABA-A-",
+        b"\xe0\x00\x01\x03\xe0>"
+    )]
+    #[case(
+        "-A-B",
+        matter::Codex::StrB64_L0,
+        b"\xf8\x0f\x81",
+        b"4AAB-A-B",
+        "4AAB-A-B",
+        b"\xe0\x00\x01\xf8\x0f\x81"
+    )]
+    #[case(
+        "A",
+        matter::Codex::StrB64_L2,
+        b"\x00",
+        b"6AABAAAA",
+        "6AABAAAA",
+        b"\xe8\x00\x01\x00\x00\x00"
+    )]
+    #[case(
+        "AA",
+        matter::Codex::StrB64_L1,
+        b"\x00\x00",
+        b"5AABAAAA",
+        "5AABAAAA",
+        b"\xe4\x00\x01\x00\x00\x00"
+    )]
+    #[case(
+        "AAA",
+        matter::Codex::StrB64_L0,
+        b"\x00\x00\x00",
+        b"4AABAAAA",
+        "4AABAAAA",
+        b"\xe0\x00\x01\x00\x00\x00"
+    )]
+    #[case(
+        "ABB",
+        matter::Codex::StrB64_L0,
+        b"\x00\x00A",
+        b"4AABAABB",
+        "4AABAABB",
+        b"\xe0\x00\x01\x00\x00A"
+    )]
+    #[case(
+        "BBB",
+        matter::Codex::StrB64_L0,
+        b"\x00\x10A",
+        b"4AABABBB",
+        "4AABABBB",
+        b"\xe0\x00\x01\x00\x10A"
+    )]
+    fn creation(
+        #[case] bext: &str,
+        #[case] code: &str,
+        #[case] raw: &[u8],
+        #[case] qb64b: &[u8],
+        #[case] qb64: &str,
+        #[case] qb2: &[u8],
+    ) {
+        let bexter = Bexter::new(Some(bext), None, None, None, None, None).unwrap();
+        assert_eq!(bexter.code(), code);
+        assert_eq!(bexter.raw(), raw);
+        assert_eq!(bexter.qb64b().unwrap(), qb64b);
+        assert_eq!(bexter.qb64().unwrap(), qb64);
+        assert_eq!(bexter.qb2().unwrap(), qb2);
+        assert_eq!(bexter.bext().unwrap(), bext);
+    }
+
+    fn unhappy() {
+        assert!(Bexter::new(
+            None,
+            None,
+            None,
+            None,
+            Some("DKxy2sgzfplyr-tgwIxS19f2OchFHtLwPWD3v4oYimBx"),
+            None
+        )
+        .is_err());
+    }
+}

--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -82,6 +82,12 @@ pub(crate) mod Ids {
     pub const n: &str = "n";
     pub const b: &str = "b";
     pub const a: &str = "a";
+    pub const s: &str = "s";
+    pub const f: &str = "f";
+    pub const v: &str = "v";
+    pub const kt: &str = "kt";
+    pub const nt: &str = "nt";
+    pub const di: &str = "di";
 }
 
 const REVER_STRING: &str = "(?P<ident>[A-Z]{4})(?P<major>[0-9a-f])(?P<minor>[0-9a-f])(?P<kind>[A-Z]{4})(?P<size>[0-9a-f]{6})_";
@@ -113,8 +119,8 @@ pub(crate) const DUMMY: u8 = b'#';
 pub const CURRENT_VERSION: &Version = &Version { major: 1, minor: 0 };
 
 const MAXIMUM_START_SIZE: usize = 12;
-const VERSION_FULL_SIZE: usize = 17;
-const MINIMUM_SNIFF_SIZE: usize = MAXIMUM_START_SIZE + VERSION_FULL_SIZE;
+pub(crate) const VERSION_FULL_SIZE: usize = 17;
+pub(crate) const MINIMUM_SNIFF_SIZE: usize = MAXIMUM_START_SIZE + VERSION_FULL_SIZE;
 
 pub(crate) fn deversify(vs: &str) -> Result<DeversifyResult> {
     lazy_static! {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod bexter;
 pub mod cigar;
 pub mod common;
 pub mod counter;
@@ -10,7 +11,9 @@ pub mod prefixer;
 pub mod sadder;
 pub mod saider;
 pub mod seqner;
+pub mod serder;
 pub mod siger;
 pub mod signer;
+pub mod tholder;
 pub mod util;
 pub mod verfer;

--- a/src/core/number.rs
+++ b/src/core/number.rs
@@ -18,6 +18,11 @@ pub mod tables {
         pub const Long: &str = matter::Codex::Long; // Long 4 octet unsigned integer
         pub const Big: &str = matter::Codex::Big; // Big 8 byte octet unsigned integer
         pub const Huge: &str = matter::Codex::Salt_128; // Huge 16 byte octet unsigned integer
+
+        pub fn has_code(code: &str) -> bool {
+            const CODES: &[&str] = &[Short, Long, Big, Huge];
+            CODES.contains(&code)
+        }
     }
 }
 
@@ -28,10 +33,7 @@ impl Default for Number {
 }
 
 fn validate_code(code: &str) -> Result<()> {
-    const CODES: &[&str] =
-        &[tables::Codex::Short, tables::Codex::Long, tables::Codex::Big, tables::Codex::Huge];
-
-    if !CODES.contains(&code) {
+    if !tables::Codex::has_code(code) {
         return err!(Error::UnexpectedCode(code.to_string()));
     }
 

--- a/src/core/prefixer.rs
+++ b/src/core/prefixer.rs
@@ -354,6 +354,22 @@ impl Prefixer {
             _ => err!(Error::UnexpectedCode(self.code())),
         }
     }
+
+    pub fn digestive(&self) -> bool {
+        const CODES: &[&str] = &[
+            matter::Codex::Blake3_256,
+            matter::Codex::Blake3_512,
+            matter::Codex::Blake2b_256,
+            matter::Codex::Blake2b_512,
+            matter::Codex::Blake2s_256,
+            matter::Codex::SHA3_256,
+            matter::Codex::SHA3_512,
+            matter::Codex::SHA2_256,
+            matter::Codex::SHA2_512,
+        ];
+
+        CODES.contains(&self.code().as_str())
+    }
 }
 
 impl Matter for Prefixer {

--- a/src/core/serder.rs
+++ b/src/core/serder.rs
@@ -1,0 +1,780 @@
+use crate::{
+    core::{
+        common::{Identage, Ids, Ilkage, Serialage, Version, CURRENT_VERSION},
+        diger::Diger,
+        matter::tables as matter,
+        number::Number,
+        sadder::Sadder,
+        saider::Saider,
+        tholder::Tholder,
+        verfer::Verfer,
+    },
+    data::{data, Value},
+    error::{err, Error, Result},
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Serder {
+    code: String,
+    raw: Vec<u8>,
+    ked: Value,
+    ident: String,
+    kind: String,
+    size: u32,
+    version: Version,
+    saider: Saider,
+}
+
+fn validate_ident(ident: &str) -> Result<()> {
+    if ident != Identage::KERI {
+        return err!(Error::Validation(format!("unexpected ident {}", ident)));
+    }
+
+    Ok(())
+}
+
+impl Serder {
+    pub fn new(
+        code: Option<&str>,
+        raw: Option<&[u8]>,
+        kind: Option<&str>,
+        ked: Option<&Value>,
+        sad: Option<&Self>,
+    ) -> Result<Self> {
+        let code = code.unwrap_or(matter::Codex::Blake3_256);
+        let serder = Sadder::new(Some(code), raw, kind, ked, sad)?;
+        validate_ident(&serder.ident())?;
+
+        Ok(serder)
+    }
+
+    pub fn verfers(&self) -> Result<Vec<Verfer>> {
+        let mut result: Vec<Verfer> = Vec::new();
+        let map = self.ked.to_map()?;
+
+        let label = Ids::k;
+        if map.contains_key(label) {
+            let r = self.ked[label].to_vec();
+            if r.is_ok() {
+                for key in r? {
+                    result.push(Verfer::new(None, None, None, Some(&key.to_string()?), None)?);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub fn digers(&self) -> Result<Vec<Diger>> {
+        let mut result: Vec<Diger> = Vec::new();
+        let map = self.ked.to_map()?;
+
+        let label = Ids::n;
+        if map.contains_key(label) {
+            let r = self.ked[label].to_vec();
+            if r.is_ok() {
+                for key in r? {
+                    result.push(Diger::new(None, None, None, None, Some(&key.to_string()?), None)?);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub fn werfers(&self) -> Result<Vec<Verfer>> {
+        let mut result: Vec<Verfer> = Vec::new();
+        let map = self.ked.to_map()?;
+
+        let label = Ids::b;
+        if map.contains_key(label) {
+            for witness in self.ked[label].to_vec()? {
+                result.push(Verfer::new(None, None, None, Some(&witness.to_string()?), None)?)
+            }
+        }
+
+        Ok(result)
+    }
+
+    pub fn tholder(&self) -> Result<Option<Tholder>> {
+        let map = self.ked.to_map()?;
+
+        let label = Ids::kt;
+        let result = if map.contains_key(label) {
+            Some(Tholder::new(None, None, Some(&(self.ked[label])))?)
+        } else {
+            None
+        };
+
+        Ok(result)
+    }
+
+    pub fn ntholder(&self) -> Result<Option<Tholder>> {
+        let map = self.ked.to_map()?;
+
+        let label = Ids::nt;
+        let result = if map.contains_key(label) {
+            Some(Tholder::new(None, None, Some(&(self.ked[label])))?)
+        } else {
+            None
+        };
+
+        Ok(result)
+    }
+
+    pub fn sner(&self) -> Result<Number> {
+        let label = Ids::s;
+
+        Number::new(None, Some(&self.ked[label].to_string()?), None, None, None, None, None)
+    }
+
+    pub fn sn(&self) -> Result<u128> {
+        self.sner()?.num()
+    }
+
+    pub fn fner(&self) -> Result<Option<Number>> {
+        let map = self.ked.to_map()?;
+
+        let label = Ids::f;
+        let result = if map.contains_key(label) {
+            Some(Number::new(
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(&self.ked[label].to_string()?),
+                None,
+            )?)
+        } else {
+            None
+        };
+
+        Ok(result)
+    }
+
+    pub fn _fn(&self) -> Result<u128> {
+        let _fner = self.fner()?;
+
+        if let Some(_fner) = _fner {
+            _fner.num()
+        } else {
+            err!(Error::Validation("first seen does not exist".to_string()))
+        }
+    }
+
+    fn pre(&self) -> Result<String> {
+        let label = Ids::i;
+        self.ked[label].to_string()
+    }
+
+    fn preb(&self) -> Result<Vec<u8>> {
+        Ok(self.pre()?.as_bytes().to_vec())
+    }
+
+    fn est(&self) -> Result<bool> {
+        const ILKS: &[&str] = &[Ilkage::icp, Ilkage::rot, Ilkage::dip, Ilkage::drt];
+
+        let label = Ids::t;
+        let ilk = self.ked[label].to_string()?;
+
+        Ok(ILKS.contains(&ilk.as_str()))
+    }
+
+    // pretty implemented in Sadder (this was overridden for some reason in KERIpy)
+}
+
+impl Default for Serder {
+    fn default() -> Self {
+        Serder {
+            code: matter::Codex::Blake3_256.to_string(),
+            raw: vec![],
+            ked: data!({}),
+            ident: Identage::KERI.to_string(),
+            kind: Serialage::JSON.to_string(),
+            size: 0,
+            version: CURRENT_VERSION.clone(),
+            saider: Saider::default(),
+        }
+    }
+}
+
+impl Sadder for Serder {
+    fn code(&self) -> String {
+        self.code.clone()
+    }
+
+    fn raw(&self) -> Vec<u8> {
+        self.raw.clone()
+    }
+
+    fn ked(&self) -> Value {
+        self.ked.clone()
+    }
+
+    fn ident(&self) -> String {
+        self.ident.clone()
+    }
+
+    fn kind(&self) -> String {
+        self.kind.clone()
+    }
+
+    fn size(&self) -> u32 {
+        self.size
+    }
+
+    fn version(&self) -> Version {
+        self.version.clone()
+    }
+
+    fn saider(&self) -> Saider {
+        self.saider.clone()
+    }
+
+    fn set_code(&mut self, code: &str) {
+        self.code = code.to_string();
+    }
+
+    fn set_raw(&mut self, raw: &[u8]) {
+        self.raw = raw.to_vec();
+    }
+
+    fn set_ked(&mut self, ked: &Value) {
+        self.ked = ked.clone();
+    }
+
+    fn set_ident(&mut self, ident: &str) {
+        self.ident = ident.to_string();
+    }
+
+    fn set_kind(&mut self, kind: &str) {
+        self.kind = kind.to_string();
+    }
+
+    fn set_size(&mut self, size: u32) {
+        self.size = size;
+    }
+
+    fn set_version(&mut self, version: &Version) {
+        self.version = version.clone();
+    }
+
+    fn set_saider(&mut self, saider: &Saider) {
+        self.saider = saider.clone();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        core::{
+            common::{
+                sniff, versify, Identage, Ids, Ilkage, Serialage, Version, CURRENT_VERSION,
+                MINIMUM_SNIFF_SIZE, VERSION_FULL_SIZE,
+            },
+            matter::{tables as matter, Matter},
+            number::Number,
+            prefixer::Prefixer,
+            sadder::Sadder,
+            saider::Saider,
+            serder::Serder,
+            tholder::Tholder,
+        },
+        data::{Data, Value},
+        error::{err, Error, Result},
+    };
+
+    #[test]
+    fn python_interop() {
+        assert!(Serder::new(None, None, None, None, None).is_err());
+
+        let _vs = "KERI10JSON000000_";
+        let e1 = data!({
+            "v": _vs,
+            "d": "",
+            "i": "ABCDEFG",
+            "s": "0001",
+            "t": "rot"
+        });
+        let (_, mut e1) = Saider::saidify(&e1, None, None, None, None).unwrap();
+
+        let serder = Serder::new(None, None, None, Some(&e1), None).unwrap();
+        assert_eq!(serder.ked(), e1);
+        assert_eq!(serder.kind(), Serialage::JSON);
+        assert_eq!(serder.version(), *CURRENT_VERSION);
+        assert_eq!(serder.said().unwrap(), "EIM66TjBMfwPnbwK7oZqbZyGz9nOeVmQHeH3NZxrsk8F");
+        assert_eq!(serder.saidb().unwrap(), b"EIM66TjBMfwPnbwK7oZqbZyGz9nOeVmQHeH3NZxrsk8F");
+        assert_eq!(serder.size(), 111);
+        assert_eq!(serder.verfers().unwrap(), []);
+        assert_eq!(serder.raw(), b"{\"v\":\"KERI10JSON00006f_\",\"d\":\"EIM66TjBMfwPnbwK7oZqbZyGz9nOeVmQHeH3NZxrsk8F\",\"i\":\"ABCDEFG\",\"s\":\"0001\",\"t\":\"rot\"}");
+        assert_eq!(serder.sn().unwrap(), 1);
+        assert_eq!(serder.pre().unwrap(), "ABCDEFG");
+        assert_eq!(serder.preb().unwrap(), b"ABCDEFG");
+
+        let e1s = e1.to_json().unwrap();
+        assert_eq!(e1s, "{\"v\":\"KERI10JSON00006f_\",\"d\":\"EIM66TjBMfwPnbwK7oZqbZyGz9nOeVmQHeH3NZxrsk8F\",\"i\":\"ABCDEFG\",\"s\":\"0001\",\"t\":\"rot\"}");
+
+        let vs = versify(None, None, Some(Serialage::JSON), Some(e1s.len() as u32)).unwrap();
+        assert_eq!(vs, "KERI10JSON00006f_");
+        let label = Ids::v;
+        e1[label] = data!(&vs);
+        let pretty = serder.pretty(None).unwrap();
+        // this next one indents by 2, unlike KERIpy
+        assert_eq!(
+            pretty,
+            "{\n".to_string()
+                + "  \"v\": \"KERI10JSON00006f_\",\n"
+                + "  \"d\": \"EIM66TjBMfwPnbwK7oZqbZyGz9nOeVmQHeH3NZxrsk8F\",\n"
+                + "  \"i\": \"ABCDEFG\",\n"
+                + "  \"s\": \"0001\",\n"
+                + "  \"t\": \"rot\"\n"
+                + "}"
+        );
+
+        let e1s = e1.to_json().unwrap();
+        let e1sb = e1s.as_bytes();
+        assert!(sniff(&e1sb[..VERSION_FULL_SIZE]).is_err());
+
+        let result1 = sniff(&e1sb[..MINIMUM_SNIFF_SIZE]).unwrap();
+        assert_eq!(result1.ident, Identage::KERI);
+        assert_eq!(result1.kind, Serialage::JSON);
+        assert_eq!(result1.size, 111);
+
+        let result1 = sniff(e1sb).unwrap();
+        assert_eq!(result1.ident, Identage::KERI);
+        assert_eq!(result1.kind, Serialage::JSON);
+        assert_eq!(result1.size, 111);
+
+        let mut e1sb_extra = e1sb.to_vec();
+        e1sb_extra.append(&mut b"extra attached at the end".to_vec());
+
+        let ked = data!({
+            "v": "KERI10JSON00006a_",
+            "d": "HAg9_-rPd8oga-oyPghCEIlJZHKbYXcP86LQl0Yg2AvA",
+            "i": "ABCDEFG",
+            "s": 1,
+            "t": "rot"
+        });
+        let raw = b"{\"v\":\"KERI10JSON00006a_\",\"d\":\"HAg9_-rPd8oga-oyPghCEIlJZHKbYXcP86LQl0Yg2AvA\",\"i\":\"ABCDEFG\",\"s\":1,\"t\":\"rot\"}";
+
+        let srdr = Serder::new(Some(matter::Codex::SHA3_256), Some(raw), None, None, None).unwrap();
+        assert_eq!(srdr.kind(), "JSON");
+        assert_eq!(srdr.raw(), raw);
+        assert_eq!(srdr.ked(), ked);
+        assert_eq!(srdr.saider().code(), matter::Codex::SHA3_256);
+
+        let ked = data!({
+            "v": "KERI10JSON00006a_",
+            "d": "EADZ055vgh5utgSY3OOL1lW0m1pJ1W0Ia6-SVuGa0OqE",
+            "i": "ABCDEFG",
+            "s": 1,
+            "t": "rot"
+        });
+        let raw = b"{\"v\":\"KERI10JSON00006a_\",\"d\":\"EADZ055vgh5utgSY3OOL1lW0m1pJ1W0Ia6-SVuGa0OqE\",\"i\":\"ABCDEFG\",\"s\":1,\"t\":\"rot\"}";
+
+        let srdr =
+            Serder::new(Some(matter::Codex::Blake3_256), Some(raw), None, None, None).unwrap();
+        assert_eq!(srdr.kind(), "JSON");
+        assert_eq!(srdr.raw(), raw);
+        assert_eq!(srdr.ked(), ked);
+        assert_eq!(srdr.saider().code(), matter::Codex::Blake3_256);
+
+        assert!(srdr.est().unwrap());
+    }
+
+    #[test]
+    fn inception() {
+        let aids = &[
+            "BEy_EvE8OUMqj0AgCJ3wOCOrIVHVtwubYAysPyaAv9VI",
+            "BC9Df6ssUZQFQZJYVUyfudw4WTQsugGcvVD_Z4ChFGE4",
+            "BEejlxZytU7gjUwtgkmNKmBWiFPKSsXjk_uxzoun8dtK",
+        ];
+
+        let pre0 = aids[0];
+        let wit0 = aids[1];
+        let wit1 = aids[2];
+        let srdr = incept(
+            &[pre0],
+            None,
+            None,
+            None,
+            None,
+            Some(&[wit0, wit1]),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(srdr.raw(),
+            b"{\"v\":\"KERI10JSON00015a_\",\"t\":\"icp\",\"d\":\"EBAjyPZ8Ed4XXl5cVZhqAy7SuaGivQp0WqQKVXvg7oqd\",\"i\":\"BEy_EvE8OUMqj0AgCJ3wOCOrIVHVtwubYAysPyaAv9VI\",\"s\":\"0\",\"kt\":\"1\",\"k\":[\"BEy_EvE8OUMqj0AgCJ3wOCOrIVHVtwubYAysPyaAv9VI\"],\"nt\":\"0\",\"n\":[],\"bt\":\"2\",\"b\":[\"BC9Df6ssUZQFQZJYVUyfudw4WTQsugGcvVD_Z4ChFGE4\",\"BEejlxZytU7gjUwtgkmNKmBWiFPKSsXjk_uxzoun8dtK\"],\"c\":[],\"a\":[]}"
+        );
+        assert_eq!(srdr.pre().unwrap(), pre0);
+        assert_eq!(srdr.sn().unwrap(), 0);
+        assert_eq!(
+            srdr.verfers()
+                .unwrap()
+                .iter()
+                .map(|verfer| verfer.qb64().unwrap())
+                .collect::<Vec<String>>(),
+            [pre0.to_string()]
+        );
+        assert_eq!(
+            srdr.werfers()
+                .unwrap()
+                .iter()
+                .map(|werfer| werfer.qb64().unwrap())
+                .collect::<Vec<String>>(),
+            [wit0.to_string(), wit1.to_string()]
+        );
+
+        println!("{p}", p = srdr.pretty(None).unwrap());
+    }
+
+    #[test]
+    fn creation() {
+        let ked = data!({
+            "v": "KERI10JSON00011c_",
+            "t": "rep",
+            "d": "EBAjyPZ8Ed4XXl5cVZhqAy7SuaGivQp0WqQKVXvg7oqd",
+            "dt": "2020-08-22T17:50:12.988921+00:00",
+            "r": "logs/processor",
+            "a":
+                {
+                    "d": "EBAjyPZ8Ed4XXl5cVZhqAy7SuaGivQp0WqQKVXvg7oqd",
+                    "i": "BEy_EvE8OUMqj0AgCJ3wOCOrIVHVtwubYAysPyaAv9VI",
+                    "name": "John Jones",
+                    "role": "Founder",
+                }
+        });
+
+        let srdr = Serder::new(None, None, None, Some(&ked), None).unwrap();
+        assert_eq!(srdr.said().unwrap(), "EBAjyPZ8Ed4XXl5cVZhqAy7SuaGivQp0WqQKVXvg7oqd");
+        assert_eq!(srdr.saidb().unwrap(), b"EBAjyPZ8Ed4XXl5cVZhqAy7SuaGivQp0WqQKVXvg7oqd");
+
+        let ked = data!({
+            "v": "KERI10JSON000000_",
+            "t": "icp",
+            "d": "",
+            "i": "BEy_EvE8OUMqj0AgCJ3wOCOrIVHVtwubYAysPyaAv9VI",
+            "s": "0",
+            "kt": "1",
+            "k": ["BC9Df6ssUZQFQZJYVUyfudw4WTQsugGcvVD_Z4ChFGE4"],
+            "n": "",
+            "bt": "0",
+            "b": [],
+            "c": [],
+            "a": [],
+        });
+
+        let (_, mut ked) = Saider::saidify(&ked, None, None, None, None).unwrap();
+        let srdr = Serder::new(None, None, None, Some(&ked), None).unwrap();
+        assert_eq!(srdr.tholder().unwrap().unwrap().sith().unwrap(), data!("1"));
+        assert_eq!(srdr.tholder().unwrap().unwrap().thold(), data!(1));
+        assert_eq!(srdr.sn().unwrap(), 0);
+        assert_eq!(srdr.sner().unwrap().num().unwrap(), 0);
+
+        assert!(srdr.ntholder().unwrap().is_none());
+        assert!(srdr.fner().unwrap().is_none());
+        assert!(srdr._fn().is_err());
+        assert_eq!(srdr.digers().unwrap().len(), 0);
+
+        ked["s"] = data!("-1");
+        let srdr = Serder::new(None, None, None, Some(&ked), None).unwrap();
+        assert!(srdr.sn().is_err());
+
+        ked["s"] = data!("15.34");
+        let srdr = Serder::new(None, None, None, Some(&ked), None).unwrap();
+        assert!(srdr.sn().is_err());
+
+        let ked = data!({
+            "v": "KERI10JSON000000_",
+            "t": "icp",
+            "d": "",
+            "i": "BEy_EvE8OUMqj0AgCJ3wOCOrIVHVtwubYAysPyaAv9VI",
+            "s": "0",
+            "kt": "1",
+            "k": ["BC9Df6ssUZQFQZJYVUyfudw4WTQsugGcvVD_Z4ChFGE4"],
+            "nt": "1",
+            "n": ["ELC5L3iBVD77d_MYbYGGCUQgqQBju1o4x1Ud-z2sL-ux"],
+            "bt": "0",
+            "f": &Number::new(Some(0), None, None, None, None, None, None).unwrap().qb64().unwrap(),
+            "b": [],
+            "c": [],
+            "a": [],
+        });
+
+        let (_, ked) = Saider::saidify(&ked, None, None, None, None).unwrap();
+        let srdr = Serder::new(None, None, None, Some(&ked), None).unwrap();
+        assert_eq!(srdr.tholder().unwrap().unwrap().sith().unwrap(), data!("1"));
+        assert_eq!(srdr.tholder().unwrap().unwrap().thold(), data!(1));
+        assert_eq!(srdr.sn().unwrap(), 0);
+        assert_eq!(srdr.sner().unwrap().num().unwrap(), 0);
+
+        assert_eq!(srdr.ntholder().unwrap().unwrap().sith().unwrap(), data!("1"));
+        assert_eq!(srdr.ntholder().unwrap().unwrap().thold(), data!(1));
+        assert!(srdr.fner().unwrap().is_some());
+        assert_eq!(srdr._fn().unwrap(), 0);
+        assert_eq!(srdr.digers().unwrap().len(), 1);
+
+        let ked = data!({
+            "v": "ACDC10JSON000000_",
+            "t": "icp",
+            "d": "",
+            "i": "BEy_EvE8OUMqj0AgCJ3wOCOrIVHVtwubYAysPyaAv9VI",
+            "s": "0",
+            "kt": "1",
+            "k": ["BC9Df6ssUZQFQZJYVUyfudw4WTQsugGcvVD_Z4ChFGE4"],
+            "nt": "1",
+            "n": ["ELC5L3iBVD77d_MYbYGGCUQgqQBju1o4x1Ud-z2sL-ux"],
+            "bt": "0",
+            "f": &Number::new(Some(0), None, None, None, None, None, None).unwrap().qb64().unwrap(),
+            "b": [],
+            "c": [],
+            "a": [],
+        });
+
+        let (_, ked) = Saider::saidify(&ked, None, None, None, None).unwrap();
+        assert!(Serder::new(None, None, None, Some(&ked), None).is_err());
+    }
+
+    mod traiter {
+        #[allow(non_upper_case_globals)]
+        #[allow(non_snake_case)]
+        mod Codex {
+            const EstOnly: &str = "EO";
+            const DoNotDelegate: &str = "DND";
+            const NoBackeds: &str = "NB";
+        }
+    }
+
+    // what follows is a simple inception function. it is used above to verify serder functionality.
+
+    // this function uses convenience methods unlike most test code. it is likely that it will
+    // be extracted and used elsewhere - and convenience methods make sense outside the tests.
+    fn incept(
+        keys: &[&str],          // current keys qb64
+        sith: Option<&Value>,   // current signing threshold
+        ndigs: Option<&[&str]>, // next keys qb64
+        nsith: Option<&Value>,  // next signing threshold
+        toad: Option<u128>,     // witness threshold number
+        wits: Option<&[&str]>,  // witness identifier prefixes qb64
+        cnfg: Option<&[&str]>,  // configuration traits from traiter::Codex
+        data: Option<&[Value]>, // seal dicts
+        version: Option<&Version>,
+        kind: Option<&str>,
+        code: Option<&str>,
+        intive: Option<bool>, // sith, nsith and toad are ints, not hex when numeric
+        delpre: Option<&str>, // delegator identifier prefix
+    ) -> Result<Serder> {
+        let version = version.unwrap_or(CURRENT_VERSION);
+        let kind = kind.unwrap_or(Serialage::JSON);
+        let intive = intive.unwrap_or(false);
+
+        let vs = &versify(None, Some(version), Some(kind), Some(0))?;
+        let ilk = if delpre.is_none() { Ilkage::icp } else { Ilkage::dip };
+        let sner = Number::new_with_num(0)?;
+
+        let sith = if let Some(sith) = sith {
+            sith.clone()
+        } else {
+            let mut s: i64 = (keys.len() as i64 + 1) / 2;
+            s = if s > 1 { s } else { 1 };
+            data!(s)
+        };
+
+        let tholder = Tholder::new_with_sith(&sith)?;
+        if tholder.num()?.is_some() && tholder.num()?.unwrap() < 1 {
+            return err!(Error::Value(format!(
+                "invalid sith = {n} less than 1",
+                n = tholder.num()?.unwrap()
+            )));
+        }
+        if tholder.size() as usize > keys.len() {
+            return err!(Error::Value(format!(
+                "invalid sith size = {s} for keys = {keys:?}",
+                s = tholder.size()
+            )));
+        }
+
+        let ndigs = ndigs.unwrap_or(&[]);
+        let nsith = if let Some(nsith) = nsith {
+            nsith.clone()
+        } else {
+            let mut s: i64 = (ndigs.len() as i64 + 1) / 2;
+            s = if s > 0 { s } else { 0 };
+            data!(s)
+        };
+
+        let ntholder = Tholder::new_with_sith(&nsith)?;
+        if ntholder.size() as usize > ndigs.len() {
+            return err!(Error::Value(format!(
+                "invalid nsith size = {s} for keys = {keys:?}",
+                s = ntholder.size()
+            )));
+        }
+
+        let wits = wits.unwrap_or(&[]);
+        let mut unique = wits.to_vec();
+        unique.dedup();
+        if wits.len() != unique.len() {
+            return err!(Error::Value(format!("invalid wits = {wits:?}, has duplicates")));
+        }
+
+        let toader = if let Some(toad) = toad {
+            Number::new_with_num(toad)?
+        } else if wits.is_empty() {
+            Number::new_with_num(0)?
+        } else {
+            let toad = ample(wits.len() as u128, None, None)?;
+            Number::new_with_num(toad)?
+        };
+
+        if !wits.is_empty() {
+            if toader.num()? < 1 || toader.num()? > wits.len() as u128 {
+                return err!(Error::Value(format!(
+                    "invalid toad = {n} for wits = {wits:?}",
+                    n = toader.num()?
+                )));
+            }
+        } else if toader.num()? != 0 {
+            return err!(Error::Value(format!(
+                "invalid toad = {n} for wits = {wits:?}",
+                n = toader.num()?
+            )));
+        }
+
+        let cnfg = cnfg.unwrap_or(&[]);
+        let data = data.unwrap_or(&[]);
+
+        let kt = if let Some(n) = tholder.num()? {
+            if intive && n < u32::MAX {
+                data!(n)
+            } else {
+                tholder.sith()?
+            }
+        } else {
+            tholder.sith()?
+        };
+
+        let nt = if let Some(n) = ntholder.num()? {
+            if intive && n < u32::MAX {
+                data!(n)
+            } else {
+                ntholder.sith()?
+            }
+        } else {
+            ntholder.sith()?
+        };
+
+        let toad = if intive && toader.num()? < u32::MAX as u128 {
+            data!(toader.num()? as i64)
+        } else {
+            data!(&toader.numh()?)
+        };
+
+        let keys: Vec<Value> = keys.iter().map(|key| data!(*key)).collect();
+        let ndigs: Vec<Value> = ndigs.iter().map(|dig| data!(*dig)).collect();
+        let wits: Vec<Value> = wits.iter().map(|wit| data!(*wit)).collect();
+        let cnfg: Vec<Value> = cnfg.iter().map(|cfg| data!(*cfg)).collect();
+
+        let mut ked = data!({
+            "v": vs,
+            "t": ilk,
+            "d": "",
+            "i": "",
+            "s": &sner.numh()?,
+            "kt": kt,
+            "k": keys.as_slice(),
+            "nt": nt,
+            "n": ndigs.as_slice(),
+            "bt": toad,
+            "b": wits.as_slice(),
+            "c": cnfg.as_slice(),
+            "a": data
+        });
+
+        let code = if let Some(delpre) = delpre {
+            let label = Ids::di;
+            ked[label] = data!(delpre);
+            Some(code.unwrap_or(matter::Codex::Blake3_256))
+        } else {
+            code
+        };
+
+        let prefixer = if delpre.is_none() && code.is_none() && keys.len() == 1 {
+            let prefixer = Prefixer::new_with_qb64(&keys[0].to_string()?)?;
+            if prefixer.digestive() {
+                return err!(Error::Value(format!(
+                    "invalid code, digestive = {c}, must be derived from ked",
+                    c = prefixer.code()
+                )));
+            }
+            prefixer
+        } else {
+            let prefixer = Prefixer::new_with_ked(&ked, None, code)?;
+            if delpre.is_some() && !prefixer.digestive() {
+                return err!(Error::Value(format!(
+                    "invalid derivation code = {c} for delegation, must be digestive",
+                    c = prefixer.code()
+                )));
+            }
+            prefixer
+        };
+
+        let label = Ids::i;
+        ked[label] = data!(&prefixer.qb64()?);
+        let ked = if prefixer.digestive() {
+            let label = Ids::d;
+            ked[label] = data!(&prefixer.qb64()?);
+            ked
+        } else {
+            let (_, ked) = Saider::saidify(&ked, None, None, None, None)?;
+            ked
+        };
+
+        Serder::new(None, None, None, Some(&ked), None)
+    }
+
+    fn ample(n: u128, f: Option<u128>, weak: Option<bool>) -> Result<u128> {
+        let weak = weak.unwrap_or(true);
+        let n = if n > 0 { n } else { 0 };
+        if let Some(f) = f {
+            let f = if f > 0 { f } else { 0 };
+            let m1 = (n + f + 2) / 2;
+            let m2 = if n - f > 0 { n - f } else { 0 };
+
+            if m2 < m1 && n > 0 {
+                return err!(Error::Value(format!("invalid f={f}, too big for n={n}")));
+            }
+
+            if weak {
+                match [n, m1, m2].iter().min() {
+                    Some(x) => Ok(*x),
+                    None => err!(Error::Value("unreachable".to_string())),
+                }
+            } else {
+                Ok(std::cmp::min(n, std::cmp::max(m1, m2)))
+            }
+        } else {
+            let f1 = std::cmp::max(1, std::cmp::max(0, n - 1) / 3);
+            let f2 = std::cmp::max(1, (std::cmp::max(0, n - 1) + 2) / 3);
+
+            if weak {
+                match [n, (n + f1 + 3) / 2, (n + f2 + 3) / 2].iter().min() {
+                    Some(x) => Ok(*x),
+                    None => err!(Error::Value("unreachable".to_string())),
+                }
+            } else {
+                match [0, n - f1, (n + f1 + 3) / 2].iter().max() {
+                    Some(x) => Ok(std::cmp::min(n, *x)),
+                    None => err!(Error::Value("unreachable".to_string())),
+                }
+            }
+        }
+    }
+}

--- a/src/core/tholder.rs
+++ b/src/core/tholder.rs
@@ -1,0 +1,631 @@
+use crate::{
+    core::{
+        bexter::{tables as bexter, Bexter},
+        matter::{tables as matter, Matter},
+        number::{tables as number, Number},
+    },
+    data::{data, Array, Data, Value},
+    error::{err, Error, Result},
+};
+
+use lazy_static::lazy_static;
+use num_rational::Rational32;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Tholder {
+    thold: Value,
+    weighted: bool,
+    size: u32,
+    number: Option<Number>,
+    bexter: Option<Bexter>,
+}
+
+impl Default for Tholder {
+    fn default() -> Self {
+        Tholder { thold: data!(1), weighted: false, size: 1, number: None, bexter: None }
+    }
+}
+
+fn values_to_rationals(value: &Value) -> Result<Vec<Vec<Rational32>>> {
+    let threshold = value.to_vec()?;
+    let separator = "/";
+    let mut clauses: Vec<Vec<Rational32>> = Vec::new();
+
+    for _clause in threshold {
+        let mut clause: Vec<Rational32> = Vec::new();
+        let _clause = _clause.to_vec()?;
+        for weight in _clause {
+            let weight = weight.to_string()?;
+            let parts: Vec<&str> = weight.split(separator).into_iter().collect();
+            if parts.len() != 2 {
+                // must be 0 or 1
+                if parts[0] == "0" {
+                    clause.push(Rational32::new(0, 1));
+                } else if parts[0] == "1" {
+                    clause.push(Rational32::new(1, 1));
+                } else {
+                    return err!(Error::Value("integral weight must be 0 or 1".to_string()));
+                }
+            } else {
+                let numer = parts[0].parse::<i32>()?;
+                let denom = parts[1].parse::<i32>()?;
+                if numer < 0 || denom < 0 {
+                    return err!(Error::Value("negative weights do not make sense".to_string()));
+                }
+                if numer > denom {
+                    return err!(Error::Value(format!("weight {numer}/{denom} > 1")));
+                }
+                clause.push(Rational32::new(numer, denom));
+            }
+        }
+        clauses.push(clause);
+    }
+
+    for clause in &*clauses {
+        let mut sum = Rational32::new(0, 1);
+
+        for weight in clause {
+            sum += weight;
+        }
+
+        if sum < Rational32::new(1, 1) {
+            return err!(Error::Value(format!(
+                "invalid sith clause = {}, clause weight sums must be >= 1",
+                value.to_json()?
+            )));
+        }
+    }
+
+    Ok(clauses)
+}
+
+fn rationals_to_bext(clauses: &Vec<Vec<Rational32>>) -> String {
+    let mut envelope: Vec<String> = Vec::new();
+    for clause in clauses {
+        let mut text_clause: Vec<String> = Vec::new();
+        for weight in clause {
+            if *weight.denom() == 1 {
+                text_clause.push(format!("{n}", n = weight.numer()));
+            } else {
+                text_clause.push(format!("{n}s{d}", n = weight.numer(), d = weight.denom()));
+            }
+        }
+        envelope.push(text_clause.join("c"));
+    }
+    envelope.join("a")
+}
+
+impl Tholder {
+    pub fn new(thold: Option<&Value>, limen: Option<&[u8]>, sith: Option<&Value>) -> Result<Self> {
+        let mut tholder = Self::default();
+
+        if let Some(thold) = thold {
+            tholder.process_thold(thold)?;
+        }
+
+        if let Some(limen) = limen {
+            tholder.process_limen(limen)?;
+        }
+
+        if let Some(sith) = sith {
+            tholder.process_sith(sith)?;
+        }
+
+        if tholder == Self::default() {
+            return err!(Error::EmptyMaterial("missing threshold expression".to_string()));
+        }
+
+        Ok(tholder)
+    }
+
+    pub fn new_with_thold(thold: &Value) -> Result<Self> {
+        Self::new(Some(thold), None, None)
+    }
+
+    pub fn new_with_limen(limen: &[u8]) -> Result<Self> {
+        Self::new(None, Some(limen), None)
+    }
+
+    pub fn new_with_sith(sith: &Value) -> Result<Self> {
+        Self::new(None, None, Some(sith))
+    }
+
+    pub fn thold(&self) -> Value {
+        self.thold.clone()
+    }
+
+    pub fn weighted(&self) -> bool {
+        self.weighted
+    }
+
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+
+    pub fn num(&self) -> Result<Option<u32>> {
+        if !self.weighted() {
+            Ok(Some(u32::try_from(self.thold().to_i64()?)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn number(&self) -> Option<Number> {
+        self.number.as_ref().cloned()
+    }
+
+    pub fn bexter(&self) -> Option<Bexter> {
+        self.bexter.as_ref().cloned()
+    }
+
+    pub fn limen(&self) -> Result<Vec<u8>> {
+        if self.weighted() {
+            if let Some(bexter) = self.bexter() {
+                bexter.qb64b()
+            } else {
+                // unreachable
+                err!(Error::Value("malformed tholder".to_string()))
+            }
+        } else if let Some(number) = self.number() {
+            number.qb64b()
+        } else {
+            // unreachable
+            err!(Error::Value("malformed tholder".to_string()))
+        }
+    }
+
+    pub fn sith(&self) -> Result<Value> {
+        if self.weighted() {
+            let thold = self.thold();
+            if thold.to_vec()?.len() == 1 {
+                Ok(thold[0].clone())
+            } else {
+                Ok(thold)
+            }
+        } else {
+            let thold = self.thold().to_i64()?;
+            let sith = format!("{t:x}", t = thold);
+            Ok(data!(&sith))
+        }
+    }
+
+    pub fn to_json(&self) -> Result<String> {
+        self.sith()?.to_json()
+    }
+
+    pub fn satisfy(&self, indices: &[u32]) -> Result<bool> {
+        return if self.number().is_some() {
+            self.satisfy_numeric(indices)
+        } else if self.bexter().is_some() {
+            self.satisfy_weighted(indices)
+        } else {
+            Ok(false)
+        };
+    }
+
+    fn satisfy_numeric(&self, indices: &[u32]) -> Result<bool> {
+        let thold = self.thold().to_i64()?;
+
+        if thold > 0 && indices.len() >= thold as usize {
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
+    fn satisfy_weighted(&self, indices: &[u32]) -> Result<bool> {
+        lazy_static! {
+            static ref RATIONAL_ONE: Rational32 = Rational32::new(1, 1);
+        }
+
+        let mut indices = indices.to_vec();
+        indices.sort();
+        indices.dedup();
+
+        let mut sats = vec![false; self.size() as usize];
+        for index in indices {
+            sats[index as usize] = true
+        }
+
+        let clauses = values_to_rationals(&self.thold())?;
+
+        let mut wio: usize = 0;
+        for clause in clauses {
+            let mut cw = Rational32::new(0, 1);
+            for weight in clause {
+                if sats[wio] {
+                    cw += weight;
+                }
+                wio += 1;
+            }
+            if cw < *RATIONAL_ONE {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    fn process_thold(&mut self, thold: &Value) -> Result<()> {
+        let result = thold.to_i64();
+        if result.is_ok() {
+            self.process_unweighted(result.unwrap())?;
+            return Ok(());
+        }
+
+        self.process_weighted(thold)?;
+
+        Ok(())
+    }
+
+    fn process_limen(&mut self, limen: &[u8]) -> Result<()> {
+        if limen.is_empty() {
+            return Ok(());
+        }
+
+        let limen = String::from_utf8(limen.to_vec())?;
+
+        let hs = matter::hardage(limen.chars().next().unwrap())? as usize;
+        let code = &limen[..hs];
+
+        if number::Codex::has_code(code) {
+            let number = Number::new(None, None, None, None, None, Some(&limen), None)?;
+            let thold = i64::try_from(number.num()?)?;
+            self.process_unweighted(thold)?;
+        } else if bexter::Codex::has_code(code) {
+            let bexter = Bexter::new(None, None, None, None, Some(&limen), None)?;
+            let t = bexter.bext()?.replace('s', "/");
+            let clauses: Vec<&str> = t.split('a').into_iter().collect();
+            let mut oclauses: Array = Vec::new();
+            for clause in clauses {
+                let weights: Vec<&str> = clause.split('c').into_iter().collect();
+                let mut oweights: Array = Vec::new();
+                for weight in weights {
+                    oweights.push(data!(weight));
+                }
+                oclauses.push(data!(oweights.as_slice()));
+            }
+            let thold = data!(oclauses.as_slice());
+            self.process_weighted(&thold)?;
+        } else {
+            return err!(Error::UnexpectedCode(code.to_string()));
+        }
+
+        Ok(())
+    }
+
+    fn process_sith(&mut self, sith: &Value) -> Result<()> {
+        let result = sith.to_i64();
+        if result.is_ok() {
+            self.process_unweighted(result?)?;
+            return Ok(());
+        }
+
+        let mut sith = sith.clone();
+        let result = sith.to_string();
+        if result.is_ok() {
+            let s = result?;
+
+            if s.starts_with('[') {
+                let v: serde_json::Value = serde_json::from_str(&s)?;
+                sith = Value::from(&v);
+            } else {
+                let thold = i64::from_str_radix(&s, 16)?;
+                self.process_unweighted(thold)?;
+                return Ok(());
+            }
+        }
+
+        let array = sith.to_vec()?;
+
+        if array.is_empty() {
+            return err!(Error::Value(format!("empty weight list = {s}", s = sith.to_json()?)));
+        }
+
+        if !array.iter().all(|clause| clause.to_vec().is_ok()) {
+            sith = data!([sith]);
+        }
+
+        for clause in sith.to_vec()? {
+            let _clause = clause.to_vec()?;
+            for weight in _clause {
+                if weight.to_string().is_err() {
+                    return err!(Error::Value(format!(
+                        "invalid sith = {s}, some weights in clause {c} are not strings",
+                        s = sith.to_json()?,
+                        c = clause.to_json()?
+                    )));
+                }
+            }
+        }
+
+        // KERIpy converts to rationals here but it's more convenient for us to persist as a Value
+        // in the struct, and convert in process_weighted()
+        self.process_weighted(&sith)?;
+
+        Ok(())
+    }
+
+    fn process_unweighted(&mut self, thold: i64) -> Result<()> {
+        if thold < 0 {
+            return err!(Error::Value(format!("negative int threshold {thold}")));
+        }
+
+        self.size = u32::try_from(thold)?;
+        self.weighted = false;
+        self.thold = data!(self.size);
+        self.number = Some(Number::new(Some(thold as u128), None, None, None, None, None, None)?);
+        self.bexter = None;
+
+        Ok(())
+    }
+
+    fn process_weighted(&mut self, thold: &Value) -> Result<()> {
+        let threshold = &values_to_rationals(thold)?;
+        let mut size = 0;
+        for clause in threshold {
+            size += clause.len() as u32;
+        }
+        let mut outer: Vec<Value> = Vec::new();
+        for clause in threshold {
+            let mut inner: Vec<Value> = Vec::new();
+            for weight in clause {
+                if *weight.denom() == 1 {
+                    inner.push(data!(&format!("{n}", n = weight.numer())));
+                } else {
+                    inner.push(data!(&weight.to_string()));
+                }
+            }
+            outer.push(data!(inner.as_slice()));
+        }
+
+        self.thold = data!(outer.as_slice());
+        self.weighted = true;
+        self.size = size;
+        self.number = None;
+        let bext = rationals_to_bext(threshold);
+        self.bexter = Some(Bexter::new(Some(&bext), None, None, None, None, None)?);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core::tholder::Tholder;
+    use rstest::rstest;
+
+    #[test]
+    fn convenience() {
+        assert!(Tholder::new_with_thold(&data!(11)).is_ok());
+        assert!(Tholder::new_with_limen(b"MAAL").is_ok());
+        assert!(Tholder::new_with_sith(&data!("b")).is_ok());
+    }
+
+    #[rstest]
+    fn creation(
+        #[values(b"MAAL")] limen: &[u8],
+        #[values(
+            Tholder::new(None, None, Some(&data!("b"))).unwrap(),
+            Tholder::new(None, None, Some(&data!(11))).unwrap(),
+            Tholder::new(None, Some(limen), None).unwrap(),
+            Tholder::new(Some(&data!(11)), None, None).unwrap(),
+        )]
+        tholder: Tholder,
+    ) {
+        assert!(!tholder.weighted());
+        assert_eq!(tholder.size(), 11);
+        assert_eq!(tholder.thold().to_i64().unwrap(), 11);
+        assert_eq!(tholder.limen().unwrap(), limen);
+        assert_eq!(tholder.sith().unwrap(), data!("b"));
+        assert_eq!(tholder.to_json().unwrap(), "\"b\"");
+        assert_eq!(tholder.num().unwrap().unwrap(), 11);
+        assert!(!tholder.satisfy(&[0, 1, 2]).unwrap());
+        assert!(tholder.satisfy(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).unwrap());
+    }
+
+    #[test]
+    fn python_interop() {
+        assert!(Tholder::new(None, None, None).is_err());
+
+        assert!(Tholder::new(None, None, Some(&data!("[[\"1/2\",\"4/4\"]]"))).is_ok());
+        assert!(Tholder::new(None, None, Some(&data!("[[\"1/2\",\"-3/4\"]]"))).is_err());
+        assert!(!Tholder::default().satisfy(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap());
+        assert!(Tholder::new(None, None, Some(&data!("[[\"1/2\",\"3/4\"]]"))).is_ok());
+        assert!(Tholder::new(None, Some(&[]), Some(&data!("[[\"1/2\",\"3/4\"]]"))).is_ok());
+        assert!(Tholder::new(None, Some(b"DKxy2sgzfplyr-tgwIxS19f2OchFHtLwPWD3v4oYimBx"), None)
+            .is_err());
+
+        let tholder = Tholder::new(None, None, Some(&data!("f"))).unwrap();
+        assert!(!tholder.weighted());
+        assert_eq!(tholder.size(), 15);
+        assert_eq!(tholder.thold().to_i64().unwrap(), 15);
+        assert_eq!(tholder.limen().unwrap(), b"MAAP");
+        assert_eq!(tholder.sith().unwrap(), data!("f"));
+        assert_eq!(tholder.to_json().unwrap(), "\"f\"");
+        assert_eq!(tholder.num().unwrap().unwrap(), 15);
+        assert!(!tholder.satisfy(&[0, 1, 2]).unwrap());
+        assert!(tholder.satisfy(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]).unwrap());
+
+        let tholder = Tholder::new(None, None, Some(&data!(2))).unwrap();
+        assert!(!tholder.weighted());
+        assert_eq!(tholder.size(), 2);
+        assert_eq!(tholder.thold().to_i64().unwrap(), 2);
+        assert_eq!(tholder.limen().unwrap(), b"MAAC");
+        assert_eq!(tholder.sith().unwrap(), data!("2"));
+        assert_eq!(tholder.to_json().unwrap(), "\"2\"");
+        assert_eq!(tholder.num().unwrap().unwrap(), 2);
+        assert!(tholder.satisfy(&[0, 1, 2]).unwrap());
+        assert!(tholder.satisfy(&[0, 1]).unwrap());
+
+        let tholder = Tholder::new(None, None, Some(&data!(1))).unwrap();
+        assert!(!tholder.weighted());
+        assert_eq!(tholder.size(), 1);
+        assert_eq!(tholder.thold().to_i64().unwrap(), 1);
+        assert_eq!(tholder.limen().unwrap(), b"MAAB");
+        assert_eq!(tholder.sith().unwrap(), data!("1"));
+        assert_eq!(tholder.to_json().unwrap(), "\"1\"");
+        assert_eq!(tholder.num().unwrap().unwrap(), 1);
+        assert!(tholder.satisfy(&[0]).unwrap());
+
+        assert!(Tholder::new(None, None, Some(&data!(-1))).is_err());
+
+        assert!(Tholder::new(None, None, Some(&data!([1]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([2]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(["2"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([0.5, 0.5]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(["0.5", "0.5"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(1.0))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!("1.0"))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(0.5))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!("0.5"))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!("1.0/2.0"))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(["1/3", "1/2", []]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(["1/3", "1/2"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([[], []]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([["1/3", "1/2",], ["1"]]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([["1/3", "1/2"], []]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2"], [[], "1"]]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2", "3/2"]]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(["1/2", "1/2", "3/2"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(["1/2", "1/2", "2/1"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(["1/2", "1/2", "2"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2", "2"]]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2"], "1"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2"], 1]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2"], "1.0"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(["1/2", "1/2", []]))).is_err());
+        assert!(Tholder::new(None, None, Some(&data!(["1/2", 0.5]))).is_err());
+
+        let tholder =
+            Tholder::new(None, None, Some(&data!(["1/2", "1/2", "1/4", "1/4", "1/4"]))).unwrap();
+        assert!(tholder.weighted());
+        assert_eq!(tholder.size(), 5);
+        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"]]));
+        assert_eq!(tholder.limen().unwrap(), b"4AAFA1s2c1s2c1s4c1s4c1s4");
+        assert_eq!(tholder.sith().unwrap(), data!(["1/2", "1/2", "1/4", "1/4", "1/4"]));
+        assert_eq!(tholder.to_json().unwrap(), "[\"1/2\",\"1/2\",\"1/4\",\"1/4\",\"1/4\"]"); // this isn't identical to KERIpy but still conforms to JSON
+        assert_eq!(tholder.num().unwrap(), None);
+        assert!(tholder.satisfy(&[0, 2, 4]).unwrap());
+        assert!(tholder.satisfy(&[0, 1]).unwrap());
+        assert!(tholder.satisfy(&[1, 3, 4]).unwrap());
+        assert!(tholder.satisfy(&[0, 1, 2, 3, 4]).unwrap());
+        assert!(tholder.satisfy(&[3, 2, 0]).unwrap());
+        assert!(tholder.satisfy(&[0, 0, 1, 2, 1]).unwrap());
+        assert!(!tholder.satisfy(&[0, 2]).unwrap());
+        assert!(!tholder.satisfy(&[2, 3, 4]).unwrap());
+        assert!(!tholder.satisfy(&[0, 0, 2]).unwrap());
+
+        let tholder =
+            Tholder::new(None, None, Some(&data!(["1/2", "1/2", "1/4", "1/4", "1/4", "0"])))
+                .unwrap();
+        assert!(tholder.weighted());
+        assert_eq!(tholder.size(), 6);
+        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4", "0"]]));
+        assert_eq!(tholder.limen().unwrap(), b"6AAGAAA1s2c1s2c1s4c1s4c1s4c0");
+        assert_eq!(tholder.sith().unwrap(), data!(["1/2", "1/2", "1/4", "1/4", "1/4", "0"]));
+        assert_eq!(tholder.to_json().unwrap(), "[\"1/2\",\"1/2\",\"1/4\",\"1/4\",\"1/4\",\"0\"]");
+        assert_eq!(tholder.num().unwrap(), None);
+        assert!(tholder.satisfy(&[0, 2, 4]).unwrap());
+        assert!(tholder.satisfy(&[0, 1]).unwrap());
+        assert!(tholder.satisfy(&[1, 3, 4]).unwrap());
+        assert!(tholder.satisfy(&[0, 1, 2, 3, 4]).unwrap());
+        assert!(tholder.satisfy(&[3, 2, 0]).unwrap());
+        assert!(tholder.satisfy(&[0, 0, 1, 2, 1]).unwrap());
+        assert!(!tholder.satisfy(&[0, 2, 5]).unwrap());
+        assert!(!tholder.satisfy(&[2, 3, 4, 5]).unwrap());
+
+        let tholder =
+            Tholder::new(None, None, Some(&data!([["1/2", "1/2", "1/4", "1/4", "1/4"]]))).unwrap();
+        assert!(tholder.weighted());
+        assert_eq!(tholder.size(), 5);
+        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"]]));
+        assert_eq!(tholder.limen().unwrap(), b"4AAFA1s2c1s2c1s4c1s4c1s4");
+        assert_eq!(tholder.sith().unwrap(), data!(["1/2", "1/2", "1/4", "1/4", "1/4"]));
+        assert_eq!(tholder.to_json().unwrap(), "[\"1/2\",\"1/2\",\"1/4\",\"1/4\",\"1/4\"]"); // this isn't identical to KERIpy but still conforms to JSON
+        assert_eq!(tholder.num().unwrap(), None);
+        assert!(tholder.satisfy(&[0, 2, 4]).unwrap());
+        assert!(tholder.satisfy(&[0, 1]).unwrap());
+        assert!(tholder.satisfy(&[1, 3, 4]).unwrap());
+        assert!(tholder.satisfy(&[0, 1, 2, 3, 4]).unwrap());
+        assert!(tholder.satisfy(&[3, 2, 0]).unwrap());
+        assert!(tholder.satisfy(&[0, 0, 1, 2, 1]).unwrap());
+        assert!(!tholder.satisfy(&[0, 2]).unwrap());
+        assert!(!tholder.satisfy(&[2, 3, 4]).unwrap());
+        assert!(!tholder.satisfy(&[0, 0, 2]).unwrap());
+
+        let tholder = Tholder::new(
+            None,
+            None,
+            Some(&data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1/1", "1"]])),
+        )
+        .unwrap();
+        assert!(tholder.weighted());
+        assert_eq!(tholder.size(), 7);
+        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]]));
+        assert_eq!(tholder.limen().unwrap(), b"4AAGA1s2c1s2c1s4c1s4c1s4a1c1");
+        assert_eq!(
+            tholder.sith().unwrap(),
+            data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]])
+        );
+        assert_eq!(
+            tholder.to_json().unwrap(),
+            "[[\"1/2\",\"1/2\",\"1/4\",\"1/4\",\"1/4\"],[\"1\",\"1\"]]"
+        );
+        assert_eq!(tholder.num().unwrap(), None);
+        assert!(tholder.satisfy(&[1, 2, 3, 5]).unwrap());
+        assert!(tholder.satisfy(&[0, 1, 6]).unwrap());
+        assert!(!tholder.satisfy(&[0, 1]).unwrap());
+        assert!(!tholder.satisfy(&[5, 6]).unwrap());
+        assert!(!tholder.satisfy(&[2, 3, 4]).unwrap());
+        assert!(!tholder.satisfy(&[]).unwrap());
+
+        let tholder = Tholder::new(None, Some(b"4AAGA1s2c1s2c1s4c1s4c1s4a1c1"), None).unwrap();
+        assert!(tholder.weighted());
+        assert_eq!(tholder.size(), 7);
+        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]]));
+        assert_eq!(tholder.limen().unwrap(), b"4AAGA1s2c1s2c1s4c1s4c1s4a1c1");
+        assert_eq!(
+            tholder.sith().unwrap(),
+            data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]])
+        );
+        assert_eq!(
+            tholder.to_json().unwrap(),
+            "[[\"1/2\",\"1/2\",\"1/4\",\"1/4\",\"1/4\"],[\"1\",\"1\"]]"
+        );
+        assert_eq!(tholder.num().unwrap(), None);
+        assert!(tholder.satisfy(&[1, 2, 3, 5]).unwrap());
+        assert!(tholder.satisfy(&[0, 1, 6]).unwrap());
+        assert!(!tholder.satisfy(&[0, 1]).unwrap());
+        assert!(!tholder.satisfy(&[5, 6]).unwrap());
+        assert!(!tholder.satisfy(&[2, 3, 4]).unwrap());
+        assert!(!tholder.satisfy(&[]).unwrap());
+
+        let tholder = Tholder::new(
+            Some(&data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1/1", "1/1"]])),
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(tholder.weighted());
+        assert_eq!(tholder.size(), 7);
+        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]]));
+        assert_eq!(tholder.limen().unwrap(), b"4AAGA1s2c1s2c1s4c1s4c1s4a1c1");
+        assert_eq!(
+            tholder.sith().unwrap(),
+            data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]])
+        );
+        assert_eq!(
+            tholder.to_json().unwrap(),
+            "[[\"1/2\",\"1/2\",\"1/4\",\"1/4\",\"1/4\"],[\"1\",\"1\"]]"
+        );
+        assert_eq!(tholder.num().unwrap(), None);
+        assert!(tholder.satisfy(&[1, 2, 3, 5]).unwrap());
+        assert!(tholder.satisfy(&[0, 1, 6]).unwrap());
+        assert!(!tholder.satisfy(&[0, 1]).unwrap());
+        assert!(!tholder.satisfy(&[5, 6]).unwrap());
+        assert!(!tholder.satisfy(&[2, 3, 4]).unwrap());
+        assert!(!tholder.satisfy(&[]).unwrap());
+    }
+}

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -1,5 +1,7 @@
 use crate::error::{err, Error, Result};
 
+pub const REB64_STRING: &str = "^[A-Za-z0-9\\-_]*$";
+
 pub fn b64_char_to_index(c: char) -> Result<u8> {
     Ok(match c {
         'A' => 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 
 pub use crate::{
     core::{
+        bexter::Bexter,
         cigar::Cigar,
         counter::{tables as counter, Counter}, // This seems like it shoudl be an abstract class
         dater::Dater,
@@ -20,8 +21,10 @@ pub use crate::{
         sadder::Sadder,
         saider::Saider,
         seqner::Seqner,
+        serder::Serder,
         siger::Siger,
         signer::Signer,
+        tholder::Tholder,
         verfer::Verfer,
     },
     data::Value,


### PR DESCRIPTION
## Rationale

This adds the final pieces needed to create an inception `Serder`.

## Changes

- adds `Bexter`
- adds `Tholder`
- adds `Serder`

## Testing

Added explicit tests for `try_from()` in `data.rs` when coverage broke. Ported KERIpy tests and then improved coverage.

```
make fix clean preflight
```