### PR TITLE
Fixed wasm compilation error + corrected readme for wasm package

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "cesride-wasm"
+description = "Cryptographic primitives for use with Composable Event Streaming Representation (CESR)"
 version = "0.1.0"
 authors = ['Dmitry Kuzmenko <dmitry.kuzmenko@dsr-corporation.com>']
 edition = "2021"

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,19 +1,8 @@
 # WASM FFI for CESRIDE
 
-You can build the FFI with
-```
-$ wasm-pack build
-```
-
-### How to build
+### How to build with wasm-pack
 Install wasm-pack from https://rustwasm.github.io/wasm-pack/installer/ and then
-```
-make # Will output modules best-suited to be bundled with webpack
-WASM_TARGET=nodejs make # Will output modules that can be directly consumed by NodeJS
-WASM_TARGET=web make # Will output modules that can be directly consumed in browser without bundler usage
-```
 
-### How to build with wasm-pack build
 ```
 wasm-pack build # Will output modules best-suited to be bundled with webpack
 wasm-pack build --target=nodejs # Will output modules that can be directly consumed by NodeJS
@@ -27,7 +16,7 @@ yarn install
 yarn start
 ```
 
-### Run demo шт Browser
+### Run demo in Browser
 ```
 cd demo/web
 yarn install

--- a/wasm/src/primitives/bexter.rs
+++ b/wasm/src/primitives/bexter.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use crate::{error::*, Wrap};
-use cesride_core::{Bexter, Matter};
+use cesride_core::{Bexter, Bext, Matter};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(js_name = Bexter)]


### PR DESCRIPTION
Fixed wasm compilation error: `bext` method of `Bexter` type was moved under the `Bext` trait.  
Corrected readme for wasm package: removed incorrect instructions using make