### PR TITLE
dalek 2.0.0-rc.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo check
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
       - name: Build
         run: cargo build --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Outdated
-        run: cargo outdated -R --ignore rand --exit-code 1
+        run: cargo outdated -R --exit-code 1
 
       - name: Audit
         run: cargo audit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         run: cargo check
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy -- -D warnings
 
       - name: Build
         run: cargo build --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
       - name: WASM Sanity Build
         run: |
           cd wasm
+          cargo install wasm-pack
           wasm-pack build
 
       - name: Upload to codecov.io

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,11 @@ jobs:
         with:
           version: '0.22.0'
 
+      - name: WASM Sanity Build
+        run: |
+          cd wasm
+          wasm-pack build
+
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,19 @@ base64 = "~0.21"
 blake2 = "~0.10"
 blake3 = "~1"
 chrono = { version = "~0.4", default-features = false, features = ["clock"] }
-ed25519-dalek = "~1"
+ed25519-dalek = { version = "2.0.0-rc.2", features = ["rand_core"] }
 indexmap = "~1"
 k256 = "~0.13"
 lazy_static = "~1"
 num-rational = "~0.4"
 p256 = "~0.13"
-rand = "0.7.0" # this needs pinning for one of the seeding pieces of a signing suite
 rand_core = "~0.6"
 regex = "~1"
 serde_json = { version = "~1", features = ["preserve_order"] }
 sha2 = "~0.10"
 sha3 = "~0.10"
 thiserror = "~1"
-zeroize = "~1"
+zeroize = { version = "~1", features = ["derive"] }
 
 [dev-dependencies]
 hex-literal = "0.4.0"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ preflight:
 	cargo outdated -R --exit-code 1
 	cargo audit
 	cargo check
-	cargo clippy -- -D warnings
+	cargo clippy --all-targets -- -D warnings
 	cargo build --release
 	cargo test --release
 	cargo tarpaulin

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 setup:
-	cargo install cargo-tarpaulin cargo-outdated cargo-audit
+	cargo install cargo-tarpaulin cargo-outdated cargo-audit wasm-pack
 
 clean:
 	cargo clean
@@ -20,3 +20,4 @@ preflight:
 	cargo build --release
 	cargo test --release
 	cargo tarpaulin
+	cd wasm && wasm-pack build && wasm-pack build --target=nodejs

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+setup:
+	cargo install cargo-tarpaulin cargo-outdated cargo-audit
+
 clean:
 	cargo clean
 
@@ -5,12 +8,15 @@ fix:
 	cargo fix
 	cargo fmt
 
+clippy:
+	cargo clippy --all-targets -- -D warnings
+
 preflight:
 	cargo fmt --check
 	cargo outdated -R --exit-code 1
 	cargo audit
 	cargo check
-	cargo clippy --all-targets -- -D warnings
+	cargo clippy -- -D warnings
 	cargo build --release
 	cargo test --release
 	cargo tarpaulin

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@ fix:
 	cargo fmt
 
 preflight:
-	cargo audit
 	cargo fmt --check
 	cargo outdated -R --exit-code 1
+	cargo audit
+	cargo check
 	cargo clippy -- -D warnings
 	cargo build --release
 	cargo test --release

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ fix:
 preflight:
 	cargo audit
 	cargo fmt --check
-	cargo outdated -R --ignore rand --exit-code 1
+	cargo outdated -R --exit-code 1
 	cargo clippy -- -D warnings
 	cargo build --release
 	cargo test --release

--- a/src/core/signer.rs
+++ b/src/core/signer.rs
@@ -365,6 +365,7 @@ mod test {
         "1AAJAxaZvKBRj6Zss11rCpL2hJYoe7Zk6OhXaRW46poCBir_",
         "0ICM-rRAAdKrSrzFlouiZXbNUZ07QMM1IXOaG-gv4TAo4QeQCKZC1z82jJYy_wFkAxgIhbikl3a-nOTXxecF2lEj",
     )]
+    #[allow(clippy::too_many_arguments)]
     fn hardcoded_openssl_vectors(
         #[case] signer_code: &str,
         #[case] verfer_code: &str,

--- a/src/core/signer.rs
+++ b/src/core/signer.rs
@@ -328,6 +328,7 @@ mod test {
         assert_eq!(signer.verfer().qb64().unwrap(), verfer_qb64);
     }
 
+    #[allow(clippy::too_many_arguments)]
     #[rstest]
     // openssl genpkey -algorithm ed25519 -text
     #[case(
@@ -365,7 +366,6 @@ mod test {
         "1AAJAxaZvKBRj6Zss11rCpL2hJYoe7Zk6OhXaRW46poCBir_",
         "0ICM-rRAAdKrSrzFlouiZXbNUZ07QMM1IXOaG-gv4TAo4QeQCKZC1z82jJYy_wFkAxgIhbikl3a-nOTXxecF2lEj",
     )]
-    #[allow(clippy::too_many_arguments)]
     fn hardcoded_openssl_vectors(
         #[case] signer_code: &str,
         #[case] verfer_code: &str,

--- a/src/core/signer.rs
+++ b/src/core/signer.rs
@@ -328,7 +328,6 @@ mod test {
         assert_eq!(signer.verfer().qb64().unwrap(), verfer_qb64);
     }
 
-    #[allow(clippy::too_many_arguments)]
     #[rstest]
     // openssl genpkey -algorithm ed25519 -text
     #[case(

--- a/src/core/verfer.rs
+++ b/src/core/verfer.rs
@@ -264,7 +264,7 @@ mod test {
         let private_key = SigningKey::random(&mut csprng);
 
         let sig = <SigningKey as Signer<Signature>>::sign(&private_key, &ser).to_bytes();
-        let mut bad_sig = sig.clone();
+        let mut bad_sig = sig;
         bad_sig[0] ^= 0xff;
 
         let public_key = VerifyingKey::from(private_key);
@@ -277,7 +277,7 @@ mod test {
         assert!(!m.verify(&sig, &bad_ser).unwrap());
         assert!(m.verify(&[], &ser).is_err());
 
-        m.set_code(&matter::Codex::ECDSA_256r1N);
+        m.set_code(matter::Codex::ECDSA_256r1N);
         assert!(m.verify(&sig, &ser).unwrap());
         assert!(!m.verify(&bad_sig, &ser).unwrap());
         assert!(!m.verify(&sig, &bad_ser).unwrap());

--- a/src/core/verfer.rs
+++ b/src/core/verfer.rs
@@ -100,7 +100,6 @@ impl Matter for Verfer {
 mod test {
     use crate::core::matter::{tables as matter, Matter};
     use crate::core::verfer::Verfer;
-    use ed25519_dalek::ed25519::signature::Keypair;
     use hex_literal::hex;
 
     #[test]

--- a/src/core/verfer.rs
+++ b/src/core/verfer.rs
@@ -208,7 +208,8 @@ mod test {
 
         let raw = keypair.verifying_key().to_bytes();
 
-        let mut m = Verfer::new(Some(matter::Codex::Ed25519), Some(&raw), None, None, None).unwrap();
+        let mut m =
+            Verfer::new(Some(matter::Codex::Ed25519), Some(&raw), None, None, None).unwrap();
         assert!(m.verify(&sig, &ser).unwrap());
         assert!(!m.verify(&bad_sig, &ser).unwrap());
         assert!(!m.verify(&sig, &bad_ser).unwrap());

--- a/src/crypto/sign.rs
+++ b/src/crypto/sign.rs
@@ -109,7 +109,7 @@ mod ed25519 {
         let public_key = VerifyingKey::from_bytes(public_key.try_into()?)?;
         let signature = Signature::from_bytes(sig.try_into()?);
 
-        match public_key.verify_strict(ser, &signature) {
+        match public_key.verify(ser, &signature) {
             Ok(_) => Ok(true),
             Err(_) => Ok(false),
         }

--- a/src/crypto/sign.rs
+++ b/src/crypto/sign.rs
@@ -74,7 +74,7 @@ pub(crate) fn verify(code: &str, public_key: &[u8], sig: &[u8], ser: &[u8]) -> R
 }
 
 mod ed25519 {
-    use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+    use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
     use rand_core::OsRng;
 
     use crate::error::Result;

--- a/wasm/src/primitives/bexter.rs
+++ b/wasm/src/primitives/bexter.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use crate::{error::*, Wrap};
-use cesride_core::{Bexter, Matter};
+use cesride_core::{Bext, Bexter, Matter};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(js_name = Bexter)]


### PR DESCRIPTION
## Rationale

The old version of OsRng based on a pinned version of `rand` has been bothering me, as has the length of time ed25519-dalek has gone without updates.

This bumps to the new `2.0.0-rc.2` version, fixing this problem and making other small improvements.

## Changes

- uses `ed25519-dalek 2.0.0-rc.2`
- removes dependency `rand`
- drops ignore flag for rand in `cargo-outdated`
- checks for weak public keys (low order) on generation
- fixes `zeroize` features to include `derive` now that it is required for us
- makefile improvements
- adds WASM sanity build to CI

## Testing

```
make clean fix preflight
```

Note: Coverage is dropping because I can't easily come up with a way to exercise the stock code that generates a weak public key (or maybe I can and I am lazy/ignorant - I haven't really dug into rust monkeypatching and I don't want to make this function use dependency injection).