### PR TITLE
anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["cesr", "keri", "acdc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "~1"
 argon2 = "~0.5"
 base64 = "~0.21"
 blake2 = "~0.10"

--- a/src/core/indexer/tables.rs
+++ b/src/core/indexer/tables.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, Result};
+use crate::error::{err, Error, Result};
 /// Codex is codex hard (stable) part of all indexer derivation codes.
 ///
 /// Codes indicate which list of keys, current and/or prior next, index is for:
@@ -131,7 +131,7 @@ pub(crate) fn sizage(s: &str) -> Result<Sizage> {
         "0z" => Sizage { hs: 2, ss: 2, os: 0, fs: u32::MAX, ls: 0 },
         "1z" => Sizage { hs: 2, ss: 2, os: 1, fs: 76, ls: 1 },
         "4z" => Sizage { hs: 2, ss: 6, os: 3, fs: 80, ls: 1 },
-        _ => return Err(Box::new(Error::UnknownSizage(s.to_string()))),
+        _ => return err!(Error::UnknownSizage(s.to_string())),
     })
 }
 
@@ -139,9 +139,9 @@ pub(crate) fn hardage(c: char) -> Result<u32> {
     match c {
         'A'..='Z' | 'a'..='z' => Ok(1),
         '0'..='4' => Ok(2),
-        '-' => Err(Box::new(Error::UnexpectedCode("count code start".to_owned()))),
-        '_' => Err(Box::new(Error::UnexpectedCode("op code start".to_owned()))),
-        _ => Err(Box::new(Error::UnknownHardage(c.to_string()))),
+        '-' => err!(Error::UnexpectedCode("count code start".to_owned())),
+        '_' => err!(Error::UnexpectedCode("op code start".to_owned())),
+        _ => err!(Error::UnknownHardage(c.to_string())),
     }
 }
 
@@ -149,9 +149,9 @@ pub(crate) fn bardage(b: u8) -> Result<u32> {
     match b {
         b'\x00'..=b'\x33' => Ok(1),
         b'\x34'..=b'\x38' => Ok(2),
-        b'\x3e' => Err(Box::new(Error::UnexpectedCode("count code start".to_owned()))),
-        b'\x3f' => Err(Box::new(Error::UnexpectedCode("op code start".to_owned()))),
-        _ => Err(Box::new(Error::UnknownBardage(b.to_string()))),
+        b'\x3e' => err!(Error::UnexpectedCode("count code start".to_owned())),
+        b'\x3f' => err!(Error::UnexpectedCode("op code start".to_owned())),
+        _ => err!(Error::UnknownBardage(b.to_string())),
     }
 }
 

--- a/src/core/tholder.rs
+++ b/src/core/tholder.rs
@@ -194,13 +194,13 @@ impl Tholder {
     }
 
     pub fn satisfy(&self, indices: &[u32]) -> Result<bool> {
-        return if self.number().is_some() {
+        if self.number().is_some() {
             self.satisfy_numeric(indices)
         } else if self.bexter().is_some() {
             self.satisfy_weighted(indices)
         } else {
             Ok(false)
-        };
+        }
     }
 
     fn satisfy_numeric(&self, indices: &[u32]) -> Result<bool> {

--- a/src/data.rs
+++ b/src/data.rs
@@ -8,7 +8,7 @@ use std::ops::{Index, IndexMut};
 use indexmap::IndexMap;
 use serde_json::{json, Value as JsonValue};
 
-use crate::error::{err, BoxedError, Error as CESRError, Result};
+use crate::error::{err, Error as CESRError, Result};
 
 pub type Array = Vec<Value>;
 pub type Object = IndexMap<String, Value>;
@@ -310,7 +310,7 @@ impl From<&JsonValue> for Value {
 }
 
 impl TryFrom<&Value> for String {
-    type Error = BoxedError;
+    type Error = anyhow::Error;
 
     fn try_from(v: &Value) -> Result<Self> {
         match v {
@@ -321,7 +321,7 @@ impl TryFrom<&Value> for String {
 }
 
 impl TryFrom<&Value> for bool {
-    type Error = BoxedError;
+    type Error = anyhow::Error;
 
     fn try_from(v: &Value) -> Result<Self> {
         match v {
@@ -332,7 +332,7 @@ impl TryFrom<&Value> for bool {
 }
 
 impl TryFrom<&Value> for i64 {
-    type Error = BoxedError;
+    type Error = anyhow::Error;
 
     fn try_from(v: &Value) -> Result<Self> {
         match v {
@@ -349,7 +349,7 @@ impl TryFrom<&Value> for i64 {
 }
 
 impl TryFrom<&Value> for f64 {
-    type Error = BoxedError;
+    type Error = anyhow::Error;
 
     fn try_from(v: &Value) -> Result<Self> {
         match v {
@@ -366,7 +366,7 @@ impl TryFrom<&Value> for f64 {
 }
 
 impl TryFrom<&Value> for Vec<Value> {
-    type Error = BoxedError;
+    type Error = anyhow::Error;
 
     fn try_from(v: &Value) -> Result<Self> {
         match v {
@@ -377,7 +377,7 @@ impl TryFrom<&Value> for Vec<Value> {
 }
 
 impl TryFrom<&Value> for IndexMap<String, Value> {
-    type Error = BoxedError;
+    type Error = anyhow::Error;
 
     fn try_from(v: &Value) -> Result<Self> {
         match v {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
-pub type BoxedError = Box<dyn std::error::Error>;
-pub type Result<T> = core::result::Result<T, BoxedError>;
+pub type Result<T> = anyhow::Result<T>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -71,7 +70,7 @@ pub enum Error {
 
 macro_rules! err {
     ($e:expr) => {
-        Err(Box::new($e))
+        Err($e.into())
     };
 }
 


### PR DESCRIPTION
## Rationale

This makes it easier to consume errors from our library.

We likely want to eventually wrap all errors with our own to provide a consistent interface.

## Screenshots (attempted integration)

<img width="890" alt="Screenshot 2023-03-14 at 8 15 16 AM" src="https://user-images.githubusercontent.com/685385/224985657-827d4a62-f03d-4a78-8bd8-d26cafdbd39c.png">

## Changes

Removes boxed errors and introduces `anyhow` for similar functionality.

## Testing

Integrated with another library, and also:

```
make fix clean preflight
```
