### PR TITLE
data visibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cesride"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "Cryptographic primitives for use with Composable Event Streaming Representation (CESR)"
 license = "Apache-2.0"

--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -1,4 +1,4 @@
-use crate::data::{data, Data, Value};
+use crate::data::{dat, Value};
 use crate::error::{err, Error, Result};
 
 use lazy_static::lazy_static;
@@ -209,7 +209,7 @@ pub(crate) fn sizeify(ked: &Value, kind: Option<&str>) -> Result<SizeifyResult> 
     }
 
     let mut ked = ked.clone();
-    ked["v"] = data!(&vs);
+    ked["v"] = dat!(&vs);
 
     Ok(SizeifyResult { raw, ident: result.ident, kind, ked, version: result.version })
 }
@@ -314,12 +314,12 @@ pub(crate) fn sniff(raw: &[u8]) -> Result<SniffResult> {
 #[cfg(test)]
 mod test {
     use crate::core::common;
-    use crate::data::{data, Data};
+    use crate::data::dat;
     use rstest::rstest;
 
     #[test]
     fn loads() {
-        let raw = &data!({}).to_json().unwrap().as_bytes().to_vec();
+        let raw = &dat!({}).to_json().unwrap().as_bytes().to_vec();
         assert!(common::loads(raw, None, None).is_ok());
     }
 
@@ -327,35 +327,33 @@ mod test {
     fn sniff_unhappy_paths() {
         assert!(common::sniff(&[]).is_err()); // minimum 29 octets
         assert!(common::sniff(
-            &data!({"v":"version string must be valid!"}).to_json().unwrap().as_bytes()
+            &dat!({"v":"version string must be valid!"}).to_json().unwrap().as_bytes()
         )
         .is_err());
         assert!(common::sniff(
-            &data!({"i":"needs to start within 12 characters!","v":"KERI10JSON000000_"})
+            &dat!({"i":"needs to start within 12 characters!","v":"KERI10JSON000000_"})
                 .to_json()
                 .unwrap()
                 .as_bytes()
         )
         .is_err());
-        assert!(common::sniff(&data!({"v":"KERI10ABCD000000_","confusing but necessary filler":"hmm...maybe a 12 octet magic prefix?"}).to_json().unwrap().as_bytes()).is_err());
+        assert!(common::sniff(&dat!({"v":"KERI10ABCD000000_","confusing but necessary filler":"hmm...maybe a 12 octet magic prefix?"}).to_json().unwrap().as_bytes()).is_err());
         // needs to have a valid serialization kind
     }
 
     #[test]
     fn loads_unhappy_paths() {
-        let raw = &data!({}).to_json().unwrap().as_bytes().to_vec();
+        let raw = &dat!({}).to_json().unwrap().as_bytes().to_vec();
         assert!(common::loads(raw, None, Some("CESR")).is_err());
         assert!(common::loads(raw, Some(1024), Some("CESR")).is_err());
     }
 
     #[test]
     fn sizeify_unhappy_paths() {
-        assert!(common::sizeify(&data!({}), None).is_err());
-        assert!(common::sizeify(&data!({"v":"KERIffJSON000000_"}), None).is_err());
-        assert!(common::sizeify(&data!({"v":"KERI10JSON000000_"}), Some("CESR")).is_err());
-        assert!(
-            common::sizeify(&data!({"i":"filler entry","v":"KERI10JSON000000_"}), None).is_err()
-        );
+        assert!(common::sizeify(&dat!({}), None).is_err());
+        assert!(common::sizeify(&dat!({"v":"KERIffJSON000000_"}), None).is_err());
+        assert!(common::sizeify(&dat!({"v":"KERI10JSON000000_"}), Some("CESR")).is_err());
+        assert!(common::sizeify(&dat!({"i":"filler entry","v":"KERI10JSON000000_"}), None).is_err());
     }
 
     #[test]
@@ -373,6 +371,6 @@ mod test {
 
     #[test]
     fn dumps_unhappy_paths() {
-        assert!(common::dumps(&data!({}), Some("CESR")).is_err());
+        assert!(common::dumps(&dat!({}), Some("CESR")).is_err());
     }
 }

--- a/src/core/prefixer.rs
+++ b/src/core/prefixer.rs
@@ -156,8 +156,8 @@ fn derive_digest(ked: &Value, code: &str) -> Result<(Vec<u8>, String)> {
     let szg = matter::sizage(code)?;
     let dummy = String::from_utf8(vec![DUMMY; szg.fs as usize])?;
 
-    ked[label_i] = data!(&dummy);
-    ked[label_d] = data!(&dummy);
+    ked[label_i] = dat!(&dummy);
+    ked[label_d] = dat!(&dummy);
 
     let result = sizeify(&ked, None)?;
     let dig = hash::digest(code, &result.raw)?;
@@ -409,7 +409,7 @@ mod test {
             signer::Signer,
             verfer::Verfer,
         },
-        data::data,
+        data::dat,
     };
     use rstest::rstest;
 
@@ -420,7 +420,7 @@ mod test {
         let prefix = "BKxy2sgzfplyr-tgwIxS19f2OchFHtLwPWD3v4oYimBx";
 
         let verfer = Verfer::new(Some(code), Some(vkey), None, None, None).unwrap();
-        let ked = data!({
+        let ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": "",
             "t": "icp",
@@ -542,22 +542,22 @@ mod test {
         #[case] prefix: Option<&str>,
         #[case] code: Option<&str>,
     ) {
-        let mut ked = data!({});
+        let mut ked = dat!({});
 
         if let Some(version_string) = version_string {
-            ked["v"] = data!(version_string);
+            ked["v"] = dat!(version_string);
         }
         if !keys.is_empty() {
             let mut v = vec![];
             for key in keys {
-                v.push(data!(*key))
+                v.push(dat!(*key))
             }
-            ked["k"] = data!(v.as_slice());
+            ked["k"] = dat!(v.as_slice());
         }
-        ked["n"] = data!(next_keys);
-        ked["t"] = data!(ilk);
+        ked["n"] = dat!(next_keys);
+        ked["t"] = dat!(ilk);
         if let Some(prefix) = prefix {
-            ked["i"] = data!(prefix);
+            ked["i"] = dat!(prefix);
         }
 
         assert!(Prefixer::new(Some(&ked), None, code, None, None, None, None).is_err());
@@ -578,17 +578,17 @@ mod test {
 
         let verfer = Verfer::new(Some(code), Some(verkey), None, None, None).unwrap();
 
-        let mut ked = data!({
+        let mut ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": next_key,
             "t": "icp",
             "i": pre_n,
         });
         if let Some(a) = a {
-            ked["a"] = data!(a);
+            ked["a"] = dat!(a);
         }
         if let Some(b) = b {
-            ked["b"] = data!(b);
+            ked["b"] = dat!(b);
         }
 
         assert!(Prefixer::new(Some(&ked), None, Some(code), None, None, None, None).is_err());
@@ -604,7 +604,7 @@ mod test {
 
         // missing key
         let verfer = Verfer::new(Some(code), Some(verkey), None, None, None).unwrap();
-        let mut ked = data!({
+        let mut ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": "",
             "t": "icp",
@@ -614,13 +614,13 @@ mod test {
 
         let mut map = ked.to_map().unwrap();
         map.remove("k");
-        ked = data!(&map);
+        ked = dat!(&map);
 
         assert!(!prefixer.verify(&ked, None).unwrap());
 
         // multiple keys
         let verfer = Verfer::new(Some(code), Some(verkey), None, None, None).unwrap();
-        let mut ked = data!({
+        let mut ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": "",
             "t": "icp",
@@ -628,13 +628,13 @@ mod test {
         });
         let prefixer = Prefixer::new(Some(&ked), None, Some(code), None, None, None, None).unwrap();
 
-        ked["k"] = data!([&verfer.qb64().unwrap(), &verfer.qb64().unwrap()]);
+        ked["k"] = dat!([&verfer.qb64().unwrap(), &verfer.qb64().unwrap()]);
 
         assert!(!prefixer.verify(&ked, None).unwrap());
 
         // key != prefix
         let verfer = Verfer::new(Some(code), Some(verkey), None, None, None).unwrap();
-        let mut ked = data!({
+        let mut ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": "",
             "t": "icp",
@@ -642,13 +642,13 @@ mod test {
         });
         let prefixer = Prefixer::new(Some(&ked), None, Some(code), None, None, None, None).unwrap();
 
-        ked["k"] = data!(["ABC"]);
+        ked["k"] = dat!(["ABC"]);
 
         assert!(!prefixer.verify(&ked, None).unwrap());
 
         // bad key (doesn't match)
         let verfer = Verfer::new(Some(code), Some(verkey), None, None, None).unwrap();
-        let mut ked = data!({
+        let mut ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": "",
             "t": "icp",
@@ -657,13 +657,13 @@ mod test {
         let prefixer = Prefixer::new(Some(&ked), None, Some(code), None, None, None, None).unwrap();
 
         let nxtfer = Verfer::new(Some(code), Some(nxtkey), None, None, None).unwrap();
-        ked["k"] = data!([&nxtfer.qb64().unwrap()]);
+        ked["k"] = dat!([&nxtfer.qb64().unwrap()]);
 
         assert!(!prefixer.verify(&ked, None).unwrap());
 
         // non-incepting
         let verfer = Verfer::new(Some(code), Some(verkey), None, None, None).unwrap();
-        let mut ked = data!({
+        let mut ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": "",
             "t": "icp",
@@ -671,7 +671,7 @@ mod test {
         });
         let prefixer = Prefixer::new(Some(&ked), None, Some(code), None, None, None, None).unwrap();
 
-        ked["t"] = data!("ksn");
+        ked["t"] = dat!("ksn");
 
         assert!(prefixer.verify(&ked, None).is_err());
     }
@@ -684,7 +684,7 @@ mod test {
         // next keys present, non-transferable
         let verfer =
             Verfer::new(Some(matter::Codex::Ed25519N), Some(verkey), None, None, None).unwrap();
-        let mut ked = data!({
+        let mut ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": "",
             "t": "icp",
@@ -694,7 +694,7 @@ mod test {
             Prefixer::new(Some(&ked), None, Some(matter::Codex::Ed25519N), None, None, None, None)
                 .unwrap();
 
-        ked["n"] = data!([&verfer.qb64().unwrap()]);
+        ked["n"] = dat!([&verfer.qb64().unwrap()]);
 
         assert!(!prefixer.verify(&ked, None).unwrap());
     }
@@ -771,7 +771,7 @@ mod test {
         #[case] prefixed_result: bool,
     ) {
         let prefixer = Prefixer::new(None, None, Some(code), Some(raw), None, None, None).unwrap();
-        let ked = data!({
+        let ked = dat!({
             "k": [&prefixer.qb64().unwrap()],
             "n": n,
             "t": "icp"
@@ -809,7 +809,7 @@ mod test {
         #[case] prefixed_result: bool,
     ) {
         let prefixer = Prefixer::new(None, None, Some(code), Some(raw), None, None, None).unwrap();
-        let ked = data!({
+        let ked = dat!({
             "k": [&prefixer.qb64().unwrap()],
             "t": "icp"
         });
@@ -833,7 +833,7 @@ mod test {
         #[case] prefixed_result: bool,
     ) {
         let verfer = Verfer::new(Some(vcode), Some(vkey), None, None, None).unwrap();
-        let ked = data!({
+        let ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": "",
             "t": "icp"
@@ -868,7 +868,7 @@ mod test {
         #[case] prefixed_result: bool,
     ) {
         let verfer = Verfer::new(Some(vcode), Some(vkey), None, None, None).unwrap();
-        let ked = data!({
+        let ked = dat!({
             "k": [&verfer.qb64().unwrap()],
             "n": "",
             "t": "icp",
@@ -897,7 +897,7 @@ mod test {
     ) {
         let diger = Diger::new(Some(b""), Some(code), None, None, None, None).unwrap();
         let vs = versify(None, Some(CURRENT_VERSION), Some(Serialage::JSON), Some(0)).unwrap();
-        let ked = data!({
+        let ked = dat!({
             "v": &vs,
             "k": [&diger.qb64().unwrap()],
             "n": "",
@@ -928,7 +928,7 @@ mod test {
     ) {
         let diger = Diger::new(Some(b""), Some(code), None, None, None, None).unwrap();
         let vs = versify(None, Some(CURRENT_VERSION), Some(Serialage::JSON), Some(0)).unwrap();
-        let ked = data!({
+        let ked = dat!({
             "v": &vs,
             "k": [&diger.qb64().unwrap()],
             "n": "",
@@ -943,8 +943,8 @@ mod test {
         assert!(prefixer.verify(&ked, None).unwrap());
         assert!(!prefixer.verify(&ked, Some(true)).unwrap());
 
-        ked["i"] = data!(&prefixer.qb64().unwrap());
-        ked["d"] = data!(&prefixer.qb64().unwrap());
+        ked["i"] = dat!(&prefixer.qb64().unwrap());
+        ked["d"] = dat!(&prefixer.qb64().unwrap());
 
         assert!(prefixer.verify(&ked, None).unwrap());
         assert!(prefixer.verify(&ked, Some(true)).unwrap());
@@ -969,7 +969,7 @@ mod test {
         let sn = "0"; // hex string
         let ilk = Ilkage::icp;
         let sith = "1";
-        let keys = data!([&Prefixer::new(
+        let keys = dat!([&Prefixer::new(
             None,
             None,
             Some(matter::Codex::Ed25519),
@@ -983,10 +983,10 @@ mod test {
         .unwrap()]);
         let nxt = "";
         let toad = "0"; // hex string
-        let wits = data!([]);
-        let cnfg = data!([]);
+        let wits = dat!([]);
+        let cnfg = dat!([]);
 
-        let ked = data!({
+        let ked = dat!({
             "v": &vs,
             "i": "",
             "s": sn,
@@ -1014,11 +1014,11 @@ mod test {
         assert!(!prefixer.verify(&ked, Some(true)).unwrap());
 
         let n_digs =
-            data!([&Diger::new(Some(&nxtfer.qb64b().unwrap()), None, None, None, None, None)
+            dat!([&Diger::new(Some(&nxtfer.qb64b().unwrap()), None, None, None, None, None)
                 .unwrap()
                 .qb64()
                 .unwrap()]);
-        let ked = data!({
+        let ked = dat!({
             "v": &vs,
             "i": "",
             "s": sn,
@@ -1070,19 +1070,19 @@ mod test {
             assert_eq!(secrets[i], signers[i].qb64().unwrap());
         }
 
-        let keys = data!([
+        let keys = dat!([
             &signers[0].verfer().qb64().unwrap(),
             &signers[1].verfer().qb64().unwrap(),
             &signers[2].verfer().qb64().unwrap(),
         ]);
-        let sith = data!([["1/2", "1/2", "1"]]);
+        let sith = dat!([["1/2", "1/2", "1"]]);
         let n_dig =
             Diger::new(Some(&signers[3].verfer().qb64b().unwrap()), None, None, None, None, None)
                 .unwrap()
                 .qb64()
                 .unwrap();
-        let n_digs = data!([&n_dig]);
-        let ked = data!({
+        let n_digs = dat!([&n_dig]);
+        let ked = dat!({
             "v": &vs,
             "i": "",
             "s": sn,
@@ -1109,8 +1109,8 @@ mod test {
         assert!(prefixer.verify(&ked, None).unwrap());
         assert!(!prefixer.verify(&ked, Some(true)).unwrap());
 
-        let sith = data!([["1/2", "1/2"], ["1"]]);
-        let ked = data!({
+        let sith = dat!([["1/2", "1/2"], ["1"]]);
+        let ked = dat!({
             "v": &vs,
             "i": "",
             "s": sn,
@@ -1137,14 +1137,14 @@ mod test {
         assert!(!prefixer.verify(&ked, Some(true)).unwrap());
 
         let sith = "1";
-        let seal = data!({
+        let seal = dat!({
             "i": "EBfPkd-A2CQfJmfpmtc1V-yuleSeCcyWBIrTAygUgQ_T",
             "s": "2",
             "t": Ilkage::ixn,
             "d": "EB0_D51cTh_q6uOQ-byFiv5oNXZ-cxdqCqBAa4JmBLtb"
         });
         let ilk2 = Ilkage::dip;
-        let ked = data!({
+        let ked = dat!({
             "v": &vs,
             "i": "",
             "s": sn,

--- a/src/core/sadder.rs
+++ b/src/core/sadder.rs
@@ -3,7 +3,7 @@ use crate::core::{
     matter::{tables as matter, Matter},
     saider::Saider,
 };
-use crate::data::{Data, Value};
+use crate::data::Value;
 use crate::error::{err, Error, Result};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -220,7 +220,7 @@ mod test {
         sadder::Sadder,
         saider::Saider,
     };
-    use crate::data::{data, Data, Value};
+    use crate::data::{dat, Value};
 
     #[derive(Debug, Clone, PartialEq)]
     struct TestSadder {
@@ -239,7 +239,7 @@ mod test {
             TestSadder {
                 code: matter::Codex::Blake3_256.to_string(),
                 raw: vec![],
-                ked: data!({}),
+                ked: dat!({}),
                 ident: Identage::KERI.to_string(),
                 kind: Serialage::JSON.to_string(),
                 size: 0,
@@ -303,7 +303,7 @@ mod test {
 
     #[test]
     fn new() {
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON000000_",
             "d": "",
         });
@@ -336,14 +336,14 @@ mod test {
 
     #[test]
     fn new_unhappy_paths() {
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON000000_",
             "d": "",
         });
 
         let (saider, ked) = Saider::saidify(&ked, None, None, None, None).unwrap();
         let mut ked2 = ked.clone();
-        ked2["v"] = data!("KERI11JSON000000_");
+        ked2["v"] = dat!("KERI11JSON000000_");
 
         let raw = &ked.to_json().unwrap().as_bytes().to_vec();
         let raw2 = &ked2.to_json().unwrap().as_bytes().to_vec();
@@ -361,7 +361,7 @@ mod test {
 
     #[test]
     fn populate_from_kind_and_self() {
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON000000_",
             "d": "",
         });
@@ -374,7 +374,7 @@ mod test {
 
     #[test]
     fn populate_from_kind_and_self_unhappy_paths() {
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON000000_",
             "d": "",
         });
@@ -384,7 +384,7 @@ mod test {
         let (saider_blake2b, _) =
             Saider::saidify(&ked, Some(matter::Codex::Blake2b_256), None, None, None).unwrap();
 
-        ked_blake3["d"] = data!(&saider_blake2b.qb64().unwrap());
+        ked_blake3["d"] = dat!(&saider_blake2b.qb64().unwrap());
 
         // saider code and sadder code must match
         let mut sadder = TestSadder::default();
@@ -395,7 +395,7 @@ mod test {
 
     #[test]
     fn pretty() {
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON000000_",
             "d": "",
         });

--- a/src/core/saider.rs
+++ b/src/core/saider.rs
@@ -1,7 +1,7 @@
 use crate::core::common::{deversify, dumps, sizeify, Ids, Serialage, DUMMY};
 use crate::core::matter::{tables as matter, Matter};
 use crate::crypto::hash;
-use crate::data::{data, Value};
+use crate::data::{dat, Value};
 use crate::error::{err, Error, Result};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -63,7 +63,7 @@ fn derive(
     let szg = matter::sizage(code)?;
     let mut sad = sad.clone();
 
-    sad[label] = data!(&String::from_utf8(vec![DUMMY; szg.fs as usize])?);
+    sad[label] = dat!(&String::from_utf8(vec![DUMMY; szg.fs as usize])?);
 
     let (kind, sad) = if sad.to_map()?.contains_key("v") {
         let result = sizeify(&sad, kind)?;
@@ -79,7 +79,7 @@ fn derive(
             map.remove(*key);
         }
     }
-    let ser = data!(&map);
+    let ser = dat!(&map);
 
     let cpa =
         if let Some(kind) = kind { serialize(&ser, Some(&kind))? } else { serialize(&ser, None)? };
@@ -139,7 +139,7 @@ impl Saider {
 
                 validate_code(&code)?;
 
-                let sad = if let Some(sad) = sad { sad.clone() } else { data!({}) };
+                let sad = if let Some(sad) = sad { sad.clone() } else { dat!({}) };
                 let (raw, _) = derive(&sad, Some(&code), kind, Some(label), ignore)?;
 
                 (code, raw)
@@ -182,7 +182,7 @@ impl Saider {
         let saider =
             Self::new(Some(&sad), Some(label), kind, ignore, Some(code), None, None, None, None)?;
         let mut sad = sad;
-        sad[label] = data!(&saider.qb64()?);
+        sad[label] = dat!(&saider.qb64()?);
 
         Ok((saider, sad))
     }
@@ -299,12 +299,12 @@ mod test {
     use crate::core::common::{versify, Identage, Ids, Serialage, Version};
     use crate::core::matter::{tables as matter, Matter};
     use crate::core::saider::Saider;
-    use crate::data::data;
+    use crate::data::dat;
     use rstest::rstest;
 
     #[test]
     fn convenience() {
-        let sad = data!({"d":""});
+        let sad = dat!({"d":""});
 
         let saider =
             Saider::new(Some(&sad), None, None, None, None, None, None, None, None).unwrap();
@@ -319,7 +319,7 @@ mod test {
     #[test]
     fn new() {
         let saider = Saider::new(
-            Some(&data!({"d":""})),
+            Some(&dat!({"d":""})),
             Some(Ids::d),
             None,
             None,
@@ -388,7 +388,7 @@ mod test {
         #[case] kind: Option<&str>,
         #[case] label: Option<&str>,
     ) {
-        let sad1 = data!({
+        let sad1 = dat!({
             "$id": "",
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
@@ -402,7 +402,7 @@ mod test {
         let (saider, _) = Saider::saidify(&sad1, code, kind, label, None).unwrap();
         assert_eq!(saider.qb64().unwrap(), said);
 
-        let sad2 = data!({
+        let sad2 = dat!({
             "$id": said,
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
@@ -432,7 +432,7 @@ mod test {
         )
         .unwrap();
         assert_eq!(vs, "KERI10JSON000000_");
-        let sad6 = data!({
+        let sad6 = dat!({
             "v": &vs,
             "t": "rep",
             "d": "",
@@ -455,17 +455,17 @@ mod test {
         assert!(!saider.verify(&sad6, Some(true), Some(false), None, None, None).unwrap());
 
         let mut sad7 = sad6.clone();
-        sad7[label] = data!(&saider.qb64().unwrap());
+        sad7[label] = dat!(&saider.qb64().unwrap());
         assert!(saider.verify(&sad7, Some(true), Some(false), None, None, None).unwrap());
 
         let mut sad8 = sad7.clone();
         let (_, dsad) = derive(&sad6, Some(code), None, Some(label), None).unwrap();
-        sad8["v"] = data!(&dsad["v"].to_string().unwrap());
+        sad8["v"] = dat!(&dsad["v"].to_string().unwrap());
         assert!(saider.verify(&sad8, Some(true), None, None, None, None).unwrap());
 
         // let said8 = saider.qb64().unwrap();
 
-        let sad9 = data!({
+        let sad9 = dat!({
             "d": "",
             "first": "John",
             "last": "Doe",
@@ -498,7 +498,7 @@ mod test {
             .unwrap());
 
         // Change the 'read' field that is ignored and make sure it still verifies
-        sad10["read"] = data!(true);
+        sad10["read"] = dat!(true);
         assert!(saider1
             .verify(&sad10, Some(true), None, None, Some(Ids::d), Some(&vec!["read"]))
             .unwrap());
@@ -522,7 +522,7 @@ mod test {
     #[test]
     fn new_with_things() {
         let saider = Saider::new(
-            Some(&data!({"d":""})),
+            Some(&dat!({"d":""})),
             Some(Ids::d),
             None,
             None,
@@ -534,7 +534,7 @@ mod test {
         )
         .unwrap();
         let saider2 = Saider::new(
-            Some(&data!({"d":&saider.qb64().unwrap()})),
+            Some(&dat!({"d":&saider.qb64().unwrap()})),
             Some(Ids::d),
             None,
             None,
@@ -579,7 +579,7 @@ mod test {
         v.append(&mut saider4.raw[1..].to_vec());
         saider4.raw = v;
         assert!(!saider4
-            .verify(&data!({"d":&saider.qb64().unwrap()}), None, None, None, None, None)
+            .verify(&dat!({"d":&saider.qb64().unwrap()}), None, None, None, None, None)
             .unwrap());
     }
 
@@ -589,7 +589,7 @@ mod test {
 
         assert!(Saider::new(None, None, None, None, None, Some(&[]), None, None, None).is_err());
         assert!(Saider::new(
-            Some(&data!({})),
+            Some(&dat!({})),
             Some(Ids::d),
             None,
             None,
@@ -601,7 +601,7 @@ mod test {
         )
         .is_err());
         assert!(Saider::new(
-            Some(&data!({"d":true})),
+            Some(&dat!({"d":true})),
             Some(Ids::d),
             None,
             None,
@@ -614,8 +614,8 @@ mod test {
         .is_err());
         assert!(Saider::new(None, None, None, None, None, None, None, None, None).is_err());
         assert!(!Saider { code: "CESR".to_string(), raw: vec![], size: 0 }
-            .verify(&data!({}), None, None, None, None, None)
+            .verify(&dat!({}), None, None, None, None, None)
             .unwrap());
-        assert!(Saider::saidify(&data!({}), None, None, None, None).is_err());
+        assert!(Saider::saidify(&dat!({}), None, None, None, None).is_err());
     }
 }

--- a/src/core/salter.rs
+++ b/src/core/salter.rs
@@ -333,9 +333,9 @@ mod test {
 
             let serder = incept(
                 &ckeys,
-                Some(&data!(2)),
+                Some(&dat!(2)),
                 Some(&ndigs),
-                Some(&data!(3)),
+                Some(&dat!(3)),
                 Some(4),
                 Some(&wkeys),
                 None,
@@ -454,7 +454,7 @@ mod test {
 
         let sner = Number::new_with_num(sn)?;
 
-        let ked = data!({
+        let ked = dat!({
             "v": &vs,
             "t": ilk,
             "d": said,

--- a/src/core/serder.rs
+++ b/src/core/serder.rs
@@ -9,7 +9,7 @@ use crate::{
         tholder::Tholder,
         verfer::Verfer,
     },
-    data::{data, Value},
+    data::{dat, Value},
     error::{err, Error, Result},
 };
 
@@ -193,7 +193,7 @@ impl Default for Serder {
         Serder {
             code: matter::Codex::Blake3_256.to_string(),
             raw: vec![],
-            ked: data!({}),
+            ked: dat!({}),
             ident: Identage::KERI.to_string(),
             kind: Serialage::JSON.to_string(),
             size: 0,
@@ -285,7 +285,7 @@ pub(crate) mod test {
             serder::Serder,
             tholder::Tholder,
         },
-        data::{Data, Value},
+        data::Value,
         error::{err, Error, Result},
     };
 
@@ -294,7 +294,7 @@ pub(crate) mod test {
         assert!(Serder::new(None, None, None, None, None).is_err());
 
         let _vs = "KERI10JSON000000_";
-        let e1 = data!({
+        let e1 = dat!({
             "v": _vs,
             "d": "",
             "i": "ABCDEFG",
@@ -322,7 +322,7 @@ pub(crate) mod test {
         let vs = versify(None, None, Some(Serialage::JSON), Some(e1s.len() as u32)).unwrap();
         assert_eq!(vs, "KERI10JSON00006f_");
         let label = Ids::v;
-        e1[label] = data!(&vs);
+        e1[label] = dat!(&vs);
         let pretty = serder.pretty(None).unwrap();
         // this next one indents by 2, unlike KERIpy
         assert_eq!(
@@ -353,7 +353,7 @@ pub(crate) mod test {
         let mut e1sb_extra = e1sb.to_vec();
         e1sb_extra.append(&mut b"extra attached at the end".to_vec());
 
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON00006a_",
             "d": "HAg9_-rPd8oga-oyPghCEIlJZHKbYXcP86LQl0Yg2AvA",
             "i": "ABCDEFG",
@@ -368,7 +368,7 @@ pub(crate) mod test {
         assert_eq!(srdr.ked(), ked);
         assert_eq!(srdr.saider().code(), matter::Codex::SHA3_256);
 
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON00006a_",
             "d": "EADZ055vgh5utgSY3OOL1lW0m1pJ1W0Ia6-SVuGa0OqE",
             "i": "ABCDEFG",
@@ -441,7 +441,7 @@ pub(crate) mod test {
 
     #[test]
     fn creation() {
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON00011c_",
             "t": "rep",
             "d": "EBAjyPZ8Ed4XXl5cVZhqAy7SuaGivQp0WqQKVXvg7oqd",
@@ -460,7 +460,7 @@ pub(crate) mod test {
         assert_eq!(srdr.said().unwrap(), "EBAjyPZ8Ed4XXl5cVZhqAy7SuaGivQp0WqQKVXvg7oqd");
         assert_eq!(srdr.saidb().unwrap(), b"EBAjyPZ8Ed4XXl5cVZhqAy7SuaGivQp0WqQKVXvg7oqd");
 
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON000000_",
             "t": "icp",
             "d": "",
@@ -477,8 +477,8 @@ pub(crate) mod test {
 
         let (_, mut ked) = Saider::saidify(&ked, None, None, None, None).unwrap();
         let srdr = Serder::new(None, None, None, Some(&ked), None).unwrap();
-        assert_eq!(srdr.tholder().unwrap().unwrap().sith().unwrap(), data!("1"));
-        assert_eq!(srdr.tholder().unwrap().unwrap().thold(), data!(1));
+        assert_eq!(srdr.tholder().unwrap().unwrap().sith().unwrap(), dat!("1"));
+        assert_eq!(srdr.tholder().unwrap().unwrap().thold(), dat!(1));
         assert_eq!(srdr.sn().unwrap(), 0);
         assert_eq!(srdr.sner().unwrap().num().unwrap(), 0);
 
@@ -487,15 +487,15 @@ pub(crate) mod test {
         assert!(srdr._fn().is_err());
         assert_eq!(srdr.digers().unwrap().len(), 0);
 
-        ked["s"] = data!("-1");
+        ked["s"] = dat!("-1");
         let srdr = Serder::new(None, None, None, Some(&ked), None).unwrap();
         assert!(srdr.sn().is_err());
 
-        ked["s"] = data!("15.34");
+        ked["s"] = dat!("15.34");
         let srdr = Serder::new(None, None, None, Some(&ked), None).unwrap();
         assert!(srdr.sn().is_err());
 
-        let ked = data!({
+        let ked = dat!({
             "v": "KERI10JSON000000_",
             "t": "icp",
             "d": "",
@@ -514,18 +514,18 @@ pub(crate) mod test {
 
         let (_, ked) = Saider::saidify(&ked, None, None, None, None).unwrap();
         let srdr = Serder::new(None, None, None, Some(&ked), None).unwrap();
-        assert_eq!(srdr.tholder().unwrap().unwrap().sith().unwrap(), data!("1"));
-        assert_eq!(srdr.tholder().unwrap().unwrap().thold(), data!(1));
+        assert_eq!(srdr.tholder().unwrap().unwrap().sith().unwrap(), dat!("1"));
+        assert_eq!(srdr.tholder().unwrap().unwrap().thold(), dat!(1));
         assert_eq!(srdr.sn().unwrap(), 0);
         assert_eq!(srdr.sner().unwrap().num().unwrap(), 0);
 
-        assert_eq!(srdr.ntholder().unwrap().unwrap().sith().unwrap(), data!("1"));
-        assert_eq!(srdr.ntholder().unwrap().unwrap().thold(), data!(1));
+        assert_eq!(srdr.ntholder().unwrap().unwrap().sith().unwrap(), dat!("1"));
+        assert_eq!(srdr.ntholder().unwrap().unwrap().thold(), dat!(1));
         assert!(srdr.fner().unwrap().is_some());
         assert_eq!(srdr._fn().unwrap(), 0);
         assert_eq!(srdr.digers().unwrap().len(), 1);
 
-        let ked = data!({
+        let ked = dat!({
             "v": "ACDC10JSON000000_",
             "t": "icp",
             "d": "",
@@ -588,7 +588,7 @@ pub(crate) mod test {
         } else {
             let mut s: i64 = (keys.len() as i64 + 1) / 2;
             s = if s > 1 { s } else { 1 };
-            data!(s)
+            dat!(s)
         };
 
         let tholder = Tholder::new_with_sith(&sith)?;
@@ -611,7 +611,7 @@ pub(crate) mod test {
         } else {
             let mut s: i64 = (ndigs.len() as i64 + 1) / 2;
             s = if s > 0 { s } else { 0 };
-            data!(s)
+            dat!(s)
         };
 
         let ntholder = Tholder::new_with_sith(&nsith)?;
@@ -657,7 +657,7 @@ pub(crate) mod test {
 
         let kt = if let Some(n) = tholder.num()? {
             if intive && n < u32::MAX {
-                data!(n)
+                dat!(n)
             } else {
                 tholder.sith()?
             }
@@ -667,7 +667,7 @@ pub(crate) mod test {
 
         let nt = if let Some(n) = ntholder.num()? {
             if intive && n < u32::MAX {
-                data!(n)
+                dat!(n)
             } else {
                 ntholder.sith()?
             }
@@ -676,17 +676,17 @@ pub(crate) mod test {
         };
 
         let toad = if intive && toader.num()? < u32::MAX as u128 {
-            data!(toader.num()? as i64)
+            dat!(toader.num()? as i64)
         } else {
-            data!(&toader.numh()?)
+            dat!(&toader.numh()?)
         };
 
-        let keys: Vec<Value> = keys.iter().map(|key| data!(*key)).collect();
-        let ndigs: Vec<Value> = ndigs.iter().map(|dig| data!(*dig)).collect();
-        let wits: Vec<Value> = wits.iter().map(|wit| data!(*wit)).collect();
-        let cnfg: Vec<Value> = cnfg.iter().map(|cfg| data!(*cfg)).collect();
+        let keys: Vec<Value> = keys.iter().map(|key| dat!(*key)).collect();
+        let ndigs: Vec<Value> = ndigs.iter().map(|dig| dat!(*dig)).collect();
+        let wits: Vec<Value> = wits.iter().map(|wit| dat!(*wit)).collect();
+        let cnfg: Vec<Value> = cnfg.iter().map(|cfg| dat!(*cfg)).collect();
 
-        let mut ked = data!({
+        let mut ked = dat!({
             "v": vs,
             "t": ilk,
             "d": "",
@@ -704,7 +704,7 @@ pub(crate) mod test {
 
         let code = if let Some(delpre) = delpre {
             let label = Ids::di;
-            ked[label] = data!(delpre);
+            ked[label] = dat!(delpre);
             Some(code.unwrap_or(matter::Codex::Blake3_256))
         } else {
             code
@@ -731,10 +731,10 @@ pub(crate) mod test {
         };
 
         let label = Ids::i;
-        ked[label] = data!(&prefixer.qb64()?);
+        ked[label] = dat!(&prefixer.qb64()?);
         let ked = if prefixer.digestive() {
             let label = Ids::d;
-            ked[label] = data!(&prefixer.qb64()?);
+            ked[label] = dat!(&prefixer.qb64()?);
             ked
         } else {
             let (_, ked) = Saider::saidify(&ked, None, None, None, None)?;

--- a/src/core/signer.rs
+++ b/src/core/signer.rs
@@ -128,16 +128,16 @@ impl Signer {
         Self::new(transferable, code, Some(raw), None, None, None)
     }
 
-    pub fn new_with_qb64b(qb64b: &[u8]) -> Result<Self> {
-        Self::new(None, None, None, Some(qb64b), None, None)
+    pub fn new_with_qb64b(qb64b: &[u8], transferable: Option<bool>) -> Result<Self> {
+        Self::new(transferable, None, None, Some(qb64b), None, None)
     }
 
-    pub fn new_with_qb64(qb64: &str) -> Result<Self> {
-        Self::new(None, None, None, None, Some(qb64), None)
+    pub fn new_with_qb64(qb64: &str, transferable: Option<bool>) -> Result<Self> {
+        Self::new(transferable, None, None, None, Some(qb64), None)
     }
 
-    pub fn new_with_qb2(qb2: &[u8]) -> Result<Self> {
-        Self::new(None, None, None, None, None, Some(qb2))
+    pub fn new_with_qb2(qb2: &[u8], transferable: Option<bool>) -> Result<Self> {
+        Self::new(transferable, None, None, None, None, Some(qb2))
     }
 
     pub fn sign_unindexed(&self, ser: &[u8]) -> Result<Cigar> {
@@ -270,9 +270,9 @@ mod test {
 
         assert!(Signer::new_with_defaults(None, None).is_ok());
         assert!(Signer::new_with_raw(&signer.raw(), None, Some(&signer.code())).is_ok());
-        assert!(Signer::new_with_qb64b(&signer.qb64b().unwrap()).is_ok());
-        assert!(Signer::new_with_qb64(&signer.qb64().unwrap()).is_ok());
-        assert!(Signer::new_with_qb2(&signer.qb2().unwrap()).is_ok());
+        assert!(Signer::new_with_qb64b(&signer.qb64b().unwrap(), None).is_ok());
+        assert!(Signer::new_with_qb64(&signer.qb64().unwrap(), None).is_ok());
+        assert!(Signer::new_with_qb2(&signer.qb2().unwrap(), None).is_ok());
     }
 
     #[test]

--- a/src/core/tholder.rs
+++ b/src/core/tholder.rs
@@ -4,7 +4,7 @@ use crate::{
         matter::{tables as matter, Matter},
         number::{tables as number, Number},
     },
-    data::{data, Array, Data, Value},
+    data::{dat, Array, Value},
     error::{err, Error, Result},
 };
 
@@ -22,7 +22,7 @@ pub struct Tholder {
 
 impl Default for Tholder {
     fn default() -> Self {
-        Tholder { thold: data!(1), weighted: false, size: 1, number: None, bexter: None }
+        Tholder { thold: dat!(1), weighted: false, size: 1, number: None, bexter: None }
     }
 }
 
@@ -36,7 +36,7 @@ fn values_to_rationals(value: &Value) -> Result<Vec<Vec<Rational32>>> {
         let _clause = _clause.to_vec()?;
         for weight in _clause {
             let weight = weight.to_string()?;
-            let parts: Vec<&str> = weight.split(separator).into_iter().collect();
+            let parts: Vec<&str> = weight.split(separator).collect();
             if parts.len() != 2 {
                 // must be 0 or 1
                 if parts[0] == "0" {
@@ -185,7 +185,7 @@ impl Tholder {
         } else {
             let thold = self.thold().to_i64()?;
             let sith = format!("{thold:x}");
-            Ok(data!(&sith))
+            Ok(dat!(&sith))
         }
     }
 
@@ -275,17 +275,17 @@ impl Tholder {
         } else if bexter::Codex::has_code(code) {
             let bexter = Bexter::new(None, None, None, None, Some(&limen), None)?;
             let t = bexter.bext()?.replace('s', "/");
-            let clauses: Vec<&str> = t.split('a').into_iter().collect();
+            let clauses: Vec<&str> = t.split('a').collect();
             let mut oclauses: Array = Vec::new();
             for clause in clauses {
-                let weights: Vec<&str> = clause.split('c').into_iter().collect();
+                let weights: Vec<&str> = clause.split('c').collect();
                 let mut oweights: Array = Vec::new();
                 for weight in weights {
-                    oweights.push(data!(weight));
+                    oweights.push(dat!(weight));
                 }
-                oclauses.push(data!(oweights.as_slice()));
+                oclauses.push(dat!(oweights.as_slice()));
             }
-            let thold = data!(oclauses.as_slice());
+            let thold = dat!(oclauses.as_slice());
             self.process_weighted(&thold)?;
         } else {
             return err!(Error::UnexpectedCode(code.to_string()));
@@ -323,7 +323,7 @@ impl Tholder {
         }
 
         if !array.iter().all(|clause| clause.to_vec().is_ok()) {
-            sith = data!([sith]);
+            sith = dat!([sith]);
         }
 
         for clause in sith.to_vec()? {
@@ -353,7 +353,7 @@ impl Tholder {
 
         self.size = u32::try_from(thold)?;
         self.weighted = false;
-        self.thold = data!(self.size);
+        self.thold = dat!(self.size);
         self.number = Some(Number::new(Some(thold as u128), None, None, None, None, None, None)?);
         self.bexter = None;
 
@@ -371,15 +371,15 @@ impl Tholder {
             let mut inner: Vec<Value> = Vec::new();
             for weight in clause {
                 if *weight.denom() == 1 {
-                    inner.push(data!(&format!("{n}", n = weight.numer())));
+                    inner.push(dat!(&format!("{n}", n = weight.numer())));
                 } else {
-                    inner.push(data!(&weight.to_string()));
+                    inner.push(dat!(&weight.to_string()));
                 }
             }
-            outer.push(data!(inner.as_slice()));
+            outer.push(dat!(inner.as_slice()));
         }
 
-        self.thold = data!(outer.as_slice());
+        self.thold = dat!(outer.as_slice());
         self.weighted = true;
         self.size = size;
         self.number = None;
@@ -397,19 +397,19 @@ mod test {
 
     #[test]
     fn convenience() {
-        assert!(Tholder::new_with_thold(&data!(11)).is_ok());
+        assert!(Tholder::new_with_thold(&dat!(11)).is_ok());
         assert!(Tholder::new_with_limen(b"MAAL").is_ok());
-        assert!(Tholder::new_with_sith(&data!("b")).is_ok());
+        assert!(Tholder::new_with_sith(&dat!("b")).is_ok());
     }
 
     #[rstest]
     fn creation(
         #[values(b"MAAL")] limen: &[u8],
         #[values(
-            Tholder::new(None, None, Some(&data!("b"))).unwrap(),
-            Tholder::new(None, None, Some(&data!(11))).unwrap(),
+            Tholder::new(None, None, Some(&dat!("b"))).unwrap(),
+            Tholder::new(None, None, Some(&dat!(11))).unwrap(),
             Tholder::new(None, Some(limen), None).unwrap(),
-            Tholder::new(Some(&data!(11)), None, None).unwrap(),
+            Tholder::new(Some(&dat!(11)), None, None).unwrap(),
         )]
         tholder: Tholder,
     ) {
@@ -417,7 +417,7 @@ mod test {
         assert_eq!(tholder.size(), 11);
         assert_eq!(tholder.thold().to_i64().unwrap(), 11);
         assert_eq!(tholder.limen().unwrap(), limen);
-        assert_eq!(tholder.sith().unwrap(), data!("b"));
+        assert_eq!(tholder.sith().unwrap(), dat!("b"));
         assert_eq!(tholder.to_json().unwrap(), "\"b\"");
         assert_eq!(tholder.num().unwrap().unwrap(), 11);
         assert!(!tholder.satisfy(&[0, 1, 2]).unwrap());
@@ -428,83 +428,83 @@ mod test {
     fn python_interop() {
         assert!(Tholder::new(None, None, None).is_err());
 
-        assert!(Tholder::new(None, None, Some(&data!("[[\"1/2\",\"4/4\"]]"))).is_ok());
-        assert!(Tholder::new(None, None, Some(&data!("[[\"1/2\",\"-3/4\"]]"))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!("[[\"1/2\",\"4/4\"]]"))).is_ok());
+        assert!(Tholder::new(None, None, Some(&dat!("[[\"1/2\",\"-3/4\"]]"))).is_err());
         assert!(!Tholder::default().satisfy(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap());
-        assert!(Tholder::new(None, None, Some(&data!("[[\"1/2\",\"3/4\"]]"))).is_ok());
-        assert!(Tholder::new(None, Some(&[]), Some(&data!("[[\"1/2\",\"3/4\"]]"))).is_ok());
+        assert!(Tholder::new(None, None, Some(&dat!("[[\"1/2\",\"3/4\"]]"))).is_ok());
+        assert!(Tholder::new(None, Some(&[]), Some(&dat!("[[\"1/2\",\"3/4\"]]"))).is_ok());
         assert!(Tholder::new(None, Some(b"DKxy2sgzfplyr-tgwIxS19f2OchFHtLwPWD3v4oYimBx"), None)
             .is_err());
 
-        let tholder = Tholder::new(None, None, Some(&data!("f"))).unwrap();
+        let tholder = Tholder::new(None, None, Some(&dat!("f"))).unwrap();
         assert!(!tholder.weighted());
         assert_eq!(tholder.size(), 15);
         assert_eq!(tholder.thold().to_i64().unwrap(), 15);
         assert_eq!(tholder.limen().unwrap(), b"MAAP");
-        assert_eq!(tholder.sith().unwrap(), data!("f"));
+        assert_eq!(tholder.sith().unwrap(), dat!("f"));
         assert_eq!(tholder.to_json().unwrap(), "\"f\"");
         assert_eq!(tholder.num().unwrap().unwrap(), 15);
         assert!(!tholder.satisfy(&[0, 1, 2]).unwrap());
         assert!(tholder.satisfy(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]).unwrap());
 
-        let tholder = Tholder::new(None, None, Some(&data!(2))).unwrap();
+        let tholder = Tholder::new(None, None, Some(&dat!(2))).unwrap();
         assert!(!tholder.weighted());
         assert_eq!(tholder.size(), 2);
         assert_eq!(tholder.thold().to_i64().unwrap(), 2);
         assert_eq!(tholder.limen().unwrap(), b"MAAC");
-        assert_eq!(tholder.sith().unwrap(), data!("2"));
+        assert_eq!(tholder.sith().unwrap(), dat!("2"));
         assert_eq!(tholder.to_json().unwrap(), "\"2\"");
         assert_eq!(tholder.num().unwrap().unwrap(), 2);
         assert!(tholder.satisfy(&[0, 1, 2]).unwrap());
         assert!(tholder.satisfy(&[0, 1]).unwrap());
 
-        let tholder = Tholder::new(None, None, Some(&data!(1))).unwrap();
+        let tholder = Tholder::new(None, None, Some(&dat!(1))).unwrap();
         assert!(!tholder.weighted());
         assert_eq!(tholder.size(), 1);
         assert_eq!(tholder.thold().to_i64().unwrap(), 1);
         assert_eq!(tholder.limen().unwrap(), b"MAAB");
-        assert_eq!(tholder.sith().unwrap(), data!("1"));
+        assert_eq!(tholder.sith().unwrap(), dat!("1"));
         assert_eq!(tholder.to_json().unwrap(), "\"1\"");
         assert_eq!(tholder.num().unwrap().unwrap(), 1);
         assert!(tholder.satisfy(&[0]).unwrap());
 
-        assert!(Tholder::new(None, None, Some(&data!(-1))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(-1))).is_err());
 
-        assert!(Tholder::new(None, None, Some(&data!([1]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([2]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(["2"]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([0.5, 0.5]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(["0.5", "0.5"]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(1.0))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!("1.0"))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(0.5))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!("0.5"))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!("1.0/2.0"))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(["1/3", "1/2", []]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(["1/3", "1/2"]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([[], []]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([["1/3", "1/2",], ["1"]]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([["1/3", "1/2"], []]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2"], [[], "1"]]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2", "3/2"]]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(["1/2", "1/2", "3/2"]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(["1/2", "1/2", "2/1"]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(["1/2", "1/2", "2"]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2", "2"]]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2"], "1"]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2"], 1]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!([["1/2", "1/2"], "1.0"]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(["1/2", "1/2", []]))).is_err());
-        assert!(Tholder::new(None, None, Some(&data!(["1/2", 0.5]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([1]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([2]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(["2"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([0.5, 0.5]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(["0.5", "0.5"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(1.0))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!("1.0"))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(0.5))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!("0.5"))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!("1.0/2.0"))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(["1/3", "1/2", []]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(["1/3", "1/2"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([[], []]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([["1/3", "1/2",], ["1"]]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([["1/3", "1/2"], []]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([["1/2", "1/2"], [[], "1"]]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([["1/2", "1/2", "3/2"]]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(["1/2", "1/2", "3/2"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(["1/2", "1/2", "2/1"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(["1/2", "1/2", "2"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([["1/2", "1/2", "2"]]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([["1/2", "1/2"], "1"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([["1/2", "1/2"], 1]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!([["1/2", "1/2"], "1.0"]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(["1/2", "1/2", []]))).is_err());
+        assert!(Tholder::new(None, None, Some(&dat!(["1/2", 0.5]))).is_err());
 
         let tholder =
-            Tholder::new(None, None, Some(&data!(["1/2", "1/2", "1/4", "1/4", "1/4"]))).unwrap();
+            Tholder::new(None, None, Some(&dat!(["1/2", "1/2", "1/4", "1/4", "1/4"]))).unwrap();
         assert!(tholder.weighted());
         assert_eq!(tholder.size(), 5);
-        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"]]));
+        assert_eq!(tholder.thold(), dat!([["1/2", "1/2", "1/4", "1/4", "1/4"]]));
         assert_eq!(tholder.limen().unwrap(), b"4AAFA1s2c1s2c1s4c1s4c1s4");
-        assert_eq!(tholder.sith().unwrap(), data!(["1/2", "1/2", "1/4", "1/4", "1/4"]));
+        assert_eq!(tholder.sith().unwrap(), dat!(["1/2", "1/2", "1/4", "1/4", "1/4"]));
         assert_eq!(tholder.to_json().unwrap(), "[\"1/2\",\"1/2\",\"1/4\",\"1/4\",\"1/4\"]"); // this isn't identical to KERIpy but still conforms to JSON
         assert_eq!(tholder.num().unwrap(), None);
         assert!(tholder.satisfy(&[0, 2, 4]).unwrap());
@@ -518,13 +518,13 @@ mod test {
         assert!(!tholder.satisfy(&[0, 0, 2]).unwrap());
 
         let tholder =
-            Tholder::new(None, None, Some(&data!(["1/2", "1/2", "1/4", "1/4", "1/4", "0"])))
+            Tholder::new(None, None, Some(&dat!(["1/2", "1/2", "1/4", "1/4", "1/4", "0"])))
                 .unwrap();
         assert!(tholder.weighted());
         assert_eq!(tholder.size(), 6);
-        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4", "0"]]));
+        assert_eq!(tholder.thold(), dat!([["1/2", "1/2", "1/4", "1/4", "1/4", "0"]]));
         assert_eq!(tholder.limen().unwrap(), b"6AAGAAA1s2c1s2c1s4c1s4c1s4c0");
-        assert_eq!(tholder.sith().unwrap(), data!(["1/2", "1/2", "1/4", "1/4", "1/4", "0"]));
+        assert_eq!(tholder.sith().unwrap(), dat!(["1/2", "1/2", "1/4", "1/4", "1/4", "0"]));
         assert_eq!(tholder.to_json().unwrap(), "[\"1/2\",\"1/2\",\"1/4\",\"1/4\",\"1/4\",\"0\"]");
         assert_eq!(tholder.num().unwrap(), None);
         assert!(tholder.satisfy(&[0, 2, 4]).unwrap());
@@ -537,12 +537,12 @@ mod test {
         assert!(!tholder.satisfy(&[2, 3, 4, 5]).unwrap());
 
         let tholder =
-            Tholder::new(None, None, Some(&data!([["1/2", "1/2", "1/4", "1/4", "1/4"]]))).unwrap();
+            Tholder::new(None, None, Some(&dat!([["1/2", "1/2", "1/4", "1/4", "1/4"]]))).unwrap();
         assert!(tholder.weighted());
         assert_eq!(tholder.size(), 5);
-        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"]]));
+        assert_eq!(tholder.thold(), dat!([["1/2", "1/2", "1/4", "1/4", "1/4"]]));
         assert_eq!(tholder.limen().unwrap(), b"4AAFA1s2c1s2c1s4c1s4c1s4");
-        assert_eq!(tholder.sith().unwrap(), data!(["1/2", "1/2", "1/4", "1/4", "1/4"]));
+        assert_eq!(tholder.sith().unwrap(), dat!(["1/2", "1/2", "1/4", "1/4", "1/4"]));
         assert_eq!(tholder.to_json().unwrap(), "[\"1/2\",\"1/2\",\"1/4\",\"1/4\",\"1/4\"]"); // this isn't identical to KERIpy but still conforms to JSON
         assert_eq!(tholder.num().unwrap(), None);
         assert!(tholder.satisfy(&[0, 2, 4]).unwrap());
@@ -558,16 +558,16 @@ mod test {
         let tholder = Tholder::new(
             None,
             None,
-            Some(&data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1/1", "1"]])),
+            Some(&dat!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1/1", "1"]])),
         )
         .unwrap();
         assert!(tholder.weighted());
         assert_eq!(tholder.size(), 7);
-        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]]));
+        assert_eq!(tholder.thold(), dat!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]]));
         assert_eq!(tholder.limen().unwrap(), b"4AAGA1s2c1s2c1s4c1s4c1s4a1c1");
         assert_eq!(
             tholder.sith().unwrap(),
-            data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]])
+            dat!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]])
         );
         assert_eq!(
             tholder.to_json().unwrap(),
@@ -584,11 +584,11 @@ mod test {
         let tholder = Tholder::new(None, Some(b"4AAGA1s2c1s2c1s4c1s4c1s4a1c1"), None).unwrap();
         assert!(tholder.weighted());
         assert_eq!(tholder.size(), 7);
-        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]]));
+        assert_eq!(tholder.thold(), dat!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]]));
         assert_eq!(tholder.limen().unwrap(), b"4AAGA1s2c1s2c1s4c1s4c1s4a1c1");
         assert_eq!(
             tholder.sith().unwrap(),
-            data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]])
+            dat!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]])
         );
         assert_eq!(
             tholder.to_json().unwrap(),
@@ -603,18 +603,18 @@ mod test {
         assert!(!tholder.satisfy(&[]).unwrap());
 
         let tholder = Tholder::new(
-            Some(&data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1/1", "1/1"]])),
+            Some(&dat!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1/1", "1/1"]])),
             None,
             None,
         )
         .unwrap();
         assert!(tholder.weighted());
         assert_eq!(tholder.size(), 7);
-        assert_eq!(tholder.thold(), data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]]));
+        assert_eq!(tholder.thold(), dat!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]]));
         assert_eq!(tholder.limen().unwrap(), b"4AAGA1s2c1s2c1s4c1s4c1s4a1c1");
         assert_eq!(
             tholder.sith().unwrap(),
-            data!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]])
+            dat!([["1/2", "1/2", "1/4", "1/4", "1/4"], ["1", "1"]])
         );
         assert_eq!(
             tholder.to_json().unwrap(),

--- a/src/data.rs
+++ b/src/data.rs
@@ -10,12 +10,6 @@ use serde_json::{json, Value as JsonValue};
 
 use crate::error::{err, BoxedError, Error as CESRError, Result};
 
-pub trait Data {
-    fn to_json(&self) -> Result<String>;
-    fn to_cesr(&self) -> Result<String>;
-    fn to_cesrb(&self) -> Result<Vec<u8>>;
-}
-
 pub type Array = Vec<Value>;
 pub type Object = IndexMap<String, Value>;
 
@@ -107,6 +101,35 @@ impl Value {
             _ => err!(CESRError::Conversion("cannot convert to map".to_string())),
         }
     }
+
+    pub fn to_json(&self) -> Result<String> {
+        Ok(match self {
+            Self::Null => "null".to_string(),
+            Self::Boolean(b) => json!(b).to_string(),
+            Self::Number(n) => {
+                if n.float {
+                    json!(n.f).to_string()
+                } else {
+                    json!(n.i).to_string()
+                }
+            }
+            Self::String(s) => json!(s).to_string(),
+            Self::Array(a) => {
+                let mut v = Vec::new();
+                for element in a {
+                    v.push(element.to_json()?);
+                }
+                format!("[{}]", v.join(","))
+            }
+            Self::Object(o) => {
+                let mut v = Vec::new();
+                for (key, value) in o {
+                    v.push(format!("{}:{}", json!(key), value.to_json()?));
+                }
+                format!("{{{}}}", v.join(","))
+            }
+        })
+    }
 }
 
 impl fmt::Display for Value {
@@ -164,45 +187,6 @@ impl IndexMut<&str> for Value {
             }
             _ => panic!("attempted to mutably index non-indexable Value object with string"),
         }
-    }
-}
-
-impl Data for Value {
-    fn to_json(&self) -> Result<String> {
-        Ok(match self {
-            Self::Null => "null".to_string(),
-            Self::Boolean(b) => json!(b).to_string(),
-            Self::Number(n) => {
-                if n.float {
-                    json!(n.f).to_string()
-                } else {
-                    json!(n.i).to_string()
-                }
-            }
-            Self::String(s) => json!(s).to_string(),
-            Self::Array(a) => {
-                let mut v = Vec::new();
-                for element in a {
-                    v.push(element.to_json()?);
-                }
-                format!("[{}]", v.join(","))
-            }
-            Self::Object(o) => {
-                let mut v = Vec::new();
-                for (key, value) in o {
-                    v.push(format!("{}:{}", json!(key), value.to_json()?));
-                }
-                format!("{{{}}}", v.join(","))
-            }
-        })
-    }
-
-    fn to_cesr(&self) -> Result<String> {
-        unimplemented!();
-    }
-
-    fn to_cesrb(&self) -> Result<Vec<u8>> {
-        unimplemented!();
     }
 }
 
@@ -403,14 +387,8 @@ impl TryFrom<&Value> for IndexMap<String, Value> {
     }
 }
 
-#[macro_export]
-macro_rules! data {
-    ($($data:tt)+) => {
-        data_internal!($($data)+)
-    };
-}
-
-macro_rules! data_internal {
+#[macro_export(local_inner_macros)]
+macro_rules! dat {
     // arrays
 
     // Done with trailing comma.
@@ -425,42 +403,42 @@ macro_rules! data_internal {
 
     // Next element is `null`.
     (@array [$($elems:expr,)*] null $($rest:tt)*) => {
-        data_internal!(@array [$($elems,)* data_internal!(null)] $($rest)*)
+        dat!(@array [$($elems,)* dat!(null)] $($rest)*)
     };
 
     // Next element is `true`.
     (@array [$($elems:expr,)*] true $($rest:tt)*) => {
-        data_internal!(@array [$($elems,)* data_internal!(true)] $($rest)*)
+        dat!(@array [$($elems,)* dat!(true)] $($rest)*)
     };
 
     // Next element is `false`.
     (@array [$($elems:expr,)*] false $($rest:tt)*) => {
-        data_internal!(@array [$($elems,)* data_internal!(false)] $($rest)*)
+        dat!(@array [$($elems,)* dat!(false)] $($rest)*)
     };
 
     // Next element is an array.
     (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
-        data_internal!(@array [$($elems,)* data_internal!([$($array)*])] $($rest)*)
+        dat!(@array [$($elems,)* dat!([$($array)*])] $($rest)*)
     };
 
     // Next element is a map.
     (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
-        data_internal!(@array [$($elems,)* data_internal!({$($map)*})] $($rest)*)
+        dat!(@array [$($elems,)* dat!({$($map)*})] $($rest)*)
     };
 
     // Next element is an expression followed by comma.
     (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
-        data_internal!(@array [$($elems,)* data_internal!($next),] $($rest)*)
+        dat!(@array [$($elems,)* dat!($next),] $($rest)*)
     };
 
     // Last element is an expression with no trailing comma.
     (@array [$($elems:expr,)*] $last:expr) => {
-        data_internal!(@array [$($elems,)* data_internal!($last)])
+        dat!(@array [$($elems,)* dat!($last)])
     };
 
     // Comma after the most recent element.
     (@array [$($elems:expr),*] , $($rest:tt)*) => {
-        data_internal!(@array [$($elems,)*] $($rest)*)
+        dat!(@array [$($elems,)*] $($rest)*)
     };
 
     // Unexpected token after most recent element.
@@ -476,7 +454,7 @@ macro_rules! data_internal {
     // Insert the current entry followed by trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
         let _ = $object.insert(($($key)+).into(), $value);
-        data_internal!(@object $object () ($($rest)*) ($($rest)*));
+        dat!(@object $object () ($($rest)*) ($($rest)*));
     };
 
     // Current entry followed by unexpected token.
@@ -491,50 +469,50 @@ macro_rules! data_internal {
 
     // Next value is `null`.
     (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
-        data_internal!(@object $object [$($key)+] (data_internal!(null)) $($rest)*);
+        dat!(@object $object [$($key)+] (dat!(null)) $($rest)*);
     };
 
     // Next value is `true`.
     (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
-        data_internal!(@object $object [$($key)+] (data_internal!(true)) $($rest)*);
+        dat!(@object $object [$($key)+] (dat!(true)) $($rest)*);
     };
 
     // Next value is `false`.
     (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
-        data_internal!(@object $object [$($key)+] (data_internal!(false)) $($rest)*);
+        dat!(@object $object [$($key)+] (dat!(false)) $($rest)*);
     };
 
     // Next value is an array.
     (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
-        data_internal!(@object $object [$($key)+] (data_internal!([$($array)*])) $($rest)*);
+        dat!(@object $object [$($key)+] (dat!([$($array)*])) $($rest)*);
     };
 
     // Next value is a map.
     (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
-        data_internal!(@object $object [$($key)+] (data_internal!({$($map)*})) $($rest)*);
+        dat!(@object $object [$($key)+] (dat!({$($map)*})) $($rest)*);
     };
 
     // Next value is an expression followed by comma.
     (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
-        data_internal!(@object $object [$($key)+] (data_internal!($value)) , $($rest)*);
+        dat!(@object $object [$($key)+] (dat!($value)) , $($rest)*);
     };
 
     // Last value is an expression with no trailing comma.
     (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
-        data_internal!(@object $object [$($key)+] (data_internal!($value)));
+        dat!(@object $object [$($key)+] (dat!($value)));
     };
 
     // Missing value for last entry. Trigger a reasonable error message.
     (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
         // "unexpected end of macro invocation"
-        data_internal!();
+        dat!();
     };
 
     // Missing colon and value for last entry. Trigger a reasonable error
     // message.
     (@object $object:ident ($($key:tt)+) () $copy:tt) => {
         // "unexpected end of macro invocation"
-        data_internal!();
+        dat!();
     };
 
     // Misplaced colon. Trigger a reasonable error message.
@@ -552,7 +530,7 @@ macro_rules! data_internal {
     // Key is fully parenthesized. This avoids clippy double_parens false
     // positives because the parenthesization may be necessary here.
     (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
-        data_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+        dat!(@object $object ($key) (: $($rest)*) (: $($rest)*));
     };
 
     // Refuse to absorb colon token into key expression.
@@ -562,7 +540,7 @@ macro_rules! data_internal {
 
     // Munch a token into the current key.
     (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
-        data_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+        dat!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
     };
 
     // core logic
@@ -584,7 +562,7 @@ macro_rules! data_internal {
     };
 
     ([ $($tt:tt)+ ]) => {{
-        data_internal!(@array [] $($tt)+)
+        dat!(@array [] $($tt)+)
     }};
 
     ({}) => {
@@ -593,7 +571,7 @@ macro_rules! data_internal {
 
     ({ $($tt:tt)+ }) => {{
         let mut object = $crate::data::Object::new();
-        data_internal!(@object object () ($($tt)+) ($($tt)+));
+        dat!(@object object () ($($tt)+) ($($tt)+));
         $crate::data::Value::Object(object)
     }};
 
@@ -602,25 +580,31 @@ macro_rules! data_internal {
     }
 }
 
+#[macro_export]
+#[doc(hidden)]
 macro_rules! data_internal_vec {
     ($($content:tt)*) => {{
         $crate::data::Value::Array(vec![$($content)*])
     }};
 }
 
+#[macro_export]
+#[doc(hidden)]
 macro_rules! data_unexpected {
     () => {};
 }
 
+#[macro_export]
+#[doc(hidden)]
 macro_rules! data_expect_expr_comma {
     ($e:expr , $($tt:tt)*) => {};
 }
 
-pub use data;
+pub use dat;
 
 #[cfg(test)]
 mod test {
-    use crate::data::{data, Data, Value};
+    use crate::data::{dat, Value};
     use indexmap::IndexMap;
 
     #[test]
@@ -628,7 +612,7 @@ mod test {
         let x: i64 = -1234567890;
         let s = "string".to_string();
 
-        let mut d = data!({
+        let mut d = dat!({
             "thing": 2,
             "other thing": [&s, 1.666, x, true, {"nested array": [{}, []]}],
             "last thing": null
@@ -660,8 +644,8 @@ mod test {
         );
 
         // mutability
-        d["thing"] = data!({"something more complex": {"key": 987654321 }});
-        d[1][1] = data!(true);
+        d["thing"] = dat!({"something more complex": {"key": 987654321 }});
+        d[1][1] = dat!(true);
         assert_eq!(
             d.to_json().unwrap(),
             "{\"thing\":{\"something more complex\":{\"key\":987654321}},\"other thing\":[\"string\",true,-1234567890,true,{\"nested array\":[{},[]]}],\"last thing\":null}"
@@ -675,14 +659,14 @@ mod test {
 
     #[test]
     fn value() {
-        assert!(data!({}).to_json().is_ok());
-        // assert!(data!({}).to_cesr().is_err());
-        // assert!(data!({}).to_cesrb().is_err());
+        assert!(dat!({}).to_json().is_ok());
+        // assert!(dat!({}).to_cesr().is_err());
+        // assert!(dat!({}).to_cesrb().is_err());
 
         let array: &[Value] = &[];
         let mut hash_map = std::collections::HashMap::<String, Value>::new();
-        hash_map.insert("test".to_string(), data!(true));
-        let d = data!({
+        hash_map.insert("test".to_string(), dat!(true));
+        let d = dat!({
             "f32": 0 as f32,
             "f64": 0 as f64,
             "i8": 0 as i8,
@@ -712,12 +696,12 @@ mod test {
 
     #[test]
     fn try_from() {
-        let string = data!("string");
-        let boolean = data!(false);
-        let int64 = data!(3);
-        let float64 = data!(6.7);
-        let vector = data!([]);
-        let map = data!({});
+        let string = dat!("string");
+        let boolean = dat!(false);
+        let int64 = dat!(3);
+        let float64 = dat!(6.7);
+        let vector = dat!([]);
+        let map = dat!({});
 
         assert!(String::try_from(&string).is_ok());
         assert!(String::try_from(&boolean).is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)]
 
 #[macro_use]
-mod data;
+pub mod data;
 mod core;
 mod crypto;
 mod error;
@@ -29,6 +29,5 @@ pub use crate::{
         tholder::Tholder,
         verfer::Verfer,
     },
-    data::Value,
     error::Error,
 };


### PR DESCRIPTION
## Rationale

When I tried to integrate I couldn't access inner macros. Also, the trait implementation of to_json() accomplished nothing other than to require the caller to make another import, so I moved it to the core implementation of `Value`.

## Changes

- exports macros as serde-json does
- moves implementation of to_json()
- removes unnecessary imports
- changes convenience methods in signer to accept transferable param, as it cannot be inferred from the private material
- renames `data!` macro to `dat!` so that we can expose `cesride::data` as a module and not pollute the top level namespace with irrelevant structs that are required for the macro to work in other crates
- bumps version to 0.3.0 (changed Signer convenience api)

## Testing

Integrated these changes on another computer with another library and copied them by hand. Tests passed! Then I used this remote branch and integrated again, and I seem to be able to access what I needed.

```
make fix clean preflight
```