### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cesride"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 description = "Cryptographic primitives for use with Composable Event Streaming Representation (CESR)"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["cesr", "keri", "acdc"]
 [dependencies]
 anyhow = "~1"
 argon2 = "~0.5"
-base64 = "~0.21"
+base64 = "~0.22"
 blake2 = "~0.10"
 blake3 = "~1"
 chrono = { version = "~0.4", default-features = false, features = ["clock"] }

--- a/src/core/counter/mod.rs
+++ b/src/core/counter/mod.rs
@@ -102,7 +102,7 @@ impl Counter {
     }
 
     pub fn sem_ver_to_b64(major: u8, minor: u8, patch: u8) -> Result<String> {
-        let parts = &vec![major, minor, patch];
+        let parts = &[major, minor, patch];
         Counter::sem_ver_parts_to_b64(parts)
     }
 

--- a/src/core/indexer/mod.rs
+++ b/src/core/indexer/mod.rs
@@ -708,7 +708,7 @@ mod test {
         assert!(TestIndexer::new(None, None, None, Some(&[]), None, None, None).is_err());
 
         let code = indexer::Codex::TBD0;
-        let raw = &vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
+        let raw = &[0, 1, 2, 3, 4, 5, 6, 7, 8];
         let indexer =
             TestIndexer::new(None, None, Some(code), Some(raw), None, None, None).unwrap();
         let qb64 = &indexer.qb64().unwrap();
@@ -1027,7 +1027,7 @@ mod test {
     #[case(indexer::Codex::Ed25519_Big, 92)]
     #[case(indexer::Codex::Ed448_Big, 160)]
     fn raw_size(#[case] code: &str, #[case] full_size: usize) {
-        let raw = (0..full_size as usize - code.len()).map(|_| "A").collect::<String>();
+        let raw = (0..full_size - code.len()).map(|_| "A").collect::<String>();
         let qb64 = [code, &raw].join("");
         let indexer = TestIndexer::new(None, None, None, None, None, Some(&qb64), None).unwrap();
         assert_eq!(indexer.full_size().unwrap(), full_size);

--- a/src/core/prefixer.rs
+++ b/src/core/prefixer.rs
@@ -599,7 +599,7 @@ mod test {
         let prefixer = Prefixer::new(Some(&ked), None, Some(code), None, None, None, None).unwrap();
 
         let mut map = ked.to_map().unwrap();
-        map.remove("k");
+        map.shift_remove("k");
         ked = dat!(&map);
 
         assert!(!prefixer.verify(&ked, None).unwrap());

--- a/src/core/saider.rs
+++ b/src/core/saider.rs
@@ -76,7 +76,7 @@ fn derive(
     let mut map = sad.to_map()?;
     for key in ignore.unwrap_or(&[]) {
         if map.contains_key(*key) {
-            map.remove(*key);
+            map.shift_remove(*key);
         }
     }
     let ser = dat!(&map);

--- a/src/core/verfer.rs
+++ b/src/core/verfer.rs
@@ -198,7 +198,7 @@ mod test {
         let bad_ser = hex!("e1be4d7a8ab5560aa4199eea339849ba8e293d55ca0a81006726d184519e647f"
                                      "5b49b82f805a538c68915c1ae8035c900fd1d4b13902920fd05e1450822f36df");
 
-        let mut csprng = rand_core::OsRng::default();
+        let mut csprng = rand_core::OsRng;
         let keypair = ed25519_dalek::SigningKey::generate(&mut csprng);
 
         let sig = keypair.sign(&ser).to_bytes();


### PR DESCRIPTION
## Rationale

the dependencies in the published version of `cesride` and `parside` have fallen behind. the most recent published version isn't even the version in main right now.

- [x] Verify version bumped in `Cargo.toml`