### PR TITLE
Wasm update for parside wasm: add missing Deref's

### DIFF
--- a/wasm/src/primitives/bexter.rs
+++ b/wasm/src/primitives/bexter.rs
@@ -95,7 +95,7 @@ impl Deref for BexterWrapper {
 impl Wrap<Bexter> for BexterWrapper {
     type Wrapper = BexterWrapper;
 
-    fn wrap(verfer: &Bexter) -> Self::Wrapper {
-        BexterWrapper(verfer.clone())
+    fn wrap(bexter: &Bexter) -> Self::Wrapper {
+        BexterWrapper(bexter.clone())
     }
 }

--- a/wasm/src/primitives/bexter.rs
+++ b/wasm/src/primitives/bexter.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::error::*;
+use crate::{error::*, Wrap};
 use cesride_core::{Bexter, Matter};
 use wasm_bindgen::prelude::*;
 
@@ -89,5 +89,13 @@ impl Deref for BexterWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Bexter> for BexterWrapper {
+    type Wrapper = BexterWrapper;
+
+    fn wrap(verfer: &Bexter) -> Self::Wrapper {
+        BexterWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/cigar.rs
+++ b/wasm/src/primitives/cigar.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{error::*, VerferWrapper};
+use crate::{error::*, VerferWrapper, Wrap};
 use cesride_core::{Cigar, Matter};
 use wasm_bindgen::prelude::*;
 
@@ -88,5 +88,13 @@ impl Deref for CigarWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Cigar> for CigarWrapper {
+    type Wrapper = CigarWrapper;
+
+    fn wrap(verfer: &Cigar) -> Self::Wrapper {
+        CigarWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/cigar.rs
+++ b/wasm/src/primitives/cigar.rs
@@ -94,7 +94,7 @@ impl Deref for CigarWrapper {
 impl Wrap<Cigar> for CigarWrapper {
     type Wrapper = CigarWrapper;
 
-    fn wrap(verfer: &Cigar) -> Self::Wrapper {
-        CigarWrapper(verfer.clone())
+    fn wrap(cigar: &Cigar) -> Self::Wrapper {
+        CigarWrapper(cigar.clone())
     }
 }

--- a/wasm/src/primitives/dater.rs
+++ b/wasm/src/primitives/dater.rs
@@ -99,7 +99,7 @@ impl Deref for DaterWrapper {
 impl Wrap<Dater> for DaterWrapper {
     type Wrapper = DaterWrapper;
 
-    fn wrap(verfer: &Dater) -> Self::Wrapper {
-        DaterWrapper(verfer.clone())
+    fn wrap(dater: &Dater) -> Self::Wrapper {
+        DaterWrapper(dater.clone())
     }
 }

--- a/wasm/src/primitives/dater.rs
+++ b/wasm/src/primitives/dater.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::error::*;
+use crate::{error::*, Wrap};
 use cesride_core::{Dater, Matter};
 use wasm_bindgen::prelude::*;
 
@@ -93,5 +93,13 @@ impl Deref for DaterWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Dater> for DaterWrapper {
+    type Wrapper = DaterWrapper;
+
+    fn wrap(verfer: &Dater) -> Self::Wrapper {
+        DaterWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/diger.rs
+++ b/wasm/src/primitives/diger.rs
@@ -104,7 +104,7 @@ impl Deref for DigerWrapper {
 impl Wrap<Diger> for DigerWrapper {
     type Wrapper = DigerWrapper;
 
-    fn wrap(verfer: &Diger) -> Self::Wrapper {
-        DigerWrapper(verfer.clone())
+    fn wrap(diger: &Diger) -> Self::Wrapper {
+        DigerWrapper(diger.clone())
     }
 }

--- a/wasm/src/primitives/diger.rs
+++ b/wasm/src/primitives/diger.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::error::*;
+use crate::{error::*, Wrap};
 use cesride_core::{Diger, Matter};
 use wasm_bindgen::prelude::*;
 
@@ -98,5 +98,13 @@ impl Deref for DigerWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Diger> for DigerWrapper {
+    type Wrapper = DigerWrapper;
+
+    fn wrap(verfer: &Diger) -> Self::Wrapper {
+        DigerWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/number.rs
+++ b/wasm/src/primitives/number.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
-use crate::error::*;
 use crate::util::U128Wrapper;
+use crate::{error::*, Wrap};
 use cesride_core::{Matter, Number};
 use wasm_bindgen::prelude::*;
 
@@ -102,5 +102,13 @@ impl Deref for NumberWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Number> for NumberWrapper {
+    type Wrapper = NumberWrapper;
+
+    fn wrap(verfer: &Number) -> Self::Wrapper {
+        NumberWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/number.rs
+++ b/wasm/src/primitives/number.rs
@@ -108,7 +108,7 @@ impl Deref for NumberWrapper {
 impl Wrap<Number> for NumberWrapper {
     type Wrapper = NumberWrapper;
 
-    fn wrap(verfer: &Number) -> Self::Wrapper {
-        NumberWrapper(verfer.clone())
+    fn wrap(number: &Number) -> Self::Wrapper {
+        NumberWrapper(number.clone())
     }
 }

--- a/wasm/src/primitives/prefixer.rs
+++ b/wasm/src/primitives/prefixer.rs
@@ -111,7 +111,7 @@ impl Deref for PrefixerWrapper {
 impl Wrap<Prefixer> for PrefixerWrapper {
     type Wrapper = PrefixerWrapper;
 
-    fn wrap(verfer: &Prefixer) -> Self::Wrapper {
-        PrefixerWrapper(verfer.clone())
+    fn wrap(prefixer: &Prefixer) -> Self::Wrapper {
+        PrefixerWrapper(prefixer.clone())
     }
 }

--- a/wasm/src/primitives/prefixer.rs
+++ b/wasm/src/primitives/prefixer.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{error::*, ValueWrapper};
+use crate::{error::*, ValueWrapper, Wrap};
 use cesride_core::{data::Value, Matter, Prefixer};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
@@ -105,5 +105,13 @@ impl Deref for PrefixerWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Prefixer> for PrefixerWrapper {
+    type Wrapper = PrefixerWrapper;
+
+    fn wrap(verfer: &Prefixer) -> Self::Wrapper {
+        PrefixerWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/saider.rs
+++ b/wasm/src/primitives/saider.rs
@@ -189,7 +189,7 @@ impl Deref for SaiderWrapper {
 impl Wrap<Saider> for SaiderWrapper {
     type Wrapper = SaiderWrapper;
 
-    fn wrap(verfer: &Saider) -> Self::Wrapper {
-        SaiderWrapper(verfer.clone())
+    fn wrap(saider: &Saider) -> Self::Wrapper {
+        SaiderWrapper(saider.clone())
     }
 }

--- a/wasm/src/primitives/saider.rs
+++ b/wasm/src/primitives/saider.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{error::*, ValueWrapper};
+use crate::{error::*, ValueWrapper, Wrap};
 use cesride_core::{data::Value, Matter, Saider};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
@@ -183,5 +183,13 @@ impl Deref for SaiderWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Saider> for SaiderWrapper {
+    type Wrapper = SaiderWrapper;
+
+    fn wrap(verfer: &Saider) -> Self::Wrapper {
+        SaiderWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/salter.rs
+++ b/wasm/src/primitives/salter.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{error::*, SignerWrapper, Signers};
+use crate::{error::*, SignerWrapper, Signers, Wrap};
 use cesride_core::{Matter, Salter};
 use wasm_bindgen::prelude::*;
 
@@ -146,5 +146,13 @@ impl Deref for SalterWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Salter> for SalterWrapper {
+    type Wrapper = SalterWrapper;
+
+    fn wrap(verfer: &Salter) -> Self::Wrapper {
+        SalterWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/salter.rs
+++ b/wasm/src/primitives/salter.rs
@@ -152,7 +152,7 @@ impl Deref for SalterWrapper {
 impl Wrap<Salter> for SalterWrapper {
     type Wrapper = SalterWrapper;
 
-    fn wrap(verfer: &Salter) -> Self::Wrapper {
-        SalterWrapper(verfer.clone())
+    fn wrap(salter: &Salter) -> Self::Wrapper {
+        SalterWrapper(salter.clone())
     }
 }

--- a/wasm/src/primitives/seqner.rs
+++ b/wasm/src/primitives/seqner.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
-use crate::error::*;
 use crate::util::U128Wrapper;
+use crate::{error::*, Wrap};
 use cesride_core::{Matter, Seqner};
 use wasm_bindgen::prelude::*;
 
@@ -102,5 +102,13 @@ impl Deref for SeqnerWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Seqner> for SeqnerWrapper {
+    type Wrapper = SeqnerWrapper;
+
+    fn wrap(verfer: &Seqner) -> Self::Wrapper {
+        SeqnerWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/seqner.rs
+++ b/wasm/src/primitives/seqner.rs
@@ -108,7 +108,7 @@ impl Deref for SeqnerWrapper {
 impl Wrap<Seqner> for SeqnerWrapper {
     type Wrapper = SeqnerWrapper;
 
-    fn wrap(verfer: &Seqner) -> Self::Wrapper {
-        SeqnerWrapper(verfer.clone())
+    fn wrap(seqner: &Seqner) -> Self::Wrapper {
+        SeqnerWrapper(seqner.clone())
     }
 }

--- a/wasm/src/primitives/serder.rs
+++ b/wasm/src/primitives/serder.rs
@@ -147,7 +147,7 @@ impl Deref for SerderWrapper {
 impl Wrap<Serder> for SerderWrapper {
     type Wrapper = SerderWrapper;
 
-    fn wrap(verfer: &Serder) -> Self::Wrapper {
-        SerderWrapper(verfer.clone())
+    fn wrap(serder: &Serder) -> Self::Wrapper {
+        SerderWrapper(serder.clone())
     }
 }

--- a/wasm/src/primitives/serder.rs
+++ b/wasm/src/primitives/serder.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use crate::{
     error::*, DigerWrapper, NumberWrapper, SaiderWrapper, TholderWrapper, U128Wrapper,
-    ValueWrapper, VerferWrapper, VersionWrapper,
+    ValueWrapper, VerferWrapper, VersionWrapper, Wrap,
 };
 use cesride_core::{data::Value, Sadder, Serder};
 use js_sys::Array;
@@ -141,5 +141,13 @@ impl Deref for SerderWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Serder> for SerderWrapper {
+    type Wrapper = SerderWrapper;
+
+    fn wrap(verfer: &Serder) -> Self::Wrapper {
+        SerderWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/siger.rs
+++ b/wasm/src/primitives/siger.rs
@@ -106,7 +106,7 @@ impl Deref for SigerWrapper {
 impl Wrap<Siger> for SigerWrapper {
     type Wrapper = SigerWrapper;
 
-    fn wrap(verfer: &Siger) -> Self::Wrapper {
-        SigerWrapper(verfer.clone())
+    fn wrap(siger: &Siger) -> Self::Wrapper {
+        SigerWrapper(siger.clone())
     }
 }

--- a/wasm/src/primitives/siger.rs
+++ b/wasm/src/primitives/siger.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{error::*, VerferWrapper};
+use crate::{error::*, VerferWrapper, Wrap};
 use cesride_core::{Indexer, Siger};
 use wasm_bindgen::prelude::*;
 
@@ -100,5 +100,13 @@ impl Deref for SigerWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Siger> for SigerWrapper {
+    type Wrapper = SigerWrapper;
+
+    fn wrap(verfer: &Siger) -> Self::Wrapper {
+        SigerWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/signer.rs
+++ b/wasm/src/primitives/signer.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::{error::*, CigarWrapper, SigerWrapper, VerferWrapper};
+use crate::{error::*, CigarWrapper, SigerWrapper, VerferWrapper, Wrap};
 use cesride_core::{Matter, Signer};
 use wasm_bindgen::prelude::*;
 
@@ -128,5 +128,13 @@ impl Deref for SignerWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Signer> for SignerWrapper {
+    type Wrapper = SignerWrapper;
+
+    fn wrap(verfer: &Signer) -> Self::Wrapper {
+        SignerWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/signer.rs
+++ b/wasm/src/primitives/signer.rs
@@ -134,7 +134,7 @@ impl Deref for SignerWrapper {
 impl Wrap<Signer> for SignerWrapper {
     type Wrapper = SignerWrapper;
 
-    fn wrap(verfer: &Signer) -> Self::Wrapper {
-        SignerWrapper(verfer.clone())
+    fn wrap(signer: &Signer) -> Self::Wrapper {
+        SignerWrapper(signer.clone())
     }
 }

--- a/wasm/src/primitives/tholder.rs
+++ b/wasm/src/primitives/tholder.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
-use crate::ValueWrapper;
 use crate::{error::*, BexterWrapper, NumberWrapper};
+use crate::{ValueWrapper, Wrap};
 use cesride_core::data::Value;
 use cesride_core::Tholder;
 use wasm_bindgen::prelude::*;
@@ -92,5 +92,13 @@ impl Deref for TholderWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Tholder> for TholderWrapper {
+    type Wrapper = TholderWrapper;
+
+    fn wrap(verfer: &Tholder) -> Self::Wrapper {
+        TholderWrapper(verfer.clone())
     }
 }

--- a/wasm/src/primitives/tholder.rs
+++ b/wasm/src/primitives/tholder.rs
@@ -98,7 +98,7 @@ impl Deref for TholderWrapper {
 impl Wrap<Tholder> for TholderWrapper {
     type Wrapper = TholderWrapper;
 
-    fn wrap(verfer: &Tholder) -> Self::Wrapper {
-        TholderWrapper(verfer.clone())
+    fn wrap(tholder: &Tholder) -> Self::Wrapper {
+        TholderWrapper(tholder.clone())
     }
 }

--- a/wasm/src/primitives/verfer.rs
+++ b/wasm/src/primitives/verfer.rs
@@ -1,4 +1,4 @@
-use crate::error::*;
+use crate::{error::*, Wrap};
 use cesride_core::{Matter, Verfer};
 use std::ops::Deref;
 use wasm_bindgen::prelude::*;
@@ -82,5 +82,13 @@ impl Deref for VerferWrapper {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Wrap<Verfer> for VerferWrapper {
+    type Wrapper = VerferWrapper;
+
+    fn wrap(verfer: &Verfer) -> Self::Wrapper {
+        VerferWrapper(verfer.clone())
     }
 }

--- a/wasm/src/util.rs
+++ b/wasm/src/util.rs
@@ -40,3 +40,9 @@ impl From<ValueWrapper> for Value {
         Value::from(&v)
     }
 }
+
+pub trait Wrap<T> {
+    type Wrapper;
+
+    fn wrap(verfer: &T) -> Self::Wrapper;
+}


### PR DESCRIPTION
This update affects the only wasm part of cesride:
- Add `Deref` to each wrapper class to allow parside code to access the wrapped class. This is needed to create/re-wrap original rust classes in groups.