### PR TITLE
Changed to non deprecated removes that should have same effect as old…

### DIFF
--- a/src/core/prefixer.rs
+++ b/src/core/prefixer.rs
@@ -599,7 +599,7 @@ mod test {
         let prefixer = Prefixer::new(Some(&ked), None, Some(code), None, None, None, None).unwrap();
 
         let mut map = ked.to_map().unwrap();
-        map.remove("k");
+        map.swap_remove("k");
         ked = dat!(&map);
 
         assert!(!prefixer.verify(&ked, None).unwrap());

--- a/src/core/saider.rs
+++ b/src/core/saider.rs
@@ -76,7 +76,7 @@ fn derive(
     let mut map = sad.to_map()?;
     for key in ignore.unwrap_or(&[]) {
         if map.contains_key(*key) {
-            map.remove(*key);
+            map.swap_remove(*key);
         }
     }
     let ser = dat!(&map);


### PR DESCRIPTION
## Rationale
Not really sure why these didn't show up in my old env but in my new env got deprecation warnings about map.remove being deprecated and to use swap or shift remove to be explicit about behavior. 

Switched to something that seemed to fit with old code and tests still pass.


## Testing
Tests remain same, no change to behavior.


### For Reviewers

- [ ] Verify version bumped in `Cargo.toml`