### PR TITLE
salter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["cesr", "keri", "acdc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+argon2 = "~0.5"
 base64 = "~0.21"
 blake2 = "~0.10"
 blake3 = "~1"

--- a/src/core/bexter.rs
+++ b/src/core/bexter.rs
@@ -46,16 +46,7 @@ pub mod tables {
 }
 
 fn validate_code(code: &str) -> Result<()> {
-    const CODES: &[&str] = &[
-        matter::Codex::StrB64_L0,
-        matter::Codex::StrB64_L1,
-        matter::Codex::StrB64_L2,
-        matter::Codex::StrB64_Big_L0,
-        matter::Codex::StrB64_Big_L1,
-        matter::Codex::StrB64_Big_L2,
-    ];
-
-    if !CODES.contains(&code) {
+    if !tables::Codex::has_code(code) {
         return err!(Error::UnexpectedCode(code.to_string()));
     }
 

--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -71,6 +71,15 @@ pub(crate) mod Ilkage {
 
 #[allow(non_snake_case)]
 #[allow(non_upper_case_globals)]
+pub mod Tierage {
+    pub(crate) const min: &str = "min";
+    pub const low: &str = "low";
+    pub const med: &str = "med";
+    pub const high: &str = "high";
+}
+
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
 pub(crate) mod Ids {
     pub const dollar: &str = "$id";
     pub const at: &str = "@id";

--- a/src/core/counter/mod.rs
+++ b/src/core/counter/mod.rs
@@ -108,7 +108,7 @@ impl Counter {
         Counter::sem_ver_parts_to_b64(parts)
     }
 
-    fn new_with_code_and_count(code: &str, count: u32) -> Result<Self> {
+    pub fn new_with_code_and_count(code: &str, count: u32) -> Result<Self> {
         if code.is_empty() {
             return err!(Error::EmptyMaterial("empty code".to_string()));
         }
@@ -133,13 +133,13 @@ impl Counter {
         Ok(Counter { code: code.to_string(), count })
     }
 
-    fn new_with_qb64(qb64: &str) -> Result<Self> {
+    pub fn new_with_qb64(qb64: &str) -> Result<Self> {
         let mut counter: Counter = Default::default();
         counter.exfil(qb64)?;
         Ok(counter)
     }
 
-    fn new_with_qb64b(qb64b: &[u8]) -> Result<Self> {
+    pub fn new_with_qb64b(qb64b: &[u8]) -> Result<Self> {
         let qb64 = String::from_utf8(qb64b.to_vec())?;
 
         let mut counter: Counter = Default::default();
@@ -147,11 +147,12 @@ impl Counter {
         Ok(counter)
     }
 
-    fn new_with_qb2(qb2: &[u8]) -> Result<Self> {
+    pub fn new_with_qb2(qb2: &[u8]) -> Result<Self> {
         let mut counter: Counter = Default::default();
         counter.bexfil(qb2)?;
         Ok(counter)
     }
+
     fn sem_ver_parts_to_b64(parts: &[u8]) -> Result<String> {
         for p in parts.iter().copied() {
             if p > 63 {

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -87,6 +87,16 @@ pub(crate) fn bardage(b: u8) -> Result<u32> {
     }
 }
 
+pub(crate) fn raw_size(code: &str) -> Result<u32> {
+    let szg = sizage(code)?;
+    if szg.fs == 0 {
+        return err!(Error::UnexpectedCode(format!("cannot determine raw size for code={code}")));
+    }
+
+    let cs = szg.hs + szg.ss;
+    Ok((szg.fs - cs) * 3 / 4 - szg.ls)
+}
+
 #[allow(non_snake_case)]
 #[allow(non_upper_case_globals)]
 pub mod Codex {
@@ -323,10 +333,16 @@ mod test {
     }
 
     #[test]
+    fn raw_size() {
+        assert_eq!(matter::raw_size(matter::Codex::Ed25519).unwrap(), 32);
+    }
+
+    #[test]
     fn unhappy_paths() {
         assert!(matter::hardage('-').is_err());
         assert!(matter::hardage('_').is_err());
         assert!(matter::hardage('#').is_err());
         assert!(matter::bardage(0x40).is_err());
+        assert!(matter::raw_size(matter::Codex::Bytes_L0).is_err());
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ pub mod number;
 pub mod prefixer;
 pub mod sadder;
 pub mod saider;
+pub mod salter;
 pub mod seqner;
 pub mod serder;
 pub mod siger;

--- a/src/core/salter.rs
+++ b/src/core/salter.rs
@@ -1,0 +1,465 @@
+use crate::{
+    core::{
+        common::Tierage,
+        matter::{tables as matter, Matter},
+        signer::Signer,
+    },
+    crypto::{csprng, salt},
+    error::{err, Error, Result},
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Salter {
+    code: String,
+    raw: Vec<u8>,
+    size: u32,
+    tier: String,
+}
+
+fn validate_code(code: &str) -> Result<()> {
+    if code != matter::Codex::Salt_128 {
+        return err!(Error::UnexpectedCode(code.to_string()));
+    }
+
+    Ok(())
+}
+
+const SALTER_SEED_BYTES: usize = 16;
+
+impl Salter {
+    pub fn new(
+        tier: Option<&str>,
+        code: Option<&str>,
+        raw: Option<&[u8]>,
+        qb64b: Option<&[u8]>,
+        qb64: Option<&str>,
+        qb2: Option<&[u8]>,
+    ) -> Result<Self> {
+        let code = code.unwrap_or(matter::Codex::Salt_128);
+        validate_code(code)?;
+
+        let mut salter: Self =
+            if raw.is_none() && qb64b.is_none() && qb64.is_none() && qb2.is_none() {
+                let mut raw: [u8; SALTER_SEED_BYTES] = [0; SALTER_SEED_BYTES];
+                csprng::fill_bytes(&mut raw);
+                Matter::new(Some(code), Some(&raw), None, None, None)?
+            } else {
+                Matter::new(Some(code), raw, qb64b, qb64, qb2)?
+            };
+
+        salter.tier = tier.unwrap_or(Tierage::low).to_string();
+        Ok(salter)
+    }
+
+    pub fn new_with_defaults(tier: Option<&str>) -> Result<Self> {
+        Self::new(tier, None, None, None, None, None)
+    }
+
+    pub fn new_with_raw(raw: &[u8], code: Option<&str>, tier: Option<&str>) -> Result<Self> {
+        Self::new(tier, code, Some(raw), None, None, None)
+    }
+
+    pub fn new_with_qb64b(qb64b: &[u8], tier: Option<&str>) -> Result<Self> {
+        Self::new(tier, None, None, Some(qb64b), None, None)
+    }
+
+    pub fn new_with_qb64(qb64: &str, tier: Option<&str>) -> Result<Self> {
+        Self::new(tier, None, None, None, Some(qb64), None)
+    }
+
+    pub fn new_with_qb2(qb2: &[u8], tier: Option<&str>) -> Result<Self> {
+        Self::new(tier, None, None, None, None, Some(qb2))
+    }
+
+    pub fn stretch(
+        &self,
+        size: Option<usize>,
+        path: Option<&str>,
+        tier: Option<&str>,
+        temp: Option<bool>,
+    ) -> Result<Vec<u8>> {
+        let temp = temp.unwrap_or(false);
+        let st = self.tier();
+        let tier = if temp { Tierage::min } else { tier.unwrap_or(st.as_str()) };
+        let path = path.unwrap_or("");
+        let size = size.unwrap_or(32);
+
+        let seed = salt::stretch(path.as_bytes(), &self.raw(), size, tier)?;
+
+        Ok(seed)
+    }
+
+    pub fn tier(&self) -> String {
+        self.tier.clone()
+    }
+
+    pub fn signer(
+        &self,
+        code: Option<&str>,
+        transferable: Option<bool>,
+        path: Option<&str>,
+        tier: Option<&str>,
+        temp: Option<bool>,
+    ) -> Result<Signer> {
+        let code = code.unwrap_or(matter::Codex::Ed25519_Seed);
+        let transferable = transferable.unwrap_or(true);
+        let path = path.unwrap_or("");
+        let temp = temp.unwrap_or(false);
+
+        let size = matter::raw_size(code)?;
+        let seed = self.stretch(Some(size as usize), Some(path), tier, Some(temp))?;
+
+        Signer::new(Some(transferable), Some(code), Some(&seed), None, None, None)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn signers(
+        &self,
+        count: Option<usize>,
+        start: Option<usize>,
+        path: Option<&str>,
+        code: Option<&str>,
+        transferable: Option<bool>,
+        tier: Option<&str>,
+        temp: Option<bool>,
+    ) -> Result<Vec<Signer>> {
+        let count = count.unwrap_or(1);
+        let start = start.unwrap_or(0);
+        let path = path.unwrap_or("");
+        let mut signers: Vec<Signer> = vec![];
+
+        for i in 0..count {
+            let path = format!("{path}{n:x}", n = (i + start));
+            signers.push(self.signer(code, transferable, Some(&path), tier, temp)?);
+        }
+
+        Ok(signers)
+    }
+}
+
+impl Default for Salter {
+    fn default() -> Self {
+        Salter {
+            code: matter::Codex::Salt_128.to_string(),
+            raw: vec![],
+            size: 0,
+            tier: Tierage::low.to_string(),
+        }
+    }
+}
+
+impl Matter for Salter {
+    fn code(&self) -> String {
+        self.code.clone()
+    }
+
+    fn raw(&self) -> Vec<u8> {
+        self.raw.clone()
+    }
+
+    fn size(&self) -> u32 {
+        self.size
+    }
+
+    fn set_code(&mut self, code: &str) {
+        self.code = code.to_string();
+    }
+
+    fn set_raw(&mut self, raw: &[u8]) {
+        self.raw = raw.to_vec();
+    }
+
+    fn set_size(&mut self, size: u32) {
+        self.size = size;
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core::{
+        common::{versify, Ilkage, Serialage, Tierage, CURRENT_VERSION},
+        matter::{tables as matter, Matter},
+        salter::Salter,
+        signer::Signer,
+    };
+
+    #[test]
+    fn convenience() {
+        let salter = Salter::new_with_defaults(None).unwrap();
+
+        assert!(Salter::new_with_defaults(None).is_ok());
+        assert!(Salter::new_with_raw(&salter.raw(), Some(&salter.code()), None).is_ok());
+        assert!(Salter::new_with_qb64b(&salter.qb64b().unwrap(), None).is_ok());
+        assert!(Salter::new_with_qb64(&salter.qb64().unwrap(), None).is_ok());
+        assert!(Salter::new_with_qb2(&salter.qb2().unwrap(), None).is_ok());
+    }
+
+    #[test]
+    fn python_interop() {
+        let salter = Salter::new(None, None, None, None, None, None).unwrap();
+        assert_eq!(salter.code(), matter::Codex::Salt_128);
+        assert_eq!(salter.raw().len(), 16);
+
+        let raw = b"0123456789abcdef";
+        let qb64 = "0AAwMTIzNDU2Nzg5YWJjZGVm";
+        let salter = Salter::new(None, None, Some(raw), None, None, None).unwrap();
+        assert_eq!(salter.raw(), raw);
+        assert_eq!(salter.qb64().unwrap(), qb64);
+
+        let signer = salter.signer(None, None, Some("01"), None, Some(true)).unwrap();
+        assert_eq!(signer.code(), matter::Codex::Ed25519_Seed);
+        assert_eq!(signer.raw().len() as u32, matter::raw_size(&signer.code()).unwrap());
+        assert_eq!(signer.verfer().code(), matter::Codex::Ed25519);
+        assert_eq!(
+            signer.verfer().raw().len() as u32,
+            matter::raw_size(&signer.verfer().code()).unwrap()
+        );
+        assert_eq!(signer.qb64().unwrap(), "AMPsqBZxWdtYpBhrWnKYitwFa77s902Q-nX3sPTzqs0R");
+        assert_eq!(signer.verfer().qb64().unwrap(), "DFYFwZJOMNy3FknECL8tUaQZRBUyQ9xCv6F8ckG-UCrC");
+
+        let signer = salter.signer(None, None, Some("01"), None, None).unwrap();
+        assert_eq!(signer.code(), matter::Codex::Ed25519_Seed);
+        assert_eq!(signer.raw().len() as u32, matter::raw_size(&signer.code()).unwrap());
+        assert_eq!(signer.verfer().code(), matter::Codex::Ed25519);
+        assert_eq!(
+            signer.verfer().raw().len() as u32,
+            matter::raw_size(&signer.verfer().code()).unwrap()
+        );
+        assert_eq!(signer.qb64().unwrap(), "AEkqQiNTexWB9fTLpgJp_lXW63tFlT-Y0_mgQww4o-dC");
+        assert_eq!(signer.verfer().qb64().unwrap(), "DPJGyH9H1M_SUSf18RzX8OqdyhxEyZJpKm5Em0PnpsWd");
+
+        let salter = Salter::new(None, None, None, None, Some(qb64), None).unwrap();
+        assert_eq!(salter.raw(), raw);
+        assert_eq!(salter.qb64().unwrap(), qb64);
+
+        assert!(Salter::new(None, None, None, None, Some(""), None).is_err());
+    }
+
+    #[test]
+    fn vault() {
+        let _vault = Vault::default().unwrap();
+    }
+
+    use crate::{
+        core::{
+            cigar::Cigar,
+            common::Version,
+            counter::{tables as counter, Counter},
+            diger::Diger,
+            indexer::Indexer,
+            number::Number,
+            sadder::Sadder,
+            seqner::Seqner,
+            serder::{test::incept, Serder},
+            siger::Siger,
+        },
+        error::{err, Error, Result},
+    };
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Vault {
+        current: Vec<Signer>,
+        next: Vec<Signer>,
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Seal {
+        i: String,
+        s: String,
+        d: String,
+        last: bool,
+    }
+
+    impl Seal {
+        pub fn new(i: &str, s: &str, d: &str, last: Option<bool>) -> Self {
+            let last = last.unwrap_or(false);
+
+            Self { i: i.to_string(), s: s.to_string(), d: d.to_string(), last }
+        }
+
+        pub fn i(&self) -> String {
+            self.i.clone()
+        }
+
+        pub fn s(&self) -> Result<String> {
+            Ok(Seqner::new_with_snh(&self.s)?.qb64()?)
+        }
+
+        pub fn d(&self) -> String {
+            self.d.clone()
+        }
+    }
+
+    impl Vault {
+        fn default<'a>() -> Result<Self> {
+            // Tierage::min is not exposed externally, this is for testing. One needs to use 'temp'
+            // during stretching to accomplish this in a production scenario
+            let csalter = Salter::new_with_defaults(Some(Tierage::min))?;
+            let nsalter = Salter::new_with_defaults(Some(Tierage::min))?;
+            let wsalter = Salter::new_with_defaults(Some(Tierage::min))?;
+
+            let current = csalter.signers(Some(3), None, Some("icp"), None, None, None, None)?;
+            let next = nsalter.signers(Some(5), None, Some("rot-0"), None, None, None, None)?;
+            let witness =
+                wsalter.signers(Some(4), None, Some("wit-0"), None, Some(false), None, None)?;
+
+            let ckeys: Vec<String> =
+                current.iter().map(|signer| signer.verfer().qb64().unwrap()).collect();
+            let ndigs: Vec<String> = next
+                .iter()
+                .map(|signer| {
+                    Diger::new_with_ser(&signer.verfer().qb64b().unwrap(), None)
+                        .unwrap()
+                        .qb64()
+                        .unwrap()
+                })
+                .collect();
+            let wkeys: Vec<String> =
+                witness.iter().map(|signer| signer.verfer().qb64().unwrap()).collect();
+
+            let ckeys: Vec<&str> = ckeys.iter().map(|key| key.as_ref()).collect();
+            let ndigs: Vec<&str> = ndigs.iter().map(|dig| dig.as_ref()).collect();
+            let wkeys: Vec<&str> = wkeys.iter().map(|key| key.as_ref()).collect();
+
+            let serder = incept(
+                &ckeys,
+                Some(&data!(2)),
+                Some(&ndigs),
+                Some(&data!(3)),
+                Some(4),
+                Some(&wkeys),
+                None,
+                None,
+                None,
+                None,
+                Some(matter::Codex::Blake3_256),
+                None,
+                None,
+            )?;
+
+            let mut sigers: Vec<Siger> = vec![];
+            for i in 0..current.len() - 1 {
+                let siger: Siger = current[i].sign_indexed(&serder.raw(), false, i as u32, None)?;
+                sigers.push(siger);
+            }
+
+            let inception_message = messagize(&serder, Some(&sigers), None, None, None)?;
+
+            let ked = serder.ked();
+
+            let receipt_serder = receipt(&ked["i"].to_string()?, 0, &serder.said()?, None, None)?;
+            let mut wigers: Vec<Siger> = vec![];
+            for i in 0..witness.len() {
+                let siger: Siger = witness[i].sign_indexed(&serder.raw(), false, i as u32, None)?;
+                wigers.push(siger);
+            }
+
+            let receipt_message = messagize(&receipt_serder, None, None, Some(&wigers), None)?;
+
+            println!("{im}{rm}", im = inception_message, rm = receipt_message);
+
+            Ok(Vault { current, next })
+        }
+
+        pub fn current(&self) -> Vec<Signer> {
+            self.current.clone()
+        }
+
+        pub fn next(&self) -> Vec<Signer> {
+            self.next.clone()
+        }
+    }
+
+    fn messagize(
+        serder: &Serder,
+        sigers: Option<&[Siger]>,
+        seal: Option<&Seal>,
+        wigers: Option<&[Siger]>,
+        cigars: Option<&[Cigar]>,
+    ) -> Result<String> {
+        let message = String::from_utf8(serder.raw())?;
+        let mut atc = "".to_string();
+
+        if sigers.is_none() && wigers.is_none() && cigars.is_none() {
+            return err!(Error::Value("missing attached signatures".to_string()));
+        }
+
+        if let Some(sigers) = sigers {
+            if let Some(seal) = seal {
+                if seal.last {
+                    atc += &Counter::new_with_code_and_count(
+                        counter::Codex::TransLastIdxSigGroups,
+                        1,
+                    )?
+                    .qb64()?;
+                    atc += &seal.i();
+                } else {
+                    atc += &Counter::new_with_code_and_count(counter::Codex::TransIdxSigGroups, 1)?
+                        .qb64()?;
+                    atc += &seal.i();
+                    atc += &seal.s()?;
+                    atc += &seal.d();
+                }
+            }
+
+            atc += &Counter::new(
+                Some(sigers.len() as u32),
+                None,
+                Some(counter::Codex::ControllerIdxSigs),
+                None,
+                None,
+                None,
+            )?
+            .qb64()?;
+            for siger in sigers {
+                atc += &(*siger).qb64()?;
+            }
+        }
+
+        if let Some(wigers) = wigers {
+            atc += &Counter::new(
+                Some(wigers.len() as u32),
+                None,
+                Some(counter::Codex::WitnessIdxSigs),
+                None,
+                None,
+                None,
+            )?
+            .qb64()?;
+            for wiger in wigers {
+                // todo: deny non-transferable
+                atc += &(*wiger).qb64()?;
+            }
+        }
+
+        // todo: complete this
+
+        Ok(message + &atc)
+    }
+
+    fn receipt(
+        pre: &str,
+        sn: u128,
+        said: &str,
+        version: Option<&Version>,
+        kind: Option<&str>,
+    ) -> Result<Serder> {
+        let version = version.unwrap_or(CURRENT_VERSION);
+        let kind = kind.unwrap_or(Serialage::JSON);
+
+        let vs = versify(None, Some(version), Some(kind), Some(0))?;
+        let ilk = Ilkage::rct;
+
+        let sner = Number::new_with_num(sn)?;
+
+        let ked = data!({
+            "v": &vs,
+            "t": ilk,
+            "d": said,
+            "i": pre,
+            "s": &sner.numh()?
+        });
+
+        Serder::new_with_ked(&ked, None, None)
+    }
+}

--- a/src/core/serder.rs
+++ b/src/core/serder.rs
@@ -48,6 +48,10 @@ impl Serder {
         Ok(serder)
     }
 
+    pub fn new_with_ked(ked: &Value, code: Option<&str>, kind: Option<&str>) -> Result<Self> {
+        Self::new(code, None, kind, Some(ked), None)
+    }
+
     pub fn verfers(&self) -> Result<Vec<Verfer>> {
         let mut result: Vec<Verfer> = Vec::new();
         let map = self.ked.to_map()?;
@@ -266,7 +270,7 @@ impl Sadder for Serder {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use crate::{
         core::{
             common::{
@@ -542,7 +546,7 @@ mod test {
         assert!(Serder::new(None, None, None, Some(&ked), None).is_err());
     }
 
-    mod traiter {
+    pub(crate) mod traiter {
         #[allow(non_upper_case_globals)]
         #[allow(non_snake_case)]
         mod Codex {
@@ -556,7 +560,7 @@ mod test {
 
     // this function uses convenience methods unlike most test code. it is likely that it will
     // be extracted and used elsewhere - and convenience methods make sense outside the tests.
-    fn incept(
+    pub(crate) fn incept(
         keys: &[&str],          // current keys qb64
         sith: Option<&Value>,   // current signing threshold
         ndigs: Option<&[&str]>, // next keys qb64

--- a/src/crypto/csprng.rs
+++ b/src/crypto/csprng.rs
@@ -1,0 +1,5 @@
+use rand_core::{OsRng, RngCore};
+
+pub(crate) fn fill_bytes(bytes: &mut [u8]) {
+    OsRng.fill_bytes(bytes);
+}

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,2 +1,4 @@
+pub(crate) mod csprng;
 pub(crate) mod hash;
+pub(crate) mod salt;
 pub(crate) mod sign;

--- a/src/crypto/salt.rs
+++ b/src/crypto/salt.rs
@@ -1,0 +1,64 @@
+use crate::core::common::Tierage;
+use crate::error::{err, Error, Result};
+use argon2::{Algorithm, Argon2, Params, Version};
+
+fn params(tier: &str, length: usize) -> Result<Params> {
+    let params = match tier {
+        // had to check here https://github.com/jedisct1/libsodium/blob/master/src/libsodium/crypto_pwhash/argon2/pwhash_argon2id.c
+        // to make sure we are compatible with the KERIpy implementation
+        Tierage::min => Params::new(8, 1, 1, Some(length)),
+        Tierage::low => Params::new(65536, 2, 1, Some(length)),
+        Tierage::med => Params::new(262144, 3, 1, Some(length)),
+        Tierage::high => Params::new(1048576, 4, 1, Some(length)),
+        _ => return err!(Error::Value("unknown security tier selected".to_string())),
+    };
+
+    Ok(match params {
+        Ok(p) => p,
+        Err(e) => return err!(Error::Derivation(e.to_string())),
+    })
+}
+
+pub(crate) fn stretch(pwd: &[u8], salt: &[u8], length: usize, tier: &str) -> Result<Vec<u8>> {
+    let params = params(tier, length)?;
+    let algorithm = Algorithm::Argon2id;
+    let version = Version::V0x13;
+    let stretcher = Argon2::new(algorithm, version, params);
+
+    let mut result: Vec<u8> = vec![0; length];
+    match stretcher.hash_password_into(pwd, salt, &mut result) {
+        Ok(_) => (),
+        Err(e) => return err!(Error::Derivation(e.to_string())),
+    };
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::core::common::Tierage;
+    use crate::crypto::salt;
+
+    #[test]
+    fn params() {
+        assert!(salt::params(Tierage::min, 32).is_ok());
+        assert!(salt::params(Tierage::low, 32).is_ok());
+        assert!(salt::params(Tierage::med, 32).is_ok());
+        assert!(salt::params(Tierage::high, 32).is_ok());
+        assert!(salt::params("CESR", 32).is_err());
+        assert!(salt::params(Tierage::high, 0).is_err());
+    }
+
+    #[test]
+    fn stretch() {
+        assert!(salt::stretch(&[], &[], 0, Tierage::min).is_err());
+        assert!(salt::stretch(&[], &[], 32, Tierage::min).is_err());
+        assert!(salt::stretch(&[0; 16], &[0; 16], 32, Tierage::min).is_ok());
+
+        let expected: [u8; 32] = [
+            18, 204, 212, 191, 84, 194, 87, 100, 6, 30, 92, 215, 51, 38, 107, 153, 250, 56, 19, 67,
+            240, 139, 73, 162, 108, 231, 67, 120, 152, 225, 46, 245,
+        ];
+        assert_eq!(salt::stretch(&[0; 16], &[0; 16], 32, Tierage::min).unwrap(), expected);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use crate::{
         prefixer::Prefixer,
         sadder::Sadder,
         saider::Saider,
+        salter::Salter,
         seqner::Seqner,
         serder::Serder,
         siger::Siger,


### PR DESCRIPTION
## Rationale

With `Salter` we are able to easily create random (if we choose) keys from a secret salt and path.

## Changes

- adds `Salter` implementation

## Testing

`make fix clean preflight`