### PR TITLE
zero memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { version = "~1", features = ["preserve_order"] }
 sha2 = "~0.10"
 sha3 = "~0.10"
 thiserror = "~1"
+zeroize = "~1"
 
 [dev-dependencies]
 hex-literal = "0.3.4"

--- a/src/core/counter/mod.rs
+++ b/src/core/counter/mod.rs
@@ -66,7 +66,7 @@ impl Counter {
 
     pub fn sem_ver_str_to_b64(version: &str) -> Result<String> {
         let strings = version.split('.').collect::<Vec<_>>();
-        let mut parts = Vec::new();
+        let mut parts = vec![0u8; 3];
 
         if strings.len() > 3 {
             return err!(Error::Conversion(format!(
@@ -74,8 +74,8 @@ impl Counter {
             )));
         }
 
-        for s in strings {
-            let n = match s.parse::<i8>() {
+        for i in 0..strings.len() {
+            let n = match strings[i].parse::<i8>() {
                 Ok(n) => {
                     if n < 0 {
                         return err!(Error::Conversion(format!(
@@ -86,7 +86,7 @@ impl Counter {
                     }
                 }
                 Err(_) => {
-                    if s.is_empty() {
+                    if strings[i].is_empty() {
                         0
                     } else {
                         return err!(Error::Conversion(format!(
@@ -95,10 +95,8 @@ impl Counter {
                     }
                 }
             };
-            parts.push(n);
+            parts[i] = n;
         }
-
-        parts.resize(3, 0);
 
         Counter::sem_ver_parts_to_b64(&parts)
     }

--- a/src/core/indexer/tables.rs
+++ b/src/core/indexer/tables.rs
@@ -128,7 +128,7 @@ pub(crate) fn sizage(s: &str) -> Result<Sizage> {
         "2D" => Sizage { hs: 2, ss: 4, os: 2, fs: 92, ls: 0 },
         "3A" => Sizage { hs: 2, ss: 6, os: 3, fs: 160, ls: 0 },
         "3B" => Sizage { hs: 2, ss: 6, os: 3, fs: 160, ls: 0 },
-        "0z" => Sizage { hs: 2, ss: 2, os: 0, fs: 0, ls: 0 },
+        "0z" => Sizage { hs: 2, ss: 2, os: 0, fs: u32::MAX, ls: 0 },
         "1z" => Sizage { hs: 2, ss: 2, os: 1, fs: 76, ls: 1 },
         "4z" => Sizage { hs: 2, ss: 6, os: 3, fs: 80, ls: 1 },
         _ => return Err(Box::new(Error::UnknownSizage(s.to_string()))),
@@ -234,7 +234,7 @@ mod test {
     #[case("2D", 2, 4, 2, 92, 0)]
     #[case("3A", 2, 6, 3, 160, 0)]
     #[case("3B", 2, 6, 3, 160, 0)]
-    #[case("0z", 2, 2, 0, 0, 0)]
+    #[case("0z", 2, 2, 0, u32::MAX, 0)]
     #[case("1z", 2, 2, 1, 76, 1)]
     #[case("4z", 2, 6, 3, 80, 1)]
     fn sizage(

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -49,18 +49,18 @@ pub(crate) fn sizage(s: &str) -> Result<Sizage> {
         "1AAH" => Sizage { hs: 4, ss: 0, fs: 100, ls: 0 },
         "2AAA" => Sizage { hs: 4, ss: 0, fs: 8, ls: 1 },
         "3AAA" => Sizage { hs: 4, ss: 0, fs: 8, ls: 2 },
-        "4A" => Sizage { hs: 2, ss: 2, fs: 0, ls: 0 },
-        "5A" => Sizage { hs: 2, ss: 2, fs: 0, ls: 1 },
-        "6A" => Sizage { hs: 2, ss: 2, fs: 0, ls: 2 },
-        "7AAA" => Sizage { hs: 4, ss: 4, fs: 0, ls: 0 },
-        "8AAA" => Sizage { hs: 4, ss: 4, fs: 0, ls: 1 },
-        "9AAA" => Sizage { hs: 4, ss: 4, fs: 0, ls: 2 },
-        "4B" => Sizage { hs: 2, ss: 2, fs: 0, ls: 0 },
-        "5B" => Sizage { hs: 2, ss: 2, fs: 0, ls: 1 },
-        "6B" => Sizage { hs: 2, ss: 2, fs: 0, ls: 2 },
-        "7AAB" => Sizage { hs: 4, ss: 4, fs: 0, ls: 0 },
-        "8AAB" => Sizage { hs: 4, ss: 4, fs: 0, ls: 1 },
-        "9AAB" => Sizage { hs: 4, ss: 4, fs: 0, ls: 2 },
+        "4A" => Sizage { hs: 2, ss: 2, fs: u32::MAX, ls: 0 },
+        "5A" => Sizage { hs: 2, ss: 2, fs: u32::MAX, ls: 1 },
+        "6A" => Sizage { hs: 2, ss: 2, fs: u32::MAX, ls: 2 },
+        "7AAA" => Sizage { hs: 4, ss: 4, fs: u32::MAX, ls: 0 },
+        "8AAA" => Sizage { hs: 4, ss: 4, fs: u32::MAX, ls: 1 },
+        "9AAA" => Sizage { hs: 4, ss: 4, fs: u32::MAX, ls: 2 },
+        "4B" => Sizage { hs: 2, ss: 2, fs: u32::MAX, ls: 0 },
+        "5B" => Sizage { hs: 2, ss: 2, fs: u32::MAX, ls: 1 },
+        "6B" => Sizage { hs: 2, ss: 2, fs: u32::MAX, ls: 2 },
+        "7AAB" => Sizage { hs: 4, ss: 4, fs: u32::MAX, ls: 0 },
+        "8AAB" => Sizage { hs: 4, ss: 4, fs: u32::MAX, ls: 1 },
+        "9AAB" => Sizage { hs: 4, ss: 4, fs: u32::MAX, ls: 2 },
         _ => return err!(Error::UnknownSizage(s.to_string())),
     })
 }
@@ -89,7 +89,7 @@ pub(crate) fn bardage(b: u8) -> Result<u32> {
 
 pub(crate) fn raw_size(code: &str) -> Result<u32> {
     let szg = sizage(code)?;
-    if szg.fs == 0 {
+    if szg.fs == u32::MAX {
         return err!(Error::UnexpectedCode(format!("cannot determine raw size for code={code}")));
     }
 
@@ -188,18 +188,18 @@ mod test {
     #[case("1AAH", 4, 0, 100, 0)]
     #[case("2AAA", 4, 0, 8, 1)]
     #[case("3AAA", 4, 0, 8, 2)]
-    #[case("4A", 2, 2, 0, 0)]
-    #[case("5A", 2, 2, 0, 1)]
-    #[case("6A", 2, 2, 0, 2)]
-    #[case("7AAA", 4, 4, 0, 0)]
-    #[case("8AAA", 4, 4, 0, 1)]
-    #[case("9AAA", 4, 4, 0, 2)]
-    #[case("4B", 2, 2, 0, 0)]
-    #[case("5B", 2, 2, 0, 1)]
-    #[case("6B", 2, 2, 0, 2)]
-    #[case("7AAB", 4, 4, 0, 0)]
-    #[case("8AAB", 4, 4, 0, 1)]
-    #[case("9AAB", 4, 4, 0, 2)]
+    #[case("4A", 2, 2, u32::MAX, 0)]
+    #[case("5A", 2, 2, u32::MAX, 1)]
+    #[case("6A", 2, 2, u32::MAX, 2)]
+    #[case("7AAA", 4, 4, u32::MAX, 0)]
+    #[case("8AAA", 4, 4, u32::MAX, 1)]
+    #[case("9AAA", 4, 4, u32::MAX, 2)]
+    #[case("4B", 2, 2, u32::MAX, 0)]
+    #[case("5B", 2, 2, u32::MAX, 1)]
+    #[case("6B", 2, 2, u32::MAX, 2)]
+    #[case("7AAB", 4, 4, u32::MAX, 0)]
+    #[case("8AAB", 4, 4, u32::MAX, 1)]
+    #[case("9AAB", 4, 4, u32::MAX, 2)]
     fn sizage(
         #[case] code: &str,
         #[case] hs: u32,

--- a/src/core/salter.rs
+++ b/src/core/salter.rs
@@ -1,3 +1,5 @@
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
 use crate::{
     core::{
         common::Tierage,
@@ -8,11 +10,14 @@ use crate::{
     error::{err, Error, Result},
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, ZeroizeOnDrop)]
 pub struct Salter {
+    #[zeroize(skip)]
     code: String,
     raw: Vec<u8>,
+    #[zeroize(skip)]
     size: u32,
+    #[zeroize(skip)]
     tier: String,
 }
 
@@ -40,9 +45,11 @@ impl Salter {
 
         let mut salter: Self =
             if raw.is_none() && qb64b.is_none() && qb64.is_none() && qb2.is_none() {
-                let mut raw: [u8; SALTER_SEED_BYTES] = [0; SALTER_SEED_BYTES];
+                let mut raw = [0_u8; SALTER_SEED_BYTES];
                 csprng::fill_bytes(&mut raw);
-                Matter::new(Some(code), Some(&raw), None, None, None)?
+                let matter = Matter::new(Some(code), Some(&raw), None, None, None)?;
+                raw.zeroize();
+                matter
             } else {
                 Matter::new(Some(code), raw, qb64b, qb64, qb2)?
             };
@@ -107,9 +114,12 @@ impl Salter {
         let temp = temp.unwrap_or(false);
 
         let size = matter::raw_size(code)?;
-        let seed = self.stretch(Some(size as usize), Some(path), tier, Some(temp))?;
+        let mut seed = self.stretch(Some(size as usize), Some(path), tier, Some(temp))?;
 
-        Signer::new(Some(transferable), Some(code), Some(&seed), None, None, None)
+        let signer = Signer::new(Some(transferable), Some(code), Some(&seed), None, None, None)?;
+        seed.zeroize();
+
+        Ok(signer)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -402,13 +412,9 @@ mod test {
                 }
             }
 
-            atc += &Counter::new(
-                Some(sigers.len() as u32),
-                None,
-                Some(counter::Codex::ControllerIdxSigs),
-                None,
-                None,
-                None,
+            atc += &Counter::new_with_code_and_count(
+                counter::Codex::ControllerIdxSigs,
+                sigers.len() as u32,
             )?
             .qb64()?;
             for siger in sigers {
@@ -417,13 +423,9 @@ mod test {
         }
 
         if let Some(wigers) = wigers {
-            atc += &Counter::new(
-                Some(wigers.len() as u32),
-                None,
-                Some(counter::Codex::WitnessIdxSigs),
-                None,
-                None,
-                None,
+            atc += &Counter::new_with_code_and_count(
+                counter::Codex::WitnessIdxSigs,
+                wigers.len() as u32,
             )?
             .qb64()?;
             for wiger in wigers {


### PR DESCRIPTION
## Rationale

This PR aims to improve the security posture of `cesride` by removing mutability where possible, cleaning up unnecessary heap allocations/resizes/moves and zeroing sensitive buffers after use.

## Changes

- adds `ZeroizeOnDrop` to `Signer` and `Salter`
- treats `Matter` conversions, since `Signer` and `Salter` both rely on the trait for encoding and decoding. this zeros buffers where they may contain sensitive information
- fixes instantiation of `Siger` from `Signer` to include `Verfer`.
- cleans up mutability where possible
- uses better copy methods so that the heap isn't littered with sensitive data

## Testing

```
make clean preflight
```