### PR TITLE
visibility updates and convenience methods

### DIFF
--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -5,50 +5,50 @@ use lazy_static::lazy_static;
 use regex::Regex;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct SizeifyResult {
-    pub(crate) raw: Vec<u8>,
-    pub(crate) ident: String,
-    pub(crate) kind: String,
-    pub(crate) ked: Value,
-    pub(crate) version: Version,
+pub struct SizeifyResult {
+    pub raw: Vec<u8>,
+    pub ident: String,
+    pub kind: String,
+    pub ked: Value,
+    pub version: Version,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct DeversifyResult {
-    pub(crate) ident: String,
-    pub(crate) kind: String,
-    pub(crate) version: Version,
-    pub(crate) size: u32,
+pub struct DeversifyResult {
+    pub ident: String,
+    pub kind: String,
+    pub version: Version,
+    pub size: u32,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct SniffResult {
-    pub(crate) ident: String,
-    pub(crate) kind: String,
-    pub(crate) version: Version,
-    pub(crate) size: u32,
+pub struct SniffResult {
+    pub ident: String,
+    pub kind: String,
+    pub version: Version,
+    pub size: u32,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Version {
-    pub(crate) major: u8,
-    pub(crate) minor: u8,
+    pub major: u8,
+    pub minor: u8,
 }
 
 #[allow(non_snake_case)]
-pub(crate) mod Serialage {
+pub mod Serialage {
     pub const JSON: &str = "JSON";
 }
 
 #[allow(non_snake_case)]
-pub(crate) mod Identage {
+pub mod Identage {
     pub const ACDC: &str = "ACDC";
     pub const KERI: &str = "KERI";
 }
 
 #[allow(non_snake_case)]
 #[allow(non_upper_case_globals)]
-pub(crate) mod Ilkage {
+pub mod Ilkage {
     pub const icp: &str = "icp";
     pub const rot: &str = "rot";
     pub const ixn: &str = "ixn";
@@ -80,7 +80,7 @@ pub mod Tierage {
 
 #[allow(non_snake_case)]
 #[allow(non_upper_case_globals)]
-pub(crate) mod Ids {
+pub mod Ids {
     pub const dollar: &str = "$id";
     pub const at: &str = "@id";
     pub const id: &str = "id";
@@ -131,7 +131,7 @@ const MAXIMUM_START_SIZE: usize = 12;
 pub(crate) const VERSION_FULL_SIZE: usize = 17;
 pub(crate) const MINIMUM_SNIFF_SIZE: usize = MAXIMUM_START_SIZE + VERSION_FULL_SIZE;
 
-pub(crate) fn deversify(vs: &str) -> Result<DeversifyResult> {
+pub fn deversify(vs: &str) -> Result<DeversifyResult> {
     lazy_static! {
         static ref REVER: Regex = Regex::new(REVER_STRING).unwrap();
     };
@@ -157,7 +157,7 @@ pub(crate) fn deversify(vs: &str) -> Result<DeversifyResult> {
     err!(Error::Validation(format!("invalid version string {vs}")))
 }
 
-pub(crate) fn sizeify(ked: &Value, kind: Option<&str>) -> Result<SizeifyResult> {
+pub fn sizeify(ked: &Value, kind: Option<&str>) -> Result<SizeifyResult> {
     lazy_static! {
         static ref REVER: Regex = Regex::new(REVER_STRING).unwrap();
     };
@@ -214,7 +214,7 @@ pub(crate) fn sizeify(ked: &Value, kind: Option<&str>) -> Result<SizeifyResult> 
     Ok(SizeifyResult { raw, ident: result.ident, kind, ked, version: result.version })
 }
 
-pub(crate) fn versify(
+pub fn versify(
     ident: Option<&str>,
     version: Option<&Version>,
     kind: Option<&str>,
@@ -271,7 +271,7 @@ pub(crate) fn dumps(ked: &Value, kind: Option<&str>) -> Result<Vec<u8>> {
     }
 }
 
-pub(crate) fn sniff(raw: &[u8]) -> Result<SniffResult> {
+pub fn sniff(raw: &[u8]) -> Result<SniffResult> {
     lazy_static! {
         static ref REVER: Regex = Regex::new(REVER_STRING).unwrap();
     };

--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -800,4 +800,28 @@ mod test {
         let matter = TestMatter::new(None, None, None, Some(qb64), None).unwrap();
         assert_eq!(matter.full_size().unwrap(), size);
     }
+
+    #[rstest]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::Blake3_256, b"00000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::Blake3_512, b"0000000000000000000000000000000000000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::Blake2b_256, b"00000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::Blake2b_512, b"0000000000000000000000000000000000000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::Blake2s_256, b"00000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::SHA3_256, b"00000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::SHA3_512, b"0000000000000000000000000000000000000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::SHA2_256, b"00000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::SHA2_512, b"0000000000000000000000000000000000000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::Ed25519, b"00000000000000000000000000000000").unwrap(), false)]
+    fn digestive(#[case] matter: TestMatter, #[case] result: bool) {
+        assert_eq!(matter.digestive(), result);
+    }
+
+    #[rstest]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::Ed25519, b"00000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::ECDSA_256k1, b"000000000000000000000000000000000").unwrap(), true)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::Ed25519N, b"00000000000000000000000000000000").unwrap(), false)]
+    #[case(TestMatter::new_with_code_and_raw(matter::Codex::ECDSA_256k1N, b"000000000000000000000000000000000").unwrap(), false)]
+    fn transferable(#[case] matter: TestMatter, #[case] result: bool) {
+        assert_eq!(matter.transferable(), result);
+    }
 }

--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -171,11 +171,8 @@ pub trait Matter: Default {
     }
 
     fn transferable(&self) -> bool {
-        const CODES: &[&str] = &[
-            tables::Codex::Ed25519N,
-            tables::Codex::ECDSA_256k1N,
-            tables::Codex::Ed448N
-        ];
+        const CODES: &[&str] =
+            &[tables::Codex::Ed25519N, tables::Codex::ECDSA_256k1N, tables::Codex::Ed448N];
 
         !CODES.contains(&self.code().as_str())
     }

--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -154,6 +154,32 @@ pub trait Matter: Default {
         self.binfil()
     }
 
+    fn digestive(&self) -> bool {
+        const CODES: &[&str] = &[
+            tables::Codex::Blake3_256,
+            tables::Codex::Blake3_512,
+            tables::Codex::Blake2b_256,
+            tables::Codex::Blake2b_512,
+            tables::Codex::Blake2s_256,
+            tables::Codex::SHA3_256,
+            tables::Codex::SHA3_512,
+            tables::Codex::SHA2_256,
+            tables::Codex::SHA2_512,
+        ];
+
+        CODES.contains(&self.code().as_str())
+    }
+
+    fn transferable(&self) -> bool {
+        const CODES: &[&str] = &[
+            tables::Codex::Ed25519N,
+            tables::Codex::ECDSA_256k1N,
+            tables::Codex::Ed448N
+        ];
+
+        !CODES.contains(&self.code().as_str())
+    }
+
     fn infil(&self) -> Result<String> {
         let code = &self.code();
         let size = self.size();

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -148,6 +148,19 @@ pub mod Codex {
     pub const Bytes_Big_L2: &str = "9AAB"; // Byte String Big Leader Size 2
 }
 
+#[allow(non_snake_case)]
+#[allow(non_upper_case_globals)]
+pub mod NonTransCodex {
+    pub const Ed25519N: &str = "B"; // Ed25519 verification key non-transferable, basic derivation.
+    pub const ECDSA_256k1N: &str = "1AAA"; // ECDSA secp256k1 verification key non-transferable, basic derivation.
+    pub const Ed448N: &str = "1AAC"; // Ed448 non-transferable prefix public signing verification key. Basic derivation.
+
+    pub fn has_code(code: &str) -> bool {
+        const CODES: &[&str] = &[Ed25519N, ECDSA_256k1N, Ed448N];
+        CODES.contains(&code)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::core::matter::tables::{self as matter, Codex};

--- a/src/core/matter/tables.rs
+++ b/src/core/matter/tables.rs
@@ -148,19 +148,6 @@ pub mod Codex {
     pub const Bytes_Big_L2: &str = "9AAB"; // Byte String Big Leader Size 2
 }
 
-#[allow(non_snake_case)]
-#[allow(non_upper_case_globals)]
-pub mod NonTransCodex {
-    pub const Ed25519N: &str = "B"; // Ed25519 verification key non-transferable, basic derivation.
-    pub const ECDSA_256k1N: &str = "1AAA"; // ECDSA secp256k1 verification key non-transferable, basic derivation.
-    pub const Ed448N: &str = "1AAC"; // Ed448 non-transferable prefix public signing verification key. Basic derivation.
-
-    pub fn has_code(code: &str) -> bool {
-        const CODES: &[&str] = &[Ed25519N, ECDSA_256k1N, Ed448N];
-        CODES.contains(&code)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use crate::core::matter::tables::{self as matter, Codex};

--- a/src/core/prefixer.rs
+++ b/src/core/prefixer.rs
@@ -354,22 +354,6 @@ impl Prefixer {
             _ => err!(Error::UnexpectedCode(self.code())),
         }
     }
-
-    pub fn digestive(&self) -> bool {
-        const CODES: &[&str] = &[
-            matter::Codex::Blake3_256,
-            matter::Codex::Blake3_512,
-            matter::Codex::Blake2b_256,
-            matter::Codex::Blake2b_512,
-            matter::Codex::Blake2s_256,
-            matter::Codex::SHA3_256,
-            matter::Codex::SHA3_512,
-            matter::Codex::SHA2_256,
-            matter::Codex::SHA2_512,
-        ];
-
-        CODES.contains(&self.code().as_str())
-    }
 }
 
 impl Matter for Prefixer {

--- a/src/core/serder.rs
+++ b/src/core/serder.rs
@@ -167,16 +167,16 @@ impl Serder {
         }
     }
 
-    fn pre(&self) -> Result<String> {
+    pub fn pre(&self) -> Result<String> {
         let label = Ids::i;
         self.ked[label].to_string()
     }
 
-    fn preb(&self) -> Result<Vec<u8>> {
+    pub fn preb(&self) -> Result<Vec<u8>> {
         Ok(self.pre()?.as_bytes().to_vec())
     }
 
-    fn est(&self) -> Result<bool> {
+    pub fn est(&self) -> Result<bool> {
         const ILKS: &[&str] = &[Ilkage::icp, Ilkage::rot, Ilkage::dip, Ilkage::drt];
 
         let label = Ids::t;


### PR DESCRIPTION
## Rationale

Found all this when I implemented inception and rotation outside the library.

## Changes

- updates visibility for things in common so they are usable outside the crate
- adds convenience methods `digestive()` and `transferable()` to `Matter`
- updates visibility of some `Serder` methods (like `pre()` which is a pretty major oversight)

## Testing

```
make fix clean preflight
```