### PR TITLE
clarify crypto dependencies in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,183 @@ make clean preflight
 
 You are now ready to open a pull request!
 
+## Terminology
+
+`cesride` is built from cryptographic primitives that are named clearly and concisely. That said,
+those unfamiliar with the naming strategy but familiar with cryptography may find themselves a bit
+lost when first working with `cesride`. Implementation was ported from [KERIpy](https://github.com/WebOfTrust/keripy)
+and terminology was carried along with the code. The basics:
+
+- `Diger` - a primitive that represents a **digest**. It has the ability to verify that an input hashes to its raw value.
+- `Verfer` - a primitive that represents a **public key**. It has the ability to verify signatures on data.
+- `Signer` - a primitive that represents a **private key**. It has the ability to create `Sigers` and `Cigars` (signatures).
+- `Siger` - an **_indexed_ signature**, for use in weighted threshold verification.
+- `Cigar` - an **_unindexed_ signature**, for use in unweighted verification.
+- `Salter` - a primitive that represents a **seed**. It has the ability to generate new `Signers`.
+ 
+Each primitive will have methods attached to it that permit one to generate and parse the qualified
+base2 or base64 representation. Common methods you'll find:
+
+- `.qb64()` - qualified base-64 representation of cryptographic material as a string
+- `.qb64b()` - qualified base-64 representation of cryptographic material as octets (bytes)
+- `.qb2()` - qualified base-2 representation of cryptographic material as octets (bytes)
+- `.code()` - qualifying code (describes the type of cryptographic material)
+- `.raw()` - raw cryptographic material (unqualified) as octets (bytes)
+
+### Qualification
+
+Q: What do you mean, qualified cryptographic material?
+
+A: There are [tables of codes](https://github.com/WebOfTrust/cesride/blob/main/src/core/matter/tables.rs#L92)
+similar to a [TLV](https://en.wikipedia.org/wiki/Type%E2%80%93length%E2%80%93value) table but omitting
+the length field for almost all cases (as the primitives are fixed in size). The type or _code_, in
+CESR vernacular, conveys enough information to allow the application to parse data with qualified
+cryptographic material embedded in it.
+
+Here is what we mean:
+
+`DKxy2sgzfplyr-tgwIxS19f2OchFHtLwPWD3v4oYimBx` - this is prefixed with a `D`. If we look that code
+up in the table linked in the answer above, we find this is a transferable (rotatable) Ed25519
+public key.
+
+`ELEjyRTtmfyp4VpTBTkv_b6KONMS1V8-EW-aGJ5P_QMo` - this is prefixed with an `E`. Again, consulting the
+table, we learn this is a Blake3 256 digest.
+
+Each primitive can be represented in Base64 or binary, and can be processed from either format.
+
+### Examples
+
+```rust
+use cesride::{common::Tierage, Salter};
+// in this example we sign some data and ensure the signature verifies
+
+let authentic = b"abcdefg";
+let forgery = b"abcdefgh";
+let mut sigers: Vec<Siger> = vec![];
+
+// delay creating sensitive material until the last moment so it is resident in memory for shorter
+let salter = Salter::new_with_defaults(Some(Tierage::med))?;
+
+// generate a set of 3 signing keys. the fourth argument here is the code, and when we specify
+// none we'll be given an Ed25519 key. the path here (third argument) will be input during key
+// stretching so that the same seed can be used for a number of keys with differing paths
+let signers = salter.signers(Some(3), None, Some("my-key"), None, None, None, None)?;
+
+// sign some data
+for i in 0..signers.len() {
+    sigers.push(signers[i].sign_indexed(authentic, false, i as u32, None)?);
+}
+
+// verify the signatures
+for i in 0..signers.len() {
+    // check that verification works if the data and signature match
+    assert!(signers[i].verfer().verify(&sigers[i].raw(), authentic)?);
+    // verification fails if the data (or signature) does not match
+    assert!(!signers[i].verfer().verify(&sigers[i].raw(), forgery)?);
+}
+```
+
+```rust
+use cesride::{Signer, Indexer, Matter};
+// here we verify that a cigar primitive and a siger primitive have the same underlying
+// cryptographic material
+
+let data = b"abcdefg";
+
+// defaults to Ed25519
+let signer = Signer::new_with_defaults(None, None)?;
+
+// create our signatures
+let cigar = signer.sign_unindexed(data)?;
+let siger = signer.sign_indexed(data, false, 0, None)?;
+
+// compare the raw signatures
+assert_eq!(cigar.raw(), siger.raw());
+```
+
+```rust
+use cesride::{Diger, Matter, matter};
+// here we simply print a qualified digest in base64 to stdout after hashing serialized data
+// hash digests underpin core concepts of the KERI ecosystem
+
+let data = b"abcdefg";
+
+// derive the digest, opting this time to specify the algorithm
+let diger = Diger::new_with_ser(data, Some(matter::Codex::SHA3_512))?;
+
+// output the digest
+println!("Blake3 256 digest: #{d}", d=diger.qb64()?);
+```
+
+For more implementation details at this time, see [KERIpy](https://github.com/WebOfTrust/keripy).
+
+## Security
+
+- [ ] Audited for zeroing before frees/drops ([#40](https://github.com/WebOfTrust/cesride/issues/40))
+- [ ] Audited for constant time evaluation ([#116](https://github.com/WebOfTrust/cesride/issues/116))
+
+### Entropy
+
+We use two `OsRng` implementations to obtain our random data. Our private keys are
+sometimes generated from stock methods in the underlying libraries, which is why we currently
+include both implementations (the two signing modules depend on traits that are incompatible).
+
+When using `Salter`, one can produce many deterministic and reproducible results (such as keys) from
+the same seed material, or use random seed material. In the latter case, we use the more recent of 
+the `OsRng` implementations directly to fill buffers.
+
+### External Dependencies (crates)
+
+#### Key Stretching
+
+- Argon2 ([argon2](https://docs.rs/argon2)) - `Salter` uses argon2id to stretch seeds into keying
+material. These are our security tiers and param choices, which maintain compatiblity with the
+reference python implementation ([KERIpy](https://github.com/WebOfTrust/keripy)):
+    - `min`: unavailable outside the `cesride` context except when passing the `temp` param directly
+    to `stretch()` to perform manual stretching. **NEVER** use this security tier in production.
+    argon2id params:
+        - m: 8
+        - t: 1
+        - p: 1
+    - `low`: the default tier, suitable for low-risk online interactions
+        - m: 65536
+        - t: 2
+        - p: 1
+    - `med`: suitable for high-risk online interactions
+        - m: 262144
+        - t: 3
+        - p: 1
+    - `high`: resitant to offline attacks (use this for backups)
+        - m: 1048576
+        - t: 4
+        - p: 1
+
+We use 16 bytes of entropy from `OsRng` in `rand_core` to seed argon2. For more details on selecting
+appropriate argon2 parameters, consult [this document](https://argon2-cffi.readthedocs.io/en/stable/parameters.html).
+
+#### Hashing
+
+`cesride` supports the following hash algorithms:
+- Blake3 256 ([blake3](https://docs.rs/blake3))
+- Blake3 512 ([blake3](https://docs.rs/blake3))
+- Blake2b 256 ([blake2](https://docs.rs/blake2))
+- Blake2b 512 ([blake2](https://docs.rs/blake2))
+- Blake2s 256 ([blake2](https://docs.rs/blake2))
+- SHA3 256 ([sha3](https://docs.rs/sha3))
+- SHA3 512 ([sha3](https://docs.rs/sha3))
+- SHA2 256 ([sha2](https://docs.rs/sha2))
+- SHA2 512 ([sha2](https://docs.rs/sha2))
+
+Blake3 is recommended for most applications since it outperforms the other algorithms.
+
+#### Signing
+
+`cesride` supports the following signing algorithms:
+- Ed25519 ([ed25519-dalek](https://docs.rs/ed25519-dalek))
+- Secp256k1 ([k256](https://docs.rs/k256))
+
+We have planned support for ed448.
+
 ## Community
 
 ### Bi-weekly Meeting

--- a/src/core/diger.rs
+++ b/src/core/diger.rs
@@ -2,6 +2,26 @@ use crate::core::matter::{tables as matter, Matter};
 use crate::crypto::hash;
 use crate::error::{err, Error, Result};
 
+/// ```rust
+/// use cesride::{matter, Matter, Diger};
+/// use std::error::Error;
+/// // here we simply print a qualified digest in base64 to stdout after hashing serialized data
+/// // hash digests underpin core concepts of the KERI ecosystem/
+///
+/// fn example() -> Result<(), Box<dyn Error>> {
+///     let data = b"abcdefg";
+///
+///     // derive the digest, opting this time to specify the algorithm
+///     let diger = Diger::new_with_ser(data, Some(matter::Codex::SHA3_512))?;
+///
+///     // output the digest
+///     println!("Blake3 256 digest: #{d}", d=diger.qb64()?);
+///
+///     Ok(())
+/// }
+///
+/// example().unwrap();
+/// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct Diger {
     raw: Vec<u8>,

--- a/src/core/siger.rs
+++ b/src/core/siger.rs
@@ -29,14 +29,14 @@ fn validate_code(code: &str) -> Result<()> {
         indexer::Codex::Ed25519_Crt,
         indexer::Codex::ECDSA_256k1,
         indexer::Codex::ECDSA_256k1_Crt,
-        indexer::Codex::Ed448,
-        indexer::Codex::Ed448_Crt,
+        // indexer::Codex::Ed448,
+        // indexer::Codex::Ed448_Crt,
         indexer::Codex::Ed25519_Big,
         indexer::Codex::Ed25519_Big_Crt,
         indexer::Codex::ECDSA_256k1_Big,
         indexer::Codex::ECDSA_256k1_Big_Crt,
-        indexer::Codex::Ed448_Big,
-        indexer::Codex::Ed448_Big_Crt,
+        // indexer::Codex::Ed448_Big,
+        // indexer::Codex::Ed448_Big_Crt,
     ];
 
     if !CODES.contains(&code) {
@@ -205,19 +205,21 @@ mod test {
             Siger::new(Some(&verfer), None, None, None, None, None, Some(qsig64), None).unwrap();
         assert_eq!(siger.verfer(), verfer);
 
-        let raw = b"abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdef";
-        let siger = Siger::new(
-            None,
-            Some(4),
-            None,
-            Some(indexer::Codex::Ed448),
-            Some(raw),
-            None,
-            None,
-            None,
-        )
-        .unwrap();
-        assert_eq!(siger.qb64().unwrap(), "0AEEYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVm");
+        // we don't support ed448 yet
+
+        // let raw = b"abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdef";
+        // let siger = Siger::new(
+        //     None,
+        //     Some(4),
+        //     None,
+        //     Some(indexer::Codex::Ed448),
+        //     Some(raw),
+        //     None,
+        //     None,
+        //     None,
+        // )
+        // .unwrap();
+        // assert_eq!(siger.qb64().unwrap(), "0AEEYWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVm");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 pub use crate::{
     core::{
         cigar::Cigar,
+        common,
         counter::{tables as counter, Counter}, // This seems like it shoudl be an abstract class
         diger::Diger,
         indexer::{tables as indexer, Indexer},


### PR DESCRIPTION
## Rationale

Addresses #113.

[Pretty version](https://github.com/jasoncolburne/cesride/blob/clarify-crypto/README.md#terminology).

## Changes

- updates readme to describe our underlying cryptographic usage
- updates readme to describe some common cryptographic primitves and how they are expressed in `cesride`
- adds a couple documentation tests

## Testing

I actually added a convenience method so I added tests for that.