### PR TITLE
fix: resolve clippy warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy -- -W warnings
+        run: cargo clippy -- -D warnings
 
       - name: Build
         run: cargo build --release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: CI
 
 on:
   push:
@@ -10,35 +10,36 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  check:
+    name: Check & Test
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
+          components: rustfmt, clippy
 
-      # format is the only step that doesn't require updating the crates.io cache, so we do it first
-      # to minimize ci cost when bailing early
-      - name: Format
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      # Format check first - fast fail
+      - name: Check formatting
         run: cargo fmt --all -- --check
 
-      - name: Outdated
-        run: cargo outdated -R --exit-code 1
-
-      - name: Audit
-        run: cargo audit
-
-      - name: Check
-        run: cargo check
-
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy -- -W warnings
 
       - name: Build
         run: cargo build --release
@@ -46,18 +47,33 @@ jobs:
       - name: Test
         run: cargo test --release
 
-      - name: Tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.22.0'
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: WASM Sanity Build
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Security audit
+        run: cargo audit
+
+  wasm:
+    name: WASM Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+
+      - name: Build WASM
         run: |
           cd wasm
-          cargo install wasm-pack
           wasm-pack build
-
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}

--- a/src/core/common.rs
+++ b/src/core/common.rs
@@ -1,4 +1,4 @@
-use crate::data::{dat, Value};
+use crate::data::Value;
 use crate::error::{err, Error, Result};
 
 use lazy_static::lazy_static;
@@ -294,7 +294,6 @@ pub fn sniff(raw: &[u8]) -> Result<SniffResult> {
 #[cfg(test)]
 mod test {
     use crate::core::common;
-    use crate::data::dat;
     use rstest::rstest;
 
     #[test]

--- a/src/core/creder.rs
+++ b/src/core/creder.rs
@@ -3,7 +3,7 @@ use crate::{
     core::matter::tables as matter,
     core::sadder::Sadder,
     core::saider::Saider,
-    data::{dat, Value},
+    data::Value,
     error::{err, Error, Result},
 };
 

--- a/src/core/indexer/mod.rs
+++ b/src/core/indexer/mod.rs
@@ -90,11 +90,12 @@ pub trait Indexer: Default {
             }
         }
 
-        if CurrentSigCodex::has_code(code) && ondex.is_some() {
-            return err!(Error::InvalidVarIndex(format!(
-                "Non None ondex '{o}' for code '{code}'",
-                o = ondex.unwrap()
-            )));
+        if CurrentSigCodex::has_code(code) {
+            if let Some(o) = ondex {
+                return err!(Error::InvalidVarIndex(format!(
+                    "Non None ondex '{o}' for code '{code}'"
+                )));
+            }
         }
 
         if BothSigCodex::has_code(code) {
@@ -365,7 +366,7 @@ pub trait Indexer: Default {
         buffer[((n + szg.ls) as usize)..].copy_from_slice(&raw);
 
         let bfs = buffer.len();
-        if bfs % 3 != 0 || (bfs * 4 / 3) != fs as usize {
+        if !bfs.is_multiple_of(3) || (bfs * 4 / 3) != fs as usize {
             return err!(Error::InvalidCodeSize(format!(
                 "Invalid code for raw size: code = '{both}', raw size = '{}'",
                 raw.len()
@@ -416,11 +417,12 @@ pub trait Indexer: Default {
                 ondex = Some(util::b64_to_u32(odx)?);
             }
             // not zero or None
-            if ondex.is_some() && ondex.unwrap() != 0 {
-                return err!(Error::Value(format!(
-                    "Invalid ondex = '{o}' for code = '{hard}'.",
-                    o = ondex.unwrap()
-                )));
+            if let Some(o) = ondex {
+                if o != 0 {
+                    return err!(Error::Value(format!(
+                        "Invalid ondex = '{o}' for code = '{hard}'."
+                    )));
+                }
             }
         } else if szg.os != 0 {
             ondex = Some(util::b64_to_u32(odx)?);
@@ -518,7 +520,7 @@ pub trait Indexer: Default {
 
         let first = util::nab_sextets(qb2, 1)?[0];
         let hs = tables::bardage(first)? as usize;
-        let bhs = (hs * 3 + 3) / 4;
+        let bhs = (hs * 3).div_ceil(4);
         if qb2.len() < bhs {
             return err!(Error::Shortage(format!(
                 "insufficient material for hard part of code: qb2 size = {}, bhs = {bhs}",
@@ -549,11 +551,12 @@ pub trait Indexer: Default {
                 ondex = Some(util::b64_to_u32(odx)?);
             }
             // not zero or None
-            if ondex.is_some() && ondex.unwrap() != 0 {
-                return err!(Error::Value(format!(
-                    "Invalid ondex = '{o}' for code = '{hard}'.",
-                    o = ondex.unwrap()
-                )));
+            if let Some(o) = ondex {
+                if o != 0 {
+                    return err!(Error::Value(format!(
+                        "Invalid ondex = '{o}' for code = '{hard}'."
+                    )));
+                }
             }
 
             // unset ondex if it was 0 - this code was in another if clause in KERIpy

--- a/src/core/indexer/tables.rs
+++ b/src/core/indexer/tables.rs
@@ -14,8 +14,6 @@ use crate::error::{err, Error, Result};
 /// _Crt: Index in code for current signing key list only.
 ///
 /// _Big: Big index values
-///
-
 pub(crate) const SMALL_VRZ_BYTES: u32 = 3;
 pub(crate) const LARGE_VRZ_BYTES: u32 = 6;
 

--- a/src/core/matter/mod.rs
+++ b/src/core/matter/mod.rs
@@ -306,7 +306,7 @@ pub trait Matter: Default {
         buffer[((n + szg.ls) as usize)..].copy_from_slice(&raw);
 
         let bfs = buffer.len();
-        if bfs % 3 != 0 || (bfs * 4 / 3) != fs as usize {
+        if !bfs.is_multiple_of(3) || (bfs * 4 / 3) != fs as usize {
             return err!(Error::InvalidCodeSize(format!(
                 "invalid code for raw size: code = '{both}', raw size = {}",
                 raw.len()
@@ -427,7 +427,7 @@ pub trait Matter: Default {
 
         let first = util::nab_sextets(qb2, 1)?[0];
         let hs = tables::bardage(first)? as usize;
-        let bhs = (hs * 3 + 3) / 4;
+        let bhs = (hs * 3).div_ceil(4);
         if qb2.len() < bhs {
             return err!(Error::Shortage(format!(
                 "insufficient material for hard part of code: qb2 size = {}, bhs = {bhs}",

--- a/src/core/pather.rs
+++ b/src/core/pather.rs
@@ -267,13 +267,11 @@ impl Matter for Pather {
 #[cfg(test)]
 mod test {
     use super::Pather;
-    use crate::{
-        core::{
-            bexter::Bext,
-            matter::{tables as matter, Matter},
-            saider::Saider,
-            serder::Serder,
-        },
+    use crate::core::{
+        bexter::Bext,
+        matter::{tables as matter, Matter},
+        saider::Saider,
+        serder::Serder,
     };
 
     #[test]

--- a/src/core/pather.rs
+++ b/src/core/pather.rs
@@ -171,7 +171,7 @@ impl Pather {
         } else if val.to_map().is_ok() || val.to_vec().is_ok() {
             val.to_json()
         } else {
-            return err!(Error::Value("bad tail value".to_string()));
+            err!(Error::Value("bad tail value".to_string()))
         }
     }
 

--- a/src/core/pather.rs
+++ b/src/core/pather.rs
@@ -274,7 +274,6 @@ mod test {
             saider::Saider,
             serder::Serder,
         },
-        data::dat,
     };
 
     #[test]

--- a/src/core/prefixer.rs
+++ b/src/core/prefixer.rs
@@ -399,7 +399,6 @@ mod test {
             signer::Signer,
             verfer::Verfer,
         },
-        data::dat,
     };
     use rstest::rstest;
 

--- a/src/core/prefixer.rs
+++ b/src/core/prefixer.rs
@@ -390,15 +390,13 @@ impl Matter for Prefixer {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        core::{
-            common::{sizeify, versify, Ilkage, Serialage, CURRENT_VERSION},
-            diger::Diger,
-            matter::{tables as matter, Matter},
-            prefixer::Prefixer,
-            signer::Signer,
-            verfer::Verfer,
-        },
+    use crate::core::{
+        common::{sizeify, versify, Ilkage, Serialage, CURRENT_VERSION},
+        diger::Diger,
+        matter::{tables as matter, Matter},
+        prefixer::Prefixer,
+        signer::Signer,
+        verfer::Verfer,
     };
     use rstest::rstest;
 

--- a/src/core/sadder.rs
+++ b/src/core/sadder.rs
@@ -220,7 +220,7 @@ mod test {
         sadder::Sadder,
         saider::Saider,
     };
-    use crate::data::{dat, Value};
+    use crate::data::Value;
 
     #[derive(Debug, Clone, PartialEq)]
     struct TestSadder {

--- a/src/core/saider.rs
+++ b/src/core/saider.rs
@@ -1,7 +1,7 @@
 use crate::core::common::{deversify, dumps, sizeify, Ids, Serialage, DUMMY};
 use crate::core::matter::{tables as matter, Matter};
 use crate::crypto::hash;
-use crate::data::{dat, Value};
+use crate::data::Value;
 use crate::error::{err, Error, Result};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -299,7 +299,6 @@ mod test {
     use crate::core::common::{versify, Identage, Ids, Serialage, Version};
     use crate::core::matter::{tables as matter, Matter};
     use crate::core::saider::Saider;
-    use crate::data::dat;
     use rstest::rstest;
 
     #[test]

--- a/src/core/serder.rs
+++ b/src/core/serder.rs
@@ -9,7 +9,7 @@ use crate::{
         tholder::Tholder,
         verfer::Verfer,
     },
-    data::{dat, Value},
+    data::Value,
     error::{err, Error, Result},
 };
 

--- a/src/core/tholder.rs
+++ b/src/core/tholder.rs
@@ -247,9 +247,8 @@ impl Tholder {
     }
 
     fn process_thold(&mut self, thold: &Value) -> Result<()> {
-        let result = thold.to_i64();
-        if result.is_ok() {
-            self.process_unweighted(result.unwrap())?;
+        if let Ok(value) = thold.to_i64() {
+            self.process_unweighted(value)?;
             return Ok(());
         }
 

--- a/src/core/tholder.rs
+++ b/src/core/tholder.rs
@@ -4,7 +4,7 @@ use crate::{
         matter::{tables as matter, Matter},
         number::{tables as number, Number},
     },
-    data::{dat, Array, Value},
+    data::{Array, Value},
     error::{err, Error, Result},
 };
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -604,7 +604,7 @@ pub use dat;
 
 #[cfg(test)]
 mod test {
-    use crate::data::{dat, Value};
+    use crate::data::Value;
     use indexmap::IndexMap;
 
     #[test]


### PR DESCRIPTION
## Summary
Resolve all clippy warnings to enable strict `cargo clippy -- -D warnings` in CI.

> **Note:** This PR depends on #171 being merged first (it builds on that branch).

## Changes

| File | Fix |
|------|-----|
| `src/core/indexer/tables.rs` | Remove empty line after doc comment |
| `src/core/indexer/mod.rs` | Use `if let` instead of `is_some()` + `unwrap()` |
| `src/core/indexer/mod.rs` | Use `.is_multiple_of(3)` instead of `% 3 != 0` |
| `src/core/indexer/mod.rs` | Use `.div_ceil(4)` instead of `(n + 3) / 4` |
| `src/core/matter/mod.rs` | Use `.is_multiple_of(3)` and `.div_ceil(4)` |
| `src/core/pather.rs` | Remove unneeded `return` statement |
| `src/core/tholder.rs` | Use `if let Ok(value)` instead of `is_ok()` + `unwrap()` |
| `.github/workflows/test.yml` | Re-enable strict clippy (`-D warnings`) |

## Test plan
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (832 tests)
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)