### PR TITLE
base64 encode_slice()

### DIFF
--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -193,8 +193,10 @@ pub trait Matter: Default {
             buffer[szg.ls as usize..].clone_from_slice(&raw);
             raw.zeroize();
 
-            let b64 = b64_engine::URL_SAFE.encode(&buffer);
-
+            let mut b64_vec = Zeroizing::new(vec![0u8; buffer.len() * 4 / 3]);
+            b64_engine::URL_SAFE.encode_slice(&buffer, &mut b64_vec)?;
+            // this does a transmute of pointers under the hood so zeroizing the vec should be enough
+            let b64 = std::str::from_utf8(&b64_vec)?;
             Ok(format!("{both}{b64}"))
         } else {
             let both = code;
@@ -210,8 +212,9 @@ pub trait Matter: Default {
             buffer[ps..].clone_from_slice(&raw);
             raw.zeroize();
 
-            let b64 = b64_engine::URL_SAFE.encode(&buffer);
-
+            let mut b64_vec = Zeroizing::new(vec![0u8; buffer.len() * 4 / 3]);
+            b64_engine::URL_SAFE.encode_slice(&buffer, &mut b64_vec)?;
+            let b64 = std::str::from_utf8(&b64_vec)?;
             Ok(format!("{both}{}", &b64[cs % 4..]))
         }
     }

--- a/src/core/tholder.rs
+++ b/src/core/tholder.rs
@@ -36,7 +36,7 @@ fn values_to_rationals(value: &Value) -> Result<Vec<Vec<Rational32>>> {
         let _clause = _clause.to_vec()?;
         for weight in _clause {
             let weight = weight.to_string()?;
-            let parts: Vec<&str> = weight.split(separator).into_iter().collect();
+            let parts: Vec<&str> = weight.split(separator).collect();
             if parts.len() != 2 {
                 // must be 0 or 1
                 if parts[0] == "0" {
@@ -275,10 +275,10 @@ impl Tholder {
         } else if bexter::Codex::has_code(code) {
             let bexter = Bexter::new(None, None, None, None, Some(&limen), None)?;
             let t = bexter.bext()?.replace('s', "/");
-            let clauses: Vec<&str> = t.split('a').into_iter().collect();
+            let clauses: Vec<&str> = t.split('a').collect();
             let mut oclauses: Array = Vec::new();
             for clause in clauses {
-                let weights: Vec<&str> = clause.split('c').into_iter().collect();
+                let weights: Vec<&str> = clause.split('c').collect();
                 let mut oweights: Array = Vec::new();
                 for weight in weights {
                     oweights.push(data!(weight));


### PR DESCRIPTION
## Rationale

This PR addresses #129. I think it only really matters in `Matter`, since that's what Signer and Salter are based upon. If we think it makes sense we can change throughout the library to be consistent with preallocation, but we won't need the zeroization code so it won't look exactly the same anyway.

## Changes

Uses zeroizing, preallocated vecs and `encode_slice()` to do minimal allocations and clear sensitive memory.

## Testing

```
make fix clean preflight
```