### PR TITLE
Remove with saider add wasm

### DIFF
--- a/wasm/src/primitives/saider.rs
+++ b/wasm/src/primitives/saider.rs
@@ -15,10 +15,11 @@ use cesride_core::{
 };
 
 #[wasm_bindgen(js_name = Saider)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SaiderWrapper(pub(crate) Saider);
 
 #[wasm_bindgen]
+#[derive(Debug)]
 pub struct SaidifyRet {
     saider: SaiderWrapper,
     value: String,
@@ -85,12 +86,15 @@ impl SaiderWrapper {
             kind.as_deref(),
             label.as_deref(),
             ignore,
-        )
-        .as_js()?;
-        Ok(SaidifyRet {
-            saider: SaiderWrapper(ret.0),
-            value: ret.1.to_string().expect("unable unwrap value"),
-        })
+        ).as_js();
+
+        match ret {
+            Ok(ret) => Ok(SaidifyRet {
+                saider: SaiderWrapper(ret.0),
+                value: ret.1.to_json().expect("unable unwrap value"),
+            }),
+            Err(err_ret) => Err(err_ret.into()),
+        }
     }
 
     pub fn verify(

--- a/wasm/src/primitives/saider.rs
+++ b/wasm/src/primitives/saider.rs
@@ -1,9 +1,18 @@
 use std::ops::Deref;
 
-use crate::{error::*, ValueWrapper, Wrap};
-use cesride_core::{data::Value, Matter, Saider};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
+
+use crate::{
+    error::*,
+    ValueWrapper,
+    Wrap
+};
+use cesride_core::{
+    data::Value,
+    Matter,
+    Saider
+};
 
 #[wasm_bindgen(js_name = Saider)]
 #[derive(Clone)]
@@ -109,48 +118,6 @@ impl SaiderWrapper {
             )
             .as_js()?;
         Ok(ret)
-    }
-
-    pub fn new_with_sad(
-        sad: ValueWrapper,
-        label: Option<String>,
-        kind: Option<String>,
-        ignore: Option<Array>,
-        code: Option<String>,
-    ) -> Result<SaiderWrapper> {
-        let ignore = ignore
-            .map(|a| a.iter().map(|v| v.as_string().unwrap_or_default()).collect::<Vec<String>>());
-        let ignore = ignore.as_deref().map(|a| a.iter().map(String::as_str).collect::<Vec<&str>>());
-        let ignore = ignore.as_deref();
-        let saider = Saider::new_with_sad(
-            &Value::from(sad),
-            label.as_deref(),
-            kind.as_deref(),
-            ignore,
-            code.as_deref(),
-        )
-        .as_js()?;
-        Ok(SaiderWrapper(saider))
-    }
-
-    pub fn new_with_raw(raw: &[u8], code: Option<String>) -> Result<SaiderWrapper> {
-        let saider = Saider::new_with_raw(raw, code.as_deref()).as_js()?;
-        Ok(SaiderWrapper(saider))
-    }
-
-    pub fn new_with_qb64b(qb64b: &[u8]) -> Result<SaiderWrapper> {
-        let saider = Saider::new_with_qb64b(qb64b).as_js()?;
-        Ok(SaiderWrapper(saider))
-    }
-
-    pub fn new_with_qb64(qb64: &str) -> Result<SaiderWrapper> {
-        let saider = Saider::new_with_qb64(qb64).as_js()?;
-        Ok(SaiderWrapper(saider))
-    }
-
-    pub fn new_with_qb2(qb2: &[u8]) -> Result<SaiderWrapper> {
-        let saider = Saider::new_with_qb2(qb2).as_js()?;
-        Ok(SaiderWrapper(saider))
     }
 
     pub fn code(&self) -> String {

--- a/wasm/src/primitives/serder.rs
+++ b/wasm/src/primitives/serder.rs
@@ -1,12 +1,25 @@
 use std::ops::Deref;
 
-use crate::{
-    error::*, DigerWrapper, NumberWrapper, SaiderWrapper, TholderWrapper, U128Wrapper,
-    ValueWrapper, VerferWrapper, VersionWrapper, Wrap,
-};
-use cesride_core::{data::Value, Sadder, Serder};
 use js_sys::Array;
 use wasm_bindgen::prelude::*;
+
+use cesride_core::{
+    Sadder,
+    Serder,
+    data::Value,
+};
+use crate::{
+    error::*,
+    DigerWrapper,
+    NumberWrapper,
+    SaiderWrapper,
+    TholderWrapper,
+    U128Wrapper,
+    ValueWrapper,
+    VerferWrapper,
+    VersionWrapper,
+    Wrap,
+};
 
 #[wasm_bindgen(js_name = Serder)]
 pub struct SerderWrapper(pub(crate) Serder);
@@ -29,23 +42,6 @@ impl SerderWrapper {
             sad.as_deref(),
         )
         .as_js()?;
-        Ok(SerderWrapper(serder))
-    }
-
-    pub fn new_with_ked(
-        ked: ValueWrapper,
-        code: Option<String>,
-        kind: Option<String>,
-    ) -> Result<SerderWrapper> {
-        let serder =
-            Serder::new_with_ked(&Value::from(ked), code.as_deref(), kind.as_deref()).as_js()?;
-        Ok(SerderWrapper(serder))
-    }
-
-    pub fn new_with_raw(
-        raw: &[u8]
-    ) -> Result<SerderWrapper> {
-        let serder = Serder::new_with_raw(raw).as_js()?;
         Ok(SerderWrapper(serder))
     }
 

--- a/wasm/tests/test_wasm.rs
+++ b/wasm/tests/test_wasm.rs
@@ -7,7 +7,9 @@ use cesride_wasm::BexterWrapper;
 use cesride_wasm::CesrideMatterCodex;
 use cesride_wasm::CigarWrapper;
 use cesride_wasm::DaterWrapper;
+use cesride_wasm::SaiderWrapper;
 use cesride_wasm::VerferWrapper;
+use cesride_wasm::ValueWrapper;
 
 /* 
 These dater tests are transcriptions from the first two test_dater tests in
@@ -87,4 +89,17 @@ fn test_verfer_convenience() {
     assert_eq!(verf_wrapper.qb64(), verf_wrapper_2.qb64());
     assert_eq!(verf_wrapper.qb64b(), verf_wrapper_2.qb64b());
     assert_eq!(verf_wrapper.qb2(), verf_wrapper_2.qb2());
+}
+
+#[wasm_bindgen_test]
+fn test_serder_convenience() {
+    // TODO implement
+}
+
+#[wasm_bindgen_test]
+fn test_saider_convenience() {
+    let sad = r#"{"d":""}"#;
+    let wrapper = SaiderWrapper::new(Some(ValueWrapper::new(&sad)),
+        None, None, None, None, None, None, None, None).unwrap();
+    assert_eq!(wrapper.code(), wrapper.code());
 }

--- a/wasm/tests/test_wasm.rs
+++ b/wasm/tests/test_wasm.rs
@@ -8,6 +8,7 @@ use cesride_wasm::CesrideMatterCodex;
 use cesride_wasm::CigarWrapper;
 use cesride_wasm::DaterWrapper;
 use cesride_wasm::SaiderWrapper;
+use cesride_wasm::SerderWrapper;
 use cesride_wasm::VerferWrapper;
 use cesride_wasm::ValueWrapper;
 
@@ -93,7 +94,20 @@ fn test_verfer_convenience() {
 
 #[wasm_bindgen_test]
 fn test_serder_convenience() {
-    // TODO implement
+    let e1 = r#"{
+        "v": "KERI10JSON000000_",
+        "d": "",
+        "i": "ABCDEFG",
+        "s": "0001",
+        "t": "rot"
+    }"#;
+    let saidify_returned = SaiderWrapper::saidify(ValueWrapper::new(&e1), None, None, None, None).unwrap();
+    let e1 = saidify_returned.value();
+
+    let serder = SerderWrapper::new(None, None, None, Some(ValueWrapper::new(e1.as_str())), None).unwrap();
+    let serder2 = SerderWrapper::new(None, Some(serder.raw()), None, None, None).unwrap();
+
+    assert_eq!(serder.pre().unwrap(), serder2.pre().unwrap());
 }
 
 #[wasm_bindgen_test]


### PR DESCRIPTION
## Rationale
Removed *_with_* from saiderwrapper.  Added test for wasm.


## Testing
Added test.  Wasm isn't used anywhere so no testing beyond that.


### For Reviewers

- [] Verify version bumped in `Cargo.toml`