### PR TITLE
Cleanup clippy warnings

### DIFF
--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -327,17 +327,17 @@ mod test {
     fn sniff_unhappy_paths() {
         assert!(common::sniff(&[]).is_err()); // minimum 29 octets
         assert!(common::sniff(
-            &dat!({"v":"version string must be valid!"}).to_json().unwrap().as_bytes()
+            dat!({"v":"version string must be valid!"}).to_json().unwrap().as_bytes()
         )
         .is_err());
         assert!(common::sniff(
-            &dat!({"i":"needs to start within 12 characters!","v":"KERI10JSON000000_"})
+            dat!({"i":"needs to start within 12 characters!","v":"KERI10JSON000000_"})
                 .to_json()
                 .unwrap()
                 .as_bytes()
         )
         .is_err());
-        assert!(common::sniff(&dat!({"v":"KERI10ABCD000000_","confusing but necessary filler":"hmm...maybe a 12 octet magic prefix?"}).to_json().unwrap().as_bytes()).is_err());
+        assert!(common::sniff(dat!({"v":"KERI10ABCD000000_","confusing but necessary filler":"hmm...maybe a 12 octet magic prefix?"}).to_json().unwrap().as_bytes()).is_err());
         // needs to have a valid serialization kind
     }
 

--- a/src/core/counter/mod.rs
+++ b/src/core/counter/mod.rs
@@ -416,7 +416,7 @@ mod test {
     fn b64_overflow_and_underflow(#[values("-AAB")] qsc: &str) {
         // add some chars
         let longqsc64 = &format!("{qsc}ABCD");
-        let counter = Counter::new(None, None, None, None, Some(&longqsc64), None).unwrap();
+        let counter = Counter::new(None, None, None, None, Some(longqsc64), None).unwrap();
         assert_eq!(
             counter.qb64().unwrap().len() as u32,
             counter::sizage(&counter.code()).unwrap().fs

--- a/src/core/diger.rs
+++ b/src/core/diger.rs
@@ -254,7 +254,7 @@ mod test {
 
         let diger = Diger::new(None, Some(matter::Codex::Blake3_512), Some(&raw), None, None, None)
             .unwrap();
-        assert!(diger.verify(&vec![0, 1, 2]).unwrap());
+        assert!(diger.verify(&[0, 1, 2]).unwrap());
     }
 
     #[test]
@@ -281,7 +281,7 @@ mod test {
         assert!(diger.compare(&ser, Some(&matter.qb64b().unwrap()), None).unwrap());
 
         // different ser, different algorithm - should return false
-        let raw = hash::digest(code, &vec![0, 1, 2, 3]).unwrap();
+        let raw = hash::digest(code, &[0, 1, 2, 3]).unwrap();
         let matter: Diger = Matter::new(Some(code), Some(&raw), None, None, None).unwrap();
         assert!(!diger.compare(&ser, Some(&matter.qb64b().unwrap()), None).unwrap());
     }
@@ -312,7 +312,7 @@ mod test {
         assert!(diger.compare(&ser, None, Some(&d2)).unwrap());
 
         // different ser, different algorithm - should return false
-        let raw2 = hash::digest(code2, &vec![0, 1, 2, 3]).unwrap();
+        let raw2 = hash::digest(code2, &[0, 1, 2, 3]).unwrap();
         let d2 = Diger::new(None, Some(code2), Some(&raw2), None, None, None).unwrap();
         assert!(!diger.compare(&ser, None, Some(&d2)).unwrap());
     }

--- a/src/core/indexer/mod.rs
+++ b/src/core/indexer/mod.rs
@@ -770,7 +770,7 @@ mod test {
         let qsc = format!("{code}{}", util::u32_to_b64(0, 1).unwrap());
         assert_eq!(qsc, "AA");
 
-        let qsig64 = qsc + &sig64[(ps as usize)..];
+        let qsig64 = qsc + &sig64[ps..];
         assert_eq!(qsig64, "AACZ0jw5JCQwn2v7GKCMQHISMi5rsscfcA4nbY9AqqWMyG6FyCH2cZFwqezPkq8p3sr8f37Xb3wXgh3UPG8igSYJ");
         assert_eq!(qsig64.len(), 88);
 

--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -714,7 +714,7 @@ mod test {
         // raw size too large
         assert!(TestMatter::new(
             Some(matter::Codex::Bytes_Big_L2),
-            Some(&mut [0; (16777215 * 3 + 1)].to_vec()),
+            Some([0; (16777215 * 3 + 1)].as_ref()),
             None,
             None,
             None
@@ -722,7 +722,7 @@ mod test {
         .is_err());
         assert!(TestMatter::new(
             Some(matter::Codex::Bytes_L2),
-            Some(&mut [0; (16777215 * 3 + 1)].to_vec()),
+            Some([0; (16777215 * 3 + 1)].as_ref()),
             None,
             None,
             None
@@ -772,20 +772,18 @@ mod test {
             None,
             None,
             None,
-            Some(&mut vec![
+            Some(&[
                 19, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
-                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255
             ])
         )
         .is_err());
 
         // non-zeroed lead byte(s)
         assert!(TestMatter::new(None, None, None, Some("5AAB____"), None,).is_err());
-        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![228, 0, 1, 255, 255, 255]))
-            .is_err());
+        assert!(TestMatter::new(None, None, None, None, Some(&[228, 0, 1, 255, 255, 255])).is_err());
         assert!(TestMatter::new(None, None, None, Some("6AAB____"), None,).is_err());
-        assert!(TestMatter::new(None, None, None, None, Some(&mut vec![232, 0, 1, 255, 255, 255]))
-            .is_err());
+        assert!(TestMatter::new(None, None, None, None, Some(&[232, 0, 1, 255, 255, 255])).is_err());
 
         // unexpected qb2 codes
         assert!(TestMatter::new(None, None, None, None, Some(&[0xf8]),).is_err()); // count code

--- a/src/core/number.rs
+++ b/src/core/number.rs
@@ -169,6 +169,7 @@ impl Matter for Number {
         self.size
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn set_code(&mut self, code: &str) {
         self.code = code.to_string();
     }
@@ -183,6 +184,7 @@ impl Matter for Number {
 }
 
 #[cfg(test)]
+#[allow(clippy::too_many_arguments)]
 mod test {
     use crate::core::{
         matter::Matter,

--- a/src/core/prefixer.rs
+++ b/src/core/prefixer.rs
@@ -1008,7 +1008,7 @@ mod test {
             "s": sn,
             "t": ilk,
             "kt": sith,
-            "k": keys.clone(),
+            "k": keys,
             "n": n_digs,
             "wt": toad,
             "w": wits.clone(),
@@ -1134,11 +1134,11 @@ mod test {
             "s": sn,
             "t": ilk2,
             "kt": sith,
-            "k": keys.clone(),
-            "n": n_digs.clone(),
+            "k": keys,
+            "n": n_digs,
             "wt": toad,
-            "w": wits.clone(),
-            "c": cnfg.clone(),
+            "w": wits,
+            "c": cnfg,
             "da": seal
         });
 

--- a/src/core/saider.rs
+++ b/src/core/saider.rs
@@ -476,7 +476,7 @@ mod test {
             Some(&sad9),
             None,
             None,
-            Some(&vec!["read"]),
+            Some(&["read"]),
             Some(code),
             None,
             None,
@@ -488,26 +488,26 @@ mod test {
         assert_eq!(saider.qb64().unwrap(), said9);
 
         let (saider1, mut sad10) =
-            Saider::saidify(&sad9, Some(code), None, Some(Ids::d), Some(&vec!["read"])).unwrap();
+            Saider::saidify(&sad9, Some(code), None, Some(Ids::d), Some(&["read"])).unwrap();
         assert_eq!(saider.qb64().unwrap(), saider1.qb64().unwrap());
         assert_eq!(sad10[Ids::d].to_string().unwrap(), said9);
         assert!(!sad10["read"].to_bool().unwrap());
 
         assert!(saider1
-            .verify(&sad10, Some(true), None, None, Some(Ids::d), Some(&vec!["read"]))
+            .verify(&sad10, Some(true), None, None, Some(Ids::d), Some(&["read"]))
             .unwrap());
 
         // Change the 'read' field that is ignored and make sure it still verifies
         sad10["read"] = dat!(true);
         assert!(saider1
-            .verify(&sad10, Some(true), None, None, Some(Ids::d), Some(&vec!["read"]))
+            .verify(&sad10, Some(true), None, None, Some(Ids::d), Some(&["read"]))
             .unwrap());
 
         let saider2 = Saider::new(
             Some(&sad10),
             None,
             None,
-            Some(&vec!["read"]),
+            Some(&["read"]),
             Some(code),
             None,
             None,
@@ -516,7 +516,7 @@ mod test {
         )
         .unwrap();
         assert_eq!(saider1.qb64().unwrap(), saider2.qb64().unwrap());
-        assert_eq!(sad10["read"].to_bool().unwrap(), true);
+        assert!(sad10["read"].to_bool().unwrap());
     }
 
     #[test]

--- a/src/core/salter.rs
+++ b/src/core/salter.rs
@@ -292,7 +292,7 @@ mod test {
         }
 
         pub fn s(&self) -> Result<String> {
-            Ok(Seqner::new_with_snh(&self.s)?.qb64()?)
+            Seqner::new_with_snh(&self.s)?.qb64()
         }
 
         pub fn d(&self) -> String {
@@ -301,7 +301,7 @@ mod test {
     }
 
     impl Vault {
-        fn default<'a>() -> Result<Self> {
+        fn default() -> Result<Self> {
             // Tierage::min is not exposed externally, this is for testing. One needs to use 'temp'
             // during stretching to accomplish this in a production scenario
             let csalter = Salter::new_with_defaults(Some(Tierage::min))?;
@@ -348,8 +348,8 @@ mod test {
             )?;
 
             let mut sigers: Vec<Siger> = vec![];
-            for i in 0..current.len() - 1 {
-                let siger: Siger = current[i].sign_indexed(&serder.raw(), false, i as u32, None)?;
+            for (i, val) in current.iter().take(current.len() - 1).enumerate() {
+                let siger: Siger = val.sign_indexed(&serder.raw(), false, i as u32, None)?;
                 sigers.push(siger);
             }
 
@@ -359,8 +359,8 @@ mod test {
 
             let receipt_serder = receipt(&ked["i"].to_string()?, 0, &serder.said()?, None, None)?;
             let mut wigers: Vec<Siger> = vec![];
-            for i in 0..witness.len() {
-                let siger: Siger = witness[i].sign_indexed(&serder.raw(), false, i as u32, None)?;
+            for (i, val) in witness.iter().enumerate() {
+                let siger: Siger = val.sign_indexed(&serder.raw(), false, i as u32, None)?;
                 wigers.push(siger);
             }
 

--- a/src/core/seqner.rs
+++ b/src/core/seqner.rs
@@ -148,7 +148,7 @@ mod test {
             &Seqner::new(None, Some("00"), Some(matter::Codex::Salt_128), None, None, None, None).unwrap(),
             &Seqner::new(None, None, None, None, Some(qb64.as_bytes()), None, None).unwrap(),
             &Seqner::new(None, None, None, None, None, Some(qb64), None).unwrap(),
-            &Seqner::new(None, None, None, None, None, None, Some(&mut qb2.to_vec())).unwrap(),
+            &Seqner::new(None, None, None, None, None, None, Some(qb2.as_ref())).unwrap(),
         )]
         seqner: &Seqner,
     ) {
@@ -267,7 +267,7 @@ mod test {
         )]
         qb64: &str,
     ) {
-        assert!(Seqner::new(None, None, None, None, Some(&qb64.as_bytes()), None, None).is_err());
+        assert!(Seqner::new(None, None, None, None, Some(qb64.as_bytes()), None, None).is_err());
         assert!(Seqner::new(None, None, None, None, None, Some(qb64), None).is_err());
     }
 

--- a/src/core/serder.rs
+++ b/src/core/serder.rs
@@ -560,6 +560,7 @@ pub(crate) mod test {
 
     // this function uses convenience methods unlike most test code. it is likely that it will
     // be extracted and used elsewhere - and convenience methods make sense outside the tests.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn incept(
         keys: &[&str],          // current keys qb64
         sith: Option<&Value>,   // current signing threshold

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -343,10 +343,8 @@ mod test {
     fn b64_char_to_index() {
         let s = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
-        let mut i = 0;
-        for c in s.chars() {
-            assert_eq!(util::b64_char_to_index(c).unwrap(), i);
-            i += 1;
+        for (i, c) in s.chars().enumerate() {
+            assert_eq!(util::b64_char_to_index(c).unwrap(), i as u8);
         }
     }
 
@@ -359,15 +357,15 @@ mod test {
     }
 
     #[rstest]
-    #[case(&vec![0], 1, "A")]
-    #[case(&vec![0, 0, 0, 0, 0, 0], 8, "AAAAAAAA")]
-    #[case(&vec![8, 68, 145], 4, "CESR")]
-    #[case(&vec![40, 68, 72, 0, 32, 194], 8, "KERIACDC")]
-    #[case(&vec![252], 1, "_")]
-    #[case(&vec![255, 255, 255, 255, 255, 255], 8, "________")]
-    #[case(&vec![244, 0, 1], 4, "9AAB")]
-    #[case(&vec![244, 0, 1], 0, "")]
-    fn code_b2_to_b64(#[case] b2: &Vec<u8>, #[case] length: usize, #[case] b64: &str) {
+    #[case(&[0], 1, "A")]
+    #[case(&[0, 0, 0, 0, 0, 0], 8, "AAAAAAAA")]
+    #[case(&[8, 68, 145], 4, "CESR")]
+    #[case(&[40, 68, 72, 0, 32, 194], 8, "KERIACDC")]
+    #[case(&[252], 1, "_")]
+    #[case(&[255, 255, 255, 255, 255, 255], 8, "________")]
+    #[case(&[244, 0, 1], 4, "9AAB")]
+    #[case(&[244, 0, 1], 0, "")]
+    fn code_b2_to_b64(#[case] b2: &[u8], #[case] length: usize, #[case] b64: &str) {
         assert_eq!(util::code_b2_to_b64(b2, length).unwrap(), b64);
     }
 

--- a/src/core/verfer.rs
+++ b/src/core/verfer.rs
@@ -200,7 +200,7 @@ mod test {
         let keypair = ed25519_dalek::Keypair::generate(&mut csprng);
 
         let sig = keypair.sign(&ser).to_bytes();
-        let mut bad_sig = sig.clone();
+        let mut bad_sig = sig;
         bad_sig[0] ^= 0xff;
 
         let raw = keypair.public.as_bytes();
@@ -212,7 +212,7 @@ mod test {
         assert!(m.verify(&[], &ser).is_err());
 
         // exercise control flows for non-transferrable variant
-        m.set_code(&matter::Codex::Ed25519N);
+        m.set_code(matter::Codex::Ed25519N);
         assert!(m.verify(&sig, &ser).unwrap());
         assert!(!m.verify(&bad_sig, &ser).unwrap());
         assert!(!m.verify(&sig, &bad_ser).unwrap());
@@ -230,7 +230,7 @@ mod test {
         let private_key = SigningKey::random(&mut csprng);
 
         let sig = <SigningKey as Signer<Signature>>::sign(&private_key, &ser).to_bytes();
-        let mut bad_sig = sig.clone();
+        let mut bad_sig = sig;
         bad_sig[0] ^= 0xff;
 
         let public_key = VerifyingKey::from(private_key);
@@ -243,7 +243,7 @@ mod test {
         assert!(!m.verify(&sig, &bad_ser).unwrap());
         assert!(m.verify(&[], &ser).is_err());
 
-        m.set_code(&matter::Codex::ECDSA_256k1N);
+        m.set_code(matter::Codex::ECDSA_256k1N);
         assert!(m.verify(&sig, &ser).unwrap());
         assert!(!m.verify(&bad_sig, &ser).unwrap());
         assert!(!m.verify(&sig, &bad_ser).unwrap());

--- a/src/data.rs
+++ b/src/data.rs
@@ -667,15 +667,15 @@ mod test {
         let mut hash_map = std::collections::HashMap::<String, Value>::new();
         hash_map.insert("test".to_string(), dat!(true));
         let d = dat!({
-            "f32": 0 as f32,
-            "f64": 0 as f64,
-            "i8": 0 as i8,
-            "i16": 0 as i16,
-            "i32": 0 as i32,
-            "i64": 0 as i64,
-            "u8": 0 as u8,
-            "u16": 0 as u16,
-            "u32": 0 as u32,
+            "f32": 0_f32,
+            "f64": 0_f64,
+            "i8": 0_i8,
+            "i16": 0_i16,
+            "i32": 0_i32,
+            "i64": 0_i64,
+            "u8": 0_u8,
+            "u16": 0_u16,
+            "u32": 0_u32,
             "hash map": &hash_map,
             "array": array,
         });

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,7 +81,7 @@ mod test {
     use crate::error::{Error, Result};
 
     fn explode() -> Result<()> {
-        return err!(Error::Prepad());
+        err!(Error::Prepad())
     }
 
     #[test]


### PR DESCRIPTION
Just a cleanup of the rest of clippy warnings.
These can be found if run `cargo clippy --all-targets -- -D warnings` in the main branch.