### PR TITLE
chore: Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cesride"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 description = "Cryptographic primitives for use with Composable Event Streaming Representation (CESR)"
 license = "Apache-2.0"
@@ -9,27 +9,27 @@ keywords = ["cesr", "keri", "acdc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "~1"
-argon2 = "~0.5"
-base64 = "~0.22"
-blake2 = "~0.10"
-blake3 = "~1"
-chrono = { version = "~0.4", default-features = false, features = ["clock"] }
-ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
-indexmap = "~2"
-k256 = "~0.13"
-lazy_static = "~1"
-num-rational = "~0.4"
-p256 = "~0.13"
-rand_core = "~0.6"
-regex = "~1"
-serde_json = { version = "~1", features = ["preserve_order"] }
-sha2 = "~0.10"
-sha3 = "~0.10"
-thiserror = "~1"
-zeroize = { version = "~1", features = ["derive"] }
+anyhow = "~1.0.86"
+argon2 = "~0.5.3"
+base64 = "~0.22.1"
+blake2 = "~0.10.6"
+blake3 = "~1.5.1"
+chrono = { version = "~0.4.38", default-features = false, features = ["clock"] }
+ed25519-dalek = { version = "2.1.1", features = ["rand_core"] }
+indexmap = "~2.2.6"
+k256 = "~0.13.3"
+lazy_static = "~1.5.0"
+num-rational = "~0.4.2"
+p256 = "~0.13.2"
+rand_core = "~0.6.4"
+regex = "~1.10.5"
+serde_json = { version = "~1.0.118", features = ["preserve_order"] }
+sha2 = "~0.10.8"
+sha3 = "~0.10.8"
+thiserror = "~1.0.61"
+zeroize = { version = "~1.8.1", features = ["derive"] }
 
 [dev-dependencies]
-hex-literal = "~0.4"
-hex = "~0.4"
-rstest = "~0.18"
+hex-literal = "~0.4.1"
+hex = "~0.4.3"
+rstest = "~0.21.0"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Change some code and then fix it automatically:
 make fix
 ```
 
-Commit your changes locally, and run these automated tests:
+Commit your changes locally, and run these automated tests (requires `brew install wasm-pack`):
+
 ```shell
 make clean preflight
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Cryptographic primitives for use with Composable Event Streaming Representation 
 This library is **currently under construction**. If you want to help build, see [contributing](#contributing) below.
 
 ## Important Reference Material
-- WebOfTrust/[ietf-cesr](https://github.com/WebOfTrust/ietf-cesr) repository - IETF draft specification for CESR
+- trustoverip/[tswg-cesr-specification](https://github.com/trustoverip/tswg-cesr-specification) repository - [ToIP draft specification](https://trustoverip.github.io/tswg-cesr-specification/) for CESR
 - Design Assumptions, Use Cases, and ToDo list - [HackMD link](https://hackmd.io/W2Z39cuSSTmD2TovVLvAPg?view)
 - Introductory articles:
     - [#1 CESR Proof Signatures](https://medium.com/happy-blockchains/cesr-proof-signatures-are-the-segwit-of-authentic-data-in-keri-e891c83e070a)


### PR DESCRIPTION
## Rationale
Upgrading to the most recent dependencies worked and resolved a build failure on the `outdated` check with `cargo outdated -R --exit-code 1` in the Makefile.



## Testing
All tests passed. There is no new functionality so a passing build is enough to merge.


### For Reviewers

- [X ] Verify version bumped in `Cargo.toml` -> version `0.6.5`