### PR TITLE
update readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ thiserror = "~1"
 zeroize = "~1"
 
 [dev-dependencies]
-hex-literal = "0.3.4"
+hex-literal = "0.4.0"
 hex = "0.4.3"
 rstest = "0.17.0"

--- a/README.md
+++ b/README.md
@@ -164,11 +164,6 @@ println!("Blake3 256 digest: #{d}", d=diger.qb64()?);
 
 For more implementation details at this time, see [KERIpy](https://github.com/WebOfTrust/keripy).
 
-## Security
-
-- [ ] Audited for zeroing before frees/drops ([#40](https://github.com/WebOfTrust/cesride/issues/40))
-- [ ] Audited for constant time evaluation ([#116](https://github.com/WebOfTrust/cesride/issues/116))
-
 ### Entropy
 
 We use two `OsRng` implementations to obtain our random data. Our private keys are

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ and terminology was carried along with the code. The basics:
 - `Diger` - a primitive that represents a **digest**. It has the ability to verify that an input hashes to its raw value.
 - `Verfer` - a primitive that represents a **public key**. It has the ability to verify signatures on data.
 - `Signer` - a primitive that represents a **private key**. It has the ability to create `Sigers` and `Cigars` (signatures).
-- `Siger` - an **_indexed_ signature**, for use in weighted threshold verification.
-- `Cigar` - an **_unindexed_ signature**, for use in unweighted verification.
+- `Siger` - an **_indexed_ signature**. This is used when there are multiple current keys associated with an identifier.
+- `Cigar` - an **_unindexed_ signature**.
 - `Salter` - a primitive that represents a **seed**. It has the ability to generate new `Signers`.
  
 Each primitive will have methods attached to it that permit one to generate and parse the qualified
@@ -228,8 +228,14 @@ Blake3 is recommended for most applications since it outperforms the other algor
 `cesride` supports the following signing algorithms:
 - Ed25519 ([ed25519-dalek](https://docs.rs/ed25519-dalek))
 - Secp256k1 ([k256](https://docs.rs/k256))
+- Secp256r1 ([p256](https://docs.rs/p256))
 
-We have planned support for ed448.
+We have planned support for Ed448.
+
+The ECDSA curves (Secp256k1 and Secp256r1) use randomized signatures. Ed25519 is always deterministic.
+This means that if you need to avoid correlation and want to use Ed25519, you'll need to salt your data
+for every use case that you do not want correlated. ACDC, for example, takes this into account, allowing for
+configurable use of Ed25519 by injecting salty nonces in the data to be signed where privacy is a concern.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ and terminology was carried along with the code. The basics:
 - `Diger` - a primitive that represents a **digest**. It has the ability to verify that an input hashes to its raw value.
 - `Verfer` - a primitive that represents a **public key**. It has the ability to verify signatures on data.
 - `Signer` - a primitive that represents a **private key**. It has the ability to create `Sigers` and `Cigars` (signatures).
-- `Siger` - an **_indexed_ signature**. This is used when there are multiple current keys associated with an identifier.
+- `Siger` - an **_indexed_ signature**. This is used within KERI when there are multiple current keys associated with an identifier.
 - `Cigar` - an **_unindexed_ signature**.
 - `Salter` - a primitive that represents a **seed**. It has the ability to generate new `Signers`.
  


### PR DESCRIPTION
## Rationale

This should have been updated along with the p-256 PR and it was missed. Readme updates.

## Changes

- adds p-256 documentation link to readme
- reworks language around indexed signatures in readme
- adds details surrounding use of randomized vs deterministic signatures to readme
- removes checklist items that have been completed (rather not claim we have done a thorough job in the readme, so removed)
- bumps testing crate (`hex-literal`)

## Testing

- Github Actions